### PR TITLE
[PE-6327] Add Wallet UI M2 UI for RN 

### DIFF
--- a/packages/common/src/messages/buySell.ts
+++ b/packages/common/src/messages/buySell.ts
@@ -1,5 +1,7 @@
 import { USDC } from '@audius/fixed-decimal'
 
+import { formatTokenPrice } from '../api/tan-query/jupiter/utils'
+
 export const buySellMessages = {
   title: 'BUY / SELL',
   buy: 'Buy',
@@ -42,5 +44,13 @@ export const buySellMessages = {
   priceEach: (price: number) => {
     const formatted = USDC(price).toLocaleString('en-US')
     return `(${formatted} ea.)`
-  }
+  },
+  amountInputLabel: (symbol: string) => `Amount (${symbol})`,
+  tokenPrice: (price: string, decimalPlaces: number) => {
+    return formatTokenPrice(price, decimalPlaces)
+  },
+  stackedBalance: (formattedAvailableBalance: string) =>
+    `${formattedAvailableBalance}  Available`,
+  tokenTicker: (symbol: string, isStablecoin: boolean) =>
+    isStablecoin ? symbol : `$${symbol}`
 }

--- a/packages/mobile/src/components/buy-sell/SwapBalanceSection.tsx
+++ b/packages/mobile/src/components/buy-sell/SwapBalanceSection.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+
+import type { TokenInfo } from '@audius/common/store'
+
+import {
+  Flex,
+  Text,
+  Paper,
+  IconTokenAUDIO,
+  IconLogoCircleUSDC
+} from '@audius/harmony-native'
+
+type SwapBalanceSectionProps = {
+  title: string
+  tokenInfo: TokenInfo
+  amount: string
+  priceLabel?: string
+}
+
+// Mobile adaptation of web SwapBalanceSection
+export const SwapBalanceSection = ({
+  title,
+  tokenInfo,
+  amount,
+  priceLabel
+}: SwapBalanceSectionProps) => {
+  const { symbol } = tokenInfo
+
+  // Get the appropriate token icon for mobile
+  const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconLogoCircleUSDC
+
+  return (
+    <Paper p='l'>
+      <Flex direction='column' gap='m'>
+        {/* Header */}
+        <Text variant='heading' size='s' color='subdued'>
+          {title}
+        </Text>
+
+        {/* Amount and token info */}
+        <Flex direction='row' alignItems='center' gap='s'>
+          <TokenIcon size='xl' />
+          <Flex direction='column'>
+            <Text variant='heading' size='l'>
+              {amount}
+            </Text>
+            <Flex direction='row' gap='xs'>
+              <Text variant='heading' size='s' color='subdued'>
+                {tokenInfo.isStablecoin
+                  ? tokenInfo.symbol
+                  : `$${tokenInfo.symbol}`}
+              </Text>
+              {priceLabel && (
+                <Text variant='heading' size='s' color='subdued'>
+                  {priceLabel}
+                </Text>
+              )}
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Paper>
+  )
+}

--- a/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
+++ b/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
@@ -1,17 +1,16 @@
 import React, { useMemo } from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
-import { useTokenAmountFormatting } from '@audius/common/store'
 import type { TokenAmountSectionProps, TokenInfo } from '@audius/common/store'
+import { useTokenAmountFormatting } from '@audius/common/store'
 
 import {
   Button,
   Flex,
+  IconLogoCircleUSDC,
+  IconTokenAUDIO,
   Text,
   TextInput,
-  Paper,
-  IconTokenAUDIO,
-  IconLogoCircleUSDC,
   useTheme
 } from '@audius/harmony-native'
 
@@ -77,11 +76,11 @@ const StackedBalanceSection = ({
         <Text variant='heading' size='s' color='subdued'>
           {messages.tokenTicker(symbol, !!isStablecoin)}
         </Text>
-        <Text variant='body' size='s' color='default'>
+        <Text variant='title' size='s' color='default'>
           {messages.stackedBalance(formattedAvailableBalance)}
         </Text>
       </Flex>
-      <TokenIcon size='xl' style={{ borderRadius: cornerRadius.circle }} />
+      <TokenIcon size='4xl' style={{ borderRadius: cornerRadius.circle }} />
     </Flex>
   )
 }
@@ -151,8 +150,8 @@ export const TokenAmountSection = ({
   isTokenPriceLoading,
   tokenPriceDecimalPlaces = 2
 }: TokenAmountSectionProps) => {
+  const { spacing } = useTheme()
   const { symbol, isStablecoin } = tokenInfo
-
   const { formattedAvailableBalance, formattedAmount } =
     useTokenAmountFormatting({
       amount,
@@ -166,18 +165,6 @@ export const TokenAmountSection = ({
     tokenPrice && !isTokenPriceLoading
       ? messages.tokenPrice(tokenPrice, tokenPriceDecimalPlaces)
       : undefined
-
-  const handleMaxClick = () => {
-    if (onMaxClick) {
-      onMaxClick()
-    }
-  }
-
-  const handleAmountChange = (value: string) => {
-    if (onAmountChange) {
-      onAmountChange(value)
-    }
-  }
 
   const titleText = useMemo(() => {
     const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconLogoCircleUSDC
@@ -202,7 +189,7 @@ export const TokenAmountSection = ({
 
   const youPaySection = useMemo(() => {
     return (
-      <Flex direction='column' gap='s'>
+      <Flex direction='column' gap='l'>
         <Flex
           direction='row'
           justifyContent='space-between'
@@ -237,14 +224,18 @@ export const TokenAmountSection = ({
               label={messages.amountInputLabel(symbol)}
               placeholder={placeholder}
               value={amount?.toString() || ''}
-              onChangeText={handleAmountChange}
+              onChangeText={onAmountChange}
               keyboardType='numeric'
               error={error}
             />
           </Flex>
 
           {onMaxClick && (
-            <Button variant='secondary' size='small' onPress={handleMaxClick}>
+            <Button
+              variant='secondary'
+              onPress={onMaxClick}
+              style={{ height: spacing.unit16 }}
+            >
               {messages.max}
             </Button>
           )}
@@ -266,10 +257,10 @@ export const TokenAmountSection = ({
     symbol,
     placeholder,
     amount,
-    handleAmountChange,
+    onAmountChange,
     error,
     onMaxClick,
-    handleMaxClick,
+    spacing.unit16,
     errorMessage
   ])
 
@@ -297,20 +288,18 @@ export const TokenAmountSection = ({
   }, [formattedAmount, isStablecoin, priceDisplay, tokenInfo])
 
   return (
-    <Paper p='l'>
-      <Flex direction='column' gap='m'>
-        {isInput ? (
-          youPaySection
-        ) : (
-          <Flex direction='column' gap='s'>
-            <Flex direction='row' alignItems='center' gap='xs'>
-              {titleText}
-            </Flex>
-
-            {youReceiveSection}
+    <Flex direction='column' gap='m'>
+      {isInput ? (
+        youPaySection
+      ) : (
+        <Flex direction='column' gap='s'>
+          <Flex direction='row' alignItems='center' gap='xs'>
+            {titleText}
           </Flex>
-        )}
-      </Flex>
-    </Paper>
+
+          {youReceiveSection}
+        </Flex>
+      )}
+    </Flex>
   )
 }

--- a/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
+++ b/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
@@ -1,0 +1,316 @@
+import React, { useMemo } from 'react'
+
+import { buySellMessages as messages } from '@audius/common/messages'
+import { useTokenAmountFormatting } from '@audius/common/store'
+import type { TokenAmountSectionProps, TokenInfo } from '@audius/common/store'
+
+import {
+  Button,
+  Flex,
+  Text,
+  TextInput,
+  Paper,
+  IconTokenAUDIO,
+  IconLogoCircleUSDC,
+  useTheme
+} from '@audius/harmony-native'
+
+import { TooltipInfoIcon } from './TooltipInfoIcon'
+
+type BalanceSectionProps = {
+  isStablecoin?: boolean
+  formattedAvailableBalance: string | null
+  tokenInfo: TokenInfo
+}
+
+const DefaultBalanceSection = ({
+  isStablecoin,
+  formattedAvailableBalance,
+  tokenInfo
+}: BalanceSectionProps) => {
+  const { symbol } = tokenInfo
+  const { cornerRadius } = useTheme()
+  const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconLogoCircleUSDC
+
+  if (!formattedAvailableBalance || !TokenIcon) {
+    return null
+  }
+
+  return (
+    <Flex
+      direction='column'
+      alignItems='flex-end'
+      justifyContent='center'
+      gap='xs'
+    >
+      <Flex direction='row' alignItems='center' gap='s'>
+        <TokenIcon size='l' style={{ borderRadius: cornerRadius.circle }} />
+        <Text variant='title' size='l' color='subdued'>
+          {messages.available}
+        </Text>
+        <TooltipInfoIcon />
+      </Flex>
+      <Text variant='heading' size='l'>
+        {isStablecoin ? '$' : ''}
+        {formattedAvailableBalance}
+      </Text>
+    </Flex>
+  )
+}
+
+const StackedBalanceSection = ({
+  formattedAvailableBalance,
+  tokenInfo,
+  isStablecoin
+}: BalanceSectionProps) => {
+  const { symbol } = tokenInfo
+  const { cornerRadius } = useTheme()
+  const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconLogoCircleUSDC
+
+  if (!formattedAvailableBalance || !TokenIcon) {
+    return null
+  }
+
+  return (
+    <Flex direction='row' alignItems='center' gap='s'>
+      <Flex direction='column' alignItems='flex-end'>
+        <Text variant='heading' size='s' color='subdued'>
+          {messages.tokenTicker(symbol, !!isStablecoin)}
+        </Text>
+        <Text variant='body' size='s' color='default'>
+          {messages.stackedBalance(formattedAvailableBalance)}
+        </Text>
+      </Flex>
+      <TokenIcon size='xl' style={{ borderRadius: cornerRadius.circle }} />
+    </Flex>
+  )
+}
+
+const CryptoAmountSection = ({
+  formattedAmount,
+  tokenInfo,
+  isStablecoin,
+  priceDisplay
+}: {
+  formattedAmount: string
+  tokenInfo: TokenInfo
+  isStablecoin: boolean
+  priceDisplay?: string
+}) => {
+  const { spacing, cornerRadius } = useTheme()
+  const { symbol } = tokenInfo
+  const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconLogoCircleUSDC
+  const tokenTicker = messages.tokenTicker(symbol, !!isStablecoin)
+
+  if (!TokenIcon) {
+    return null
+  }
+
+  return (
+    <Flex direction='row' alignItems='center' gap='s'>
+      <TokenIcon
+        style={{
+          borderRadius: cornerRadius.circle,
+          width: spacing.unit16,
+          height: spacing.unit16
+        }}
+      />
+      <Flex direction='column'>
+        <Flex direction='row' alignItems='center' gap='xs'>
+          <Text variant='heading' size='l'>
+            {formattedAmount}
+          </Text>
+          <Text variant='heading' size='l' color='subdued'>
+            {tokenTicker}
+          </Text>
+        </Flex>
+        {priceDisplay && (
+          <Text variant='heading' size='s' color='subdued'>
+            {priceDisplay}
+          </Text>
+        )}
+      </Flex>
+    </Flex>
+  )
+}
+
+export const TokenAmountSection = ({
+  title,
+  tokenInfo,
+  isInput,
+  amount,
+  onAmountChange,
+  onMaxClick,
+  availableBalance,
+  exchangeRate,
+  placeholder = '0.00',
+  isDefault = true,
+  error,
+  errorMessage,
+  tokenPrice,
+  isTokenPriceLoading,
+  tokenPriceDecimalPlaces = 2
+}: TokenAmountSectionProps) => {
+  const { symbol, isStablecoin } = tokenInfo
+
+  const { formattedAvailableBalance, formattedAmount } =
+    useTokenAmountFormatting({
+      amount,
+      availableBalance,
+      exchangeRate,
+      isStablecoin: !!isStablecoin,
+      placeholder
+    })
+
+  const priceDisplay =
+    tokenPrice && !isTokenPriceLoading
+      ? messages.tokenPrice(tokenPrice, tokenPriceDecimalPlaces)
+      : undefined
+
+  const handleMaxClick = () => {
+    if (onMaxClick) {
+      onMaxClick()
+    }
+  }
+
+  const handleAmountChange = (value: string) => {
+    if (onAmountChange) {
+      onAmountChange(value)
+    }
+  }
+
+  const titleText = useMemo(() => {
+    const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconLogoCircleUSDC
+
+    if (isStablecoin && !isInput && TokenIcon) {
+      return (
+        <Flex direction='row' alignItems='center' gap='s'>
+          <TokenIcon size='l' />
+          <Text variant='heading' size='s' color='subdued'>
+            {title}
+          </Text>
+          <TooltipInfoIcon />
+        </Flex>
+      )
+    }
+    return (
+      <Text variant='heading' size='s' color='subdued'>
+        {title}
+      </Text>
+    )
+  }, [isInput, isStablecoin, symbol, title])
+
+  const youPaySection = useMemo(() => {
+    return (
+      <Flex direction='column' gap='s'>
+        <Flex
+          direction='row'
+          justifyContent='space-between'
+          alignItems='flex-start'
+        >
+          <Flex direction='row' alignItems='center' gap='xs'>
+            {titleText}
+          </Flex>
+
+          {formattedAvailableBalance && (
+            <>
+              {isDefault ? (
+                <DefaultBalanceSection
+                  isStablecoin={!!isStablecoin}
+                  formattedAvailableBalance={formattedAvailableBalance}
+                  tokenInfo={tokenInfo}
+                />
+              ) : (
+                <StackedBalanceSection
+                  formattedAvailableBalance={formattedAvailableBalance}
+                  tokenInfo={tokenInfo}
+                  isStablecoin={!!isStablecoin}
+                />
+              )}
+            </>
+          )}
+        </Flex>
+
+        <Flex direction='row' alignItems='center' gap='s'>
+          <Flex flex={1}>
+            <TextInput
+              label={messages.amountInputLabel(symbol)}
+              placeholder={placeholder}
+              value={amount?.toString() || ''}
+              onChangeText={handleAmountChange}
+              keyboardType='numeric'
+              error={error}
+            />
+          </Flex>
+
+          {onMaxClick && (
+            <Button variant='secondary' size='small' onPress={handleMaxClick}>
+              {messages.max}
+            </Button>
+          )}
+        </Flex>
+
+        {errorMessage && (
+          <Text variant='body' size='s' color='danger'>
+            {errorMessage}
+          </Text>
+        )}
+      </Flex>
+    )
+  }, [
+    titleText,
+    formattedAvailableBalance,
+    isDefault,
+    isStablecoin,
+    tokenInfo,
+    symbol,
+    placeholder,
+    amount,
+    handleAmountChange,
+    error,
+    onMaxClick,
+    handleMaxClick,
+    errorMessage
+  ])
+
+  const youReceiveSection = useMemo(() => {
+    if (!formattedAmount) {
+      return null
+    }
+
+    if (isStablecoin) {
+      return (
+        <Text variant='display' size='s'>
+          {messages.tokenPrice(formattedAmount, 2)}
+        </Text>
+      )
+    }
+
+    return (
+      <CryptoAmountSection
+        formattedAmount={formattedAmount}
+        tokenInfo={tokenInfo}
+        isStablecoin={!!isStablecoin}
+        priceDisplay={priceDisplay}
+      />
+    )
+  }, [formattedAmount, isStablecoin, priceDisplay, tokenInfo])
+
+  return (
+    <Paper p='l'>
+      <Flex direction='column' gap='m'>
+        {isInput ? (
+          youPaySection
+        ) : (
+          <Flex direction='column' gap='s'>
+            <Flex direction='row' alignItems='center' gap='xs'>
+              {titleText}
+            </Flex>
+
+            {youReceiveSection}
+          </Flex>
+        )}
+      </Flex>
+    </Paper>
+  )
+}

--- a/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
+++ b/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
@@ -16,6 +16,10 @@ import {
 
 import { TooltipInfoIcon } from './TooltipInfoIcon'
 
+const toUSD = (price: string) => {
+  return `$${price}`
+}
+
 type BalanceSectionProps = {
   isStablecoin?: boolean
   formattedAvailableBalance: string | null
@@ -163,7 +167,7 @@ export const TokenAmountSection = ({
 
   const priceDisplay =
     tokenPrice && !isTokenPriceLoading
-      ? messages.tokenPrice(tokenPrice, tokenPriceDecimalPlaces)
+      ? toUSD(messages.tokenPrice(tokenPrice, tokenPriceDecimalPlaces))
       : undefined
 
   const titleText = useMemo(() => {
@@ -272,7 +276,7 @@ export const TokenAmountSection = ({
     if (isStablecoin) {
       return (
         <Text variant='display' size='s'>
-          {messages.tokenPrice(formattedAmount, 2)}
+          {toUSD(messages.tokenPrice(formattedAmount, 2))}
         </Text>
       )
     }

--- a/packages/mobile/src/components/buy-sell/TooltipInfoIcon.tsx
+++ b/packages/mobile/src/components/buy-sell/TooltipInfoIcon.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useRef } from 'react'
+
+import { walletMessages } from '@audius/common/messages'
+import { BottomSheetBackdrop, BottomSheetModal } from '@gorhom/bottom-sheet'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import {
+  Box,
+  Flex,
+  IconButton,
+  IconInfo,
+  Text,
+  useTheme
+} from '@audius/harmony-native'
+
+const messages = {
+  text: walletMessages.cashBalanceTooltip
+}
+
+type TooltipInfoIconProps = {
+  ariaLabel?: string
+  size?: 's' | 'm' | 'l'
+  color?: 'subdued' | 'default'
+  title?: string
+  message?: string
+}
+
+export const TooltipInfoIcon = ({
+  ariaLabel = 'Information',
+  size = 's',
+  color = 'subdued',
+  title = walletMessages.cashBalance,
+  message = messages.text
+}: TooltipInfoIconProps) => {
+  const insets = useSafeAreaInsets()
+  const { color: themeColor } = useTheme()
+
+  // Create a ref for the bottom sheet modal
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null)
+
+  // Function to handle opening the bottom sheet
+  const handleOpenInfoModal = useCallback(() => {
+    bottomSheetModalRef.current?.present()
+  }, [])
+
+  return (
+    <>
+      <IconButton
+        icon={IconInfo}
+        size={size}
+        color={color}
+        aria-label={ariaLabel}
+        onPress={handleOpenInfoModal}
+        style={{ padding: 0 }}
+      />
+
+      <BottomSheetModal
+        ref={bottomSheetModalRef}
+        snapPoints={['25%']}
+        topInset={insets.top}
+        backgroundStyle={{ backgroundColor: themeColor.background.white }}
+        backdropComponent={(props) => (
+          <BottomSheetBackdrop
+            {...props}
+            appearsOnIndex={0}
+            disappearsOnIndex={-1}
+            pressBehavior='close'
+          />
+        )}
+      >
+        <Flex p='l'>
+          <Text variant='title' size='m'>
+            {title}
+          </Text>
+          <Box mt='m'>
+            <Text variant='body' size='m'>
+              {message}
+            </Text>
+          </Box>
+        </Flex>
+      </BottomSheetModal>
+    </>
+  )
+}

--- a/packages/mobile/src/components/buy-sell/index.ts
+++ b/packages/mobile/src/components/buy-sell/index.ts
@@ -1,0 +1,3 @@
+export { TokenAmountSection } from './TokenAmountSection'
+export { SwapBalanceSection } from './SwapBalanceSection'
+export { TooltipInfoIcon } from './TooltipInfoIcon'

--- a/packages/mobile/src/screens/app-screen/AppScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppScreen.tsx
@@ -6,7 +6,6 @@ import { Platform } from 'react-native'
 
 import { setLastNavAction } from 'app/hooks/useNavigation'
 
-import { ChangeEmailModalScreen } from '../change-email-screen/ChangeEmailScreen'
 import { ChangePasswordModalScreen } from '../change-password-screen'
 import { CreateChatBlastNavigator } from '../create-chat-blast-screen/CreateChatBlastNavigator'
 import { EditCollectionScreen } from '../edit-collection-screen'
@@ -71,7 +70,6 @@ export const AppScreen = () => {
           name='ChangePassword'
           component={ChangePasswordModalScreen}
         />
-        <Stack.Screen name='ChangeEmail' component={ChangeEmailModalScreen} />
       </Stack.Group>
     </Stack.Navigator>
   )

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -23,6 +23,12 @@ import { setLastNavAction } from 'app/hooks/useNavigation'
 import { AiGeneratedTracksScreen } from 'app/screens/ai-generated-tracks-screen'
 import { AppDrawerContext } from 'app/screens/app-drawer-screen'
 import { AudioScreen } from 'app/screens/audio-screen'
+import {
+  BuySellScreen,
+  ConfirmSwapScreen,
+  TransactionResultScreen
+} from 'app/screens/buy-sell-screen'
+import { ChangeEmailModalScreen } from 'app/screens/change-email-screen/ChangeEmailScreen'
 import { ChatListScreen } from 'app/screens/chat-screen/ChatListScreen'
 import { ChatScreen } from 'app/screens/chat-screen/ChatScreen'
 import { ChatUserListScreen } from 'app/screens/chat-screen/ChatUserListScreen'
@@ -102,6 +108,9 @@ export type AppTabScreenParamList = {
   AccountVerificationScreen: undefined
   ChangeEmail: undefined
   ChangePassword: undefined
+  BuySellScreen: undefined
+  ConfirmSwapScreen: undefined
+  TransactionResultScreen: undefined
   InboxSettingsScreen: undefined
   CommentSettingsScreen: undefined
   DownloadSettingsScreen: undefined
@@ -261,6 +270,15 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
         <Stack.Screen
           name='AccountVerificationScreen'
           component={AccountVerificationScreen}
+        />
+        <Stack.Screen name='ChangeEmail' component={ChangeEmailModalScreen} />
+      </Stack.Group>
+      <Stack.Group>
+        <Stack.Screen name='BuySellScreen' component={BuySellScreen} />
+        <Stack.Screen name='ConfirmSwapScreen' component={ConfirmSwapScreen} />
+        <Stack.Screen
+          name='TransactionResultScreen'
+          component={TransactionResultScreen}
         />
       </Stack.Group>
       <Stack.Screen

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
@@ -2,27 +2,27 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
 import { Name } from '@audius/common/models'
-import type { BuySellTab, Screen } from '@audius/common/store'
+import type { BuySellTab } from '@audius/common/store'
 import {
   useBuySellScreen,
   useBuySellSwap,
   useBuySellTabs,
   useBuySellTransactionData,
+  useSwapDisplayData,
   SUPPORTED_TOKEN_PAIRS,
   useAddCashModal
 } from '@audius/common/store'
+import { useFocusEffect } from '@react-navigation/native'
 
 import { Button, Flex, Hint, TextLink } from '@audius/harmony-native'
 import { SegmentedControl } from 'app/components/core'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { make, track } from 'app/services/analytics'
 
 import { BuyScreen, SellScreen } from './components'
 
 type BuySellFlowProps = {
   onClose: () => void
-  onNavigateToConfirm?: () => void
-  onScreenChange: (screen: Screen) => void
-  onLoadingStateChange?: (isLoading: boolean) => void
   initialTab?: 'buy' | 'sell'
 }
 
@@ -30,15 +30,13 @@ const WALLET_GUIDE_URL = 'https://help.audius.co/product/wallet-guide'
 
 export const BuySellFlow = ({
   onClose,
-  onNavigateToConfirm,
-  onScreenChange,
-  onLoadingStateChange,
   initialTab = 'buy'
 }: BuySellFlowProps) => {
+  const navigation = useNavigation()
   const { onOpen: openAddCashModal } = useAddCashModal()
 
   const { currentScreen, setCurrentScreen } = useBuySellScreen({
-    onScreenChange
+    onScreenChange: () => {} // No-op since we handle navigation separately
   })
 
   const {
@@ -53,6 +51,14 @@ export const BuySellFlow = ({
     resetTransactionData,
     initialTab: (initialTab as BuySellTab) || 'buy'
   })
+
+  // Reset screen state to 'input' when this screen comes into focus
+  // This handles the case where we navigate back from ConfirmSwapScreen
+  useFocusEffect(
+    useCallback(() => {
+      setCurrentScreen('input')
+    }, [setCurrentScreen])
+  )
 
   // Persistent state for each tab's input values
   const [tabInputValues, setTabInputValues] = useState<
@@ -70,11 +76,7 @@ export const BuySellFlow = ({
     }))
   }
 
-  const {
-    handleShowConfirmation,
-    isContinueButtonLoading,
-    isConfirmButtonLoading
-  } = useBuySellSwap({
+  const { handleShowConfirmation, isContinueButtonLoading } = useBuySellSwap({
     transactionData,
     currentScreen,
     setCurrentScreen,
@@ -85,24 +87,34 @@ export const BuySellFlow = ({
   // Track if user has attempted to submit the form
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
 
-  useEffect(() => {
-    onLoadingStateChange?.(isConfirmButtonLoading)
-  }, [isConfirmButtonLoading, onLoadingStateChange])
-
   const [selectedPairIndex] = useState(0)
+  const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
+
+  const { confirmationScreenData } = useSwapDisplayData({
+    swapStatus: null, // Not needed in this component
+    currentScreen,
+    transactionData,
+    swapResult: null, // Not needed in this component
+    activeTab,
+    selectedPair
+  })
 
   const tabs = [
     { key: 'buy' as BuySellTab, text: messages.buy },
     { key: 'sell' as BuySellTab, text: messages.sell }
   ]
 
-  const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
-
   const handleContinueClick = () => {
     setHasAttemptedSubmit(true)
     if (transactionData?.isValid && !isContinueButtonLoading) {
       handleShowConfirmation()
-      onNavigateToConfirm?.()
+
+      // Navigate to confirmation screen with the data
+      if (confirmationScreenData) {
+        navigation.navigate('ConfirmSwapScreen', {
+          confirmationData: confirmationScreenData
+        })
+      }
     }
   }
 
@@ -143,11 +155,7 @@ export const BuySellFlow = ({
   const shouldShowError =
     !!displayErrorMessage || (activeTab === 'buy' && !hasSufficientBalance)
 
-  // Only show the input screen for now - confirm and success screens will be separate mobile screens
-  if (currentScreen !== 'input') {
-    return null
-  }
-
+  // Always show the input screen in mobile - other screens are separate
   return (
     <Flex direction='column' gap='xl' p='l'>
       {/* Tab Control */}

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
@@ -1,0 +1,188 @@
+import React, { useState, useEffect, useMemo } from 'react'
+
+import { buySellMessages as messages } from '@audius/common/messages'
+import type { BuySellTab, Screen } from '@audius/common/store'
+import {
+  useBuySellScreen,
+  useBuySellSwap,
+  useBuySellTabs,
+  useBuySellTransactionData,
+  SUPPORTED_TOKEN_PAIRS
+} from '@audius/common/store'
+
+import { Button, Flex, Text } from '@audius/harmony-native'
+import { SegmentedControl } from 'app/components/core'
+
+import { BuyScreen, SellScreen } from './components'
+
+type BuySellFlowProps = {
+  onClose: () => void
+  onNavigateToConfirm?: () => void
+  onScreenChange: (screen: Screen) => void
+  onLoadingStateChange?: (isLoading: boolean) => void
+  initialTab?: 'buy' | 'sell'
+}
+
+export const BuySellFlow = ({
+  onClose,
+  onNavigateToConfirm,
+  onScreenChange,
+  onLoadingStateChange,
+  initialTab = 'buy'
+}: BuySellFlowProps) => {
+  const { currentScreen, setCurrentScreen } = useBuySellScreen({
+    onScreenChange
+  })
+
+  const {
+    transactionData,
+    hasSufficientBalance,
+    handleTransactionDataChange,
+    resetTransactionData
+  } = useBuySellTransactionData()
+
+  const { activeTab, handleActiveTabChange } = useBuySellTabs({
+    setCurrentScreen,
+    resetTransactionData,
+    initialTab: (initialTab as BuySellTab) || 'buy'
+  })
+
+  // Persistent state for each tab's input values
+  const [tabInputValues, setTabInputValues] = useState<
+    Record<BuySellTab, string>
+  >({
+    buy: '',
+    sell: ''
+  })
+
+  // Update input value for current tab
+  const handleTabInputValueChange = (value: string) => {
+    setTabInputValues((prev) => ({
+      ...prev,
+      [activeTab]: value
+    }))
+  }
+
+  const {
+    handleShowConfirmation,
+    isContinueButtonLoading,
+    isConfirmButtonLoading
+  } = useBuySellSwap({
+    transactionData,
+    currentScreen,
+    setCurrentScreen,
+    activeTab,
+    onClose
+  })
+
+  // Track if user has attempted to submit the form
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
+
+  useEffect(() => {
+    onLoadingStateChange?.(isConfirmButtonLoading)
+  }, [isConfirmButtonLoading, onLoadingStateChange])
+
+  const [selectedPairIndex] = useState(0)
+
+  const tabs = [
+    { key: 'buy' as BuySellTab, text: messages.buy },
+    { key: 'sell' as BuySellTab, text: messages.sell }
+  ]
+
+  const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
+
+  const handleContinueClick = () => {
+    setHasAttemptedSubmit(true)
+    if (transactionData?.isValid && !isContinueButtonLoading) {
+      handleShowConfirmation()
+      onNavigateToConfirm?.()
+    }
+  }
+
+  useEffect(() => {
+    setHasAttemptedSubmit(false)
+  }, [activeTab])
+
+  const isTransactionInvalid = !transactionData?.isValid
+
+  const displayErrorMessage = useMemo(() => {
+    if (activeTab === 'sell' && !hasSufficientBalance) {
+      return messages.insufficientAUDIOForSale
+    }
+    if (
+      hasAttemptedSubmit &&
+      isTransactionInvalid &&
+      !(activeTab === 'buy' && !hasSufficientBalance)
+    ) {
+      return messages.emptyAmount
+    }
+    return undefined
+  }, [
+    activeTab,
+    hasSufficientBalance,
+    hasAttemptedSubmit,
+    isTransactionInvalid
+  ])
+
+  const shouldShowError =
+    !!displayErrorMessage || (activeTab === 'buy' && !hasSufficientBalance)
+
+  // Only show the input screen for now - confirm and success screens will be separate mobile screens
+  if (currentScreen !== 'input') {
+    return null
+  }
+
+  return (
+    <Flex direction='column' gap='l' p='l'>
+      {/* Tab Control */}
+      <Flex alignItems='center' justifyContent='center'>
+        <SegmentedControl
+          options={tabs}
+          selected={activeTab}
+          onSelectOption={handleActiveTabChange}
+          fullWidth
+        />
+      </Flex>
+
+      {/* Tab Content */}
+      {activeTab === 'buy' ? (
+        <BuyScreen
+          tokenPair={selectedPair}
+          onTransactionDataChange={handleTransactionDataChange}
+          error={shouldShowError}
+          errorMessage={displayErrorMessage}
+          initialInputValue={tabInputValues.buy}
+          onInputValueChange={handleTabInputValueChange}
+        />
+      ) : (
+        <SellScreen
+          tokenPair={selectedPair}
+          onTransactionDataChange={handleTransactionDataChange}
+          error={shouldShowError}
+          errorMessage={displayErrorMessage}
+          initialInputValue={tabInputValues.sell}
+          onInputValueChange={handleTabInputValueChange}
+        />
+      )}
+
+      {/* Insufficient Balance Message for Buy */}
+      {activeTab === 'buy' && !hasSufficientBalance && (
+        <Flex p='m' backgroundColor='surface2' borderRadius='m'>
+          <Text variant='body' size='s' color='subdued'>
+            {messages.insufficientUSDC}
+          </Text>
+        </Flex>
+      )}
+
+      {/* Continue Button */}
+      <Button
+        variant='primary'
+        fullWidth
+        isLoading={isContinueButtonLoading}
+        onPress={handleContinueClick}
+      >
+        {messages.continue}
+      </Button>
+    </Flex>
+  )
+}

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
-import type { Screen } from '@audius/common/store'
 
 import { Flex, IconJupiterLogo, Text } from '@audius/harmony-native'
 import { Screen as MobileScreen, ScreenContent } from 'app/components/core'
@@ -21,79 +20,29 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
   const navigation = useNavigation()
   const { params } = route
 
-  const [modalScreen, setModalScreen] = useState<Screen>('input')
-  const [isFlowLoading, setIsFlowLoading] = useState(false)
-
-  // Reset modal state when screen loads
-  useEffect(() => {
-    setModalScreen('input')
-    setIsFlowLoading(false)
-  }, [])
-
   const handleClose = () => {
     navigation.goBack()
   }
 
-  const handleNavigateToConfirm = () => {
-    navigation.navigate('ConfirmSwapScreen')
-  }
-
-  const handleScreenChange = (screen: Screen) => {
-    setModalScreen(screen)
-
-    // Navigate to different screens based on the screen state
-    if (screen === 'confirm') {
-      navigation.navigate('ConfirmSwapScreen')
-    } else if (screen === 'success') {
-      navigation.navigate('TransactionResultScreen', {
-        result: {
-          status: 'success' as const
-        },
-        type: 'swap' as const
-      })
-    }
-  }
-
-  const handleLoadingStateChange = (isLoading: boolean) => {
-    setIsFlowLoading(isLoading)
-  }
-
-  const title = useMemo(() => {
-    if (isFlowLoading) return ''
-    if (modalScreen === 'confirm') return messages.confirmDetails
-    if (modalScreen === 'success') return messages.modalSuccessTitle
-    return messages.title
-  }, [isFlowLoading, modalScreen])
-
-  const shouldShowPoweredBy = modalScreen !== 'success' && !isFlowLoading
-
   return (
-    <MobileScreen title={title} variant='white' url='/buy-sell'>
+    <MobileScreen title={messages.title} variant='white' url='/buy-sell'>
       <ScreenContent>
-        {shouldShowPoweredBy && (
-          <Flex
-            direction='row'
-            alignItems='center'
-            justifyContent='center'
-            gap='l'
-            p='l'
-            border='default'
-            backgroundColor='surface1'
-          >
-            <Text variant='label' size='s' color='subdued'>
-              {messages.poweredBy}
-            </Text>
-            <IconJupiterLogo />
-          </Flex>
-        )}
+        <Flex
+          direction='row'
+          alignItems='center'
+          justifyContent='center'
+          gap='l'
+          p='l'
+          border='default'
+          backgroundColor='surface1'
+        >
+          <Text variant='label' size='s' color='subdued'>
+            {messages.poweredBy}
+          </Text>
+          <IconJupiterLogo />
+        </Flex>
         <Flex mt='xl'>
-          <BuySellFlow
-            onClose={handleClose}
-            onNavigateToConfirm={handleNavigateToConfirm}
-            onScreenChange={handleScreenChange}
-            onLoadingStateChange={handleLoadingStateChange}
-            initialTab={params?.initialTab}
-          />
+          <BuySellFlow onClose={handleClose} initialTab={params?.initialTab} />
         </Flex>
       </ScreenContent>
     </MobileScreen>

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
@@ -65,36 +65,36 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
     return messages.title
   }, [isFlowLoading, modalScreen])
 
-  const showFooter = modalScreen !== 'success' && !isFlowLoading
+  const shouldShowPoweredBy = modalScreen !== 'success' && !isFlowLoading
 
   return (
-    <MobileScreen title={title} variant='secondary' url='/buy-sell'>
+    <MobileScreen title={title} variant='white' url='/buy-sell'>
       <ScreenContent>
-        <BuySellFlow
-          onClose={handleClose}
-          onNavigateToConfirm={handleNavigateToConfirm}
-          onScreenChange={handleScreenChange}
-          onLoadingStateChange={handleLoadingStateChange}
-          initialTab={params?.initialTab}
-        />
-
-        {/* Footer with Jupiter branding */}
-        {showFooter && (
+        {shouldShowPoweredBy && (
           <Flex
             direction='row'
             alignItems='center'
             justifyContent='center'
-            gap='s'
+            gap='l'
             p='l'
-            borderTop='default'
+            border='default'
             backgroundColor='surface1'
           >
-            <Text variant='label' size='xs' color='subdued'>
+            <Text variant='label' size='s' color='subdued'>
               {messages.poweredBy}
             </Text>
-            <IconJupiterLogo size='xs' />
+            <IconJupiterLogo />
           </Flex>
         )}
+        <Flex mt='xl'>
+          <BuySellFlow
+            onClose={handleClose}
+            onNavigateToConfirm={handleNavigateToConfirm}
+            onScreenChange={handleScreenChange}
+            onLoadingStateChange={handleLoadingStateChange}
+            initialTab={params?.initialTab}
+          />
+        </Flex>
       </ScreenContent>
     </MobileScreen>
   )

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
@@ -1,0 +1,101 @@
+import React, { useState, useEffect, useMemo } from 'react'
+
+import { buySellMessages as messages } from '@audius/common/messages'
+import type { Screen } from '@audius/common/store'
+
+import { Flex, IconJupiterLogo, Text } from '@audius/harmony-native'
+import { Screen as MobileScreen, ScreenContent } from 'app/components/core'
+import { useNavigation } from 'app/hooks/useNavigation'
+
+import type { BuySellScreenParams } from '../../types/navigation'
+
+import { BuySellFlow } from './BuySellFlow'
+
+type BuySellScreenProps = {
+  route: {
+    params?: BuySellScreenParams
+  }
+}
+
+export const BuySellScreen = ({ route }: BuySellScreenProps) => {
+  const navigation = useNavigation()
+  const { params } = route
+
+  const [modalScreen, setModalScreen] = useState<Screen>('input')
+  const [isFlowLoading, setIsFlowLoading] = useState(false)
+
+  // Reset modal state when screen loads
+  useEffect(() => {
+    setModalScreen('input')
+    setIsFlowLoading(false)
+  }, [])
+
+  const handleClose = () => {
+    navigation.goBack()
+  }
+
+  const handleNavigateToConfirm = () => {
+    navigation.navigate('ConfirmSwapScreen')
+  }
+
+  const handleScreenChange = (screen: Screen) => {
+    setModalScreen(screen)
+
+    // Navigate to different screens based on the screen state
+    if (screen === 'confirm') {
+      navigation.navigate('ConfirmSwapScreen')
+    } else if (screen === 'success') {
+      navigation.navigate('TransactionResultScreen', {
+        result: {
+          status: 'success' as const
+        },
+        type: 'swap' as const
+      })
+    }
+  }
+
+  const handleLoadingStateChange = (isLoading: boolean) => {
+    setIsFlowLoading(isLoading)
+  }
+
+  const title = useMemo(() => {
+    if (isFlowLoading) return ''
+    if (modalScreen === 'confirm') return messages.confirmDetails
+    if (modalScreen === 'success') return messages.modalSuccessTitle
+    return messages.title
+  }, [isFlowLoading, modalScreen])
+
+  const showFooter = modalScreen !== 'success' && !isFlowLoading
+
+  return (
+    <MobileScreen title={title} variant='secondary' url='/buy-sell'>
+      <ScreenContent>
+        <BuySellFlow
+          onClose={handleClose}
+          onNavigateToConfirm={handleNavigateToConfirm}
+          onScreenChange={handleScreenChange}
+          onLoadingStateChange={handleLoadingStateChange}
+          initialTab={params?.initialTab}
+        />
+
+        {/* Footer with Jupiter branding */}
+        {showFooter && (
+          <Flex
+            direction='row'
+            alignItems='center'
+            justifyContent='center'
+            gap='s'
+            p='l'
+            borderTop='default'
+            backgroundColor='surface1'
+          >
+            <Text variant='label' size='xs' color='subdued'>
+              {messages.poweredBy}
+            </Text>
+            <IconJupiterLogo size='xs' />
+          </Flex>
+        )}
+      </ScreenContent>
+    </MobileScreen>
+  )
+}

--- a/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import { Screen, ScreenContent } from 'app/components/core'
+
+// Transaction confirmation (separate screen)
+// TODO: Implement in Phase 3
+
+export const ConfirmSwapScreen = () => {
+  return (
+    <Screen>
+      <ScreenContent>
+        {/* TODO: Add SwapBalanceSection components */}
+        {/* TODO: Add exchange rate and price impact display */}
+        {/* TODO: Add transaction details card */}
+        {/* TODO: Add Back/Confirm button pair */}
+        <></>
+      </ScreenContent>
+    </Screen>
+  )
+}

--- a/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
@@ -1,19 +1,241 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState, useCallback } from 'react'
 
+import { formatUSDCValue } from '@audius/common/api'
+import { buySellMessages as baseMessages } from '@audius/common/messages'
+import type { TokenInfo } from '@audius/common/store'
+import {
+  useTokenAmountFormatting,
+  useBuySellSwap,
+  useBuySellScreen,
+  useSwapDisplayData,
+  SUPPORTED_TOKEN_PAIRS
+} from '@audius/common/store'
+
+import { Button, Flex, Text, LoadingSpinner } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
+import { useNavigation } from 'app/hooks/useNavigation'
 
-// Transaction confirmation (separate screen)
-// TODO: Implement in Phase 3
+import { SwapBalanceSection } from '../../components/buy-sell'
 
-export const ConfirmSwapScreen = () => {
+const messages = {
+  ...baseMessages,
+  priceEach: (price: number) => {
+    const formatted = formatUSDCValue(price, { includeDollarSign: true })
+    return `(${formatted} ea.)`
+  },
+  loadingTitle: 'Transaction in Progress',
+  loadingSubtitle: 'This may take a moment.'
+}
+
+type ConfirmSwapScreenProps = {
+  route: {
+    params: {
+      confirmationData: {
+        payTokenInfo: TokenInfo
+        receiveTokenInfo: TokenInfo
+        payAmount: number
+        receiveAmount: number
+        pricePerBaseToken: number
+        baseTokenSymbol: string
+      }
+    }
+  }
+}
+
+const LoadingScreen = () => (
+  <Flex
+    direction='column'
+    justifyContent='center'
+    alignItems='center'
+    gap='l'
+    p='xl'
+    flex={1}
+  >
+    <LoadingSpinner />
+    <Flex direction='column' alignItems='center' gap='s'>
+      <Text variant='heading' size='l' color='default' textAlign='center'>
+        {messages.loadingTitle}
+      </Text>
+      <Text
+        variant='title'
+        size='l'
+        strength='weak'
+        color='default'
+        textAlign='center'
+      >
+        {messages.loadingSubtitle}
+      </Text>
+    </Flex>
+  </Flex>
+)
+
+export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
+  const navigation = useNavigation()
+  const {
+    confirmationData: {
+      payTokenInfo,
+      receiveTokenInfo,
+      payAmount,
+      receiveAmount,
+      pricePerBaseToken,
+      baseTokenSymbol
+    }
+  } = route.params
+
+  const stableOnScreenChange = useCallback(() => {
+    // No-op since we handle navigation separately
+  }, [])
+
+  const { currentScreen, setCurrentScreen } = useBuySellScreen({
+    onScreenChange: stableOnScreenChange
+  })
+
+  // Set the screen to 'confirm' when this component mounts
+  useEffect(() => {
+    setCurrentScreen('confirm')
+  }, [setCurrentScreen])
+
+  // Create transaction data from the confirmation data passed via navigation
+  const transactionData = useMemo(
+    () => ({
+      inputAmount: payAmount,
+      outputAmount: receiveAmount,
+      isValid: true // If we got to the confirmation screen, the data should be valid
+    }),
+    [payAmount, receiveAmount]
+  )
+
+  // Determine if this is a buy or sell based on token types
+  const activeTab = payTokenInfo.symbol === 'USDC' ? 'buy' : 'sell'
+
+  const {
+    handleConfirmSwap,
+    isConfirmButtonLoading,
+    swapStatus,
+    swapError,
+    swapResult
+  } = useBuySellSwap({
+    transactionData,
+    currentScreen,
+    setCurrentScreen,
+    activeTab,
+    onClose: () => navigation.goBack()
+  })
+
+  const [selectedPairIndex] = useState(0)
+  const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
+
+  const { successDisplayData } = useSwapDisplayData({
+    swapStatus,
+    currentScreen,
+    transactionData,
+    swapResult,
+    activeTab,
+    selectedPair
+  })
+
+  useEffect(() => {
+    if (currentScreen === 'success' && successDisplayData) {
+      navigation.navigate('TransactionResultScreen', {
+        result: {
+          status: 'success' as const,
+          data: successDisplayData
+        }
+      })
+    }
+  }, [currentScreen, successDisplayData, navigation])
+
+  // Handle swap error
+  useEffect(() => {
+    if (swapStatus === 'error' && swapError) {
+      navigation.navigate('TransactionResultScreen', {
+        result: {
+          status: 'error' as const,
+          error: swapError
+        }
+      })
+    }
+  }, [swapStatus, swapError, navigation])
+
+  // balance isn't needed so we pass 0
+  const { formattedAmount: formattedPayAmount } = useTokenAmountFormatting({
+    amount: payAmount,
+    availableBalance: 0,
+    isStablecoin: !!payTokenInfo.isStablecoin
+  })
+
+  const { formattedAmount: formattedReceiveAmount } = useTokenAmountFormatting({
+    amount: receiveAmount,
+    availableBalance: 0,
+    isStablecoin: !!receiveTokenInfo.isStablecoin
+  })
+
+  const isReceivingBaseToken = receiveTokenInfo.symbol === baseTokenSymbol
+  const priceLabel = isReceivingBaseToken
+    ? messages.priceEach(pricePerBaseToken)
+    : undefined
+
+  const handleBack = () => {
+    navigation.goBack()
+  }
+
+  const handleConfirm = () => {
+    handleConfirmSwap()
+  }
+
+  if (!formattedPayAmount || !formattedReceiveAmount) {
+    return null
+  }
+
+  // Show loading screen when confirming transaction
+  if (isConfirmButtonLoading) {
+    return (
+      <Screen
+        title={messages.confirmDetails}
+        variant='white'
+        url='/buy-sell/confirm'
+      >
+        <ScreenContent>
+          <LoadingScreen />
+        </ScreenContent>
+      </Screen>
+    )
+  }
+
   return (
-    <Screen>
+    <Screen
+      title={messages.confirmDetails}
+      variant='white'
+      url='/buy-sell/confirm'
+    >
       <ScreenContent>
-        {/* TODO: Add SwapBalanceSection components */}
-        {/* TODO: Add exchange rate and price impact display */}
-        {/* TODO: Add transaction details card */}
-        {/* TODO: Add Back/Confirm button pair */}
-        <></>
+        <Flex direction='column' gap='xl' p='l'>
+          <Text variant='body' size='m' textAlign='center'>
+            {messages.confirmReview}
+          </Text>
+          <Flex direction='column' gap='xl'>
+            <SwapBalanceSection
+              title={messages.youPay}
+              tokenInfo={payTokenInfo}
+              amount={formattedPayAmount}
+            />
+            <SwapBalanceSection
+              title={messages.youReceive}
+              tokenInfo={receiveTokenInfo}
+              amount={formattedReceiveAmount}
+              priceLabel={priceLabel}
+            />
+          </Flex>
+
+          <Flex gap='s' mt='xl'>
+            <Button variant='secondary' fullWidth onPress={handleBack}>
+              {messages.back}
+            </Button>
+            <Button variant='primary' fullWidth onPress={handleConfirm}>
+              {messages.confirm}
+            </Button>
+          </Flex>
+        </Flex>
       </ScreenContent>
     </Screen>
   )

--- a/packages/mobile/src/screens/buy-sell-screen/TransactionResultScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/TransactionResultScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { Screen, ScreenContent } from 'app/components/core'
+
+// Success/error feedback (separate screen)
+// TODO: Implement in Phase 3
+
+export const TransactionResultScreen = () => {
+  return (
+    <Screen>
+      <ScreenContent>
+        {/* TODO: Success State - icon, message, transaction summary, Done button */}
+        {/* TODO: Error State - error icon, message, Try Again/Go Back buttons */}
+        <></>
+      </ScreenContent>
+    </Screen>
+  )
+}

--- a/packages/mobile/src/screens/buy-sell-screen/TransactionResultScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/TransactionResultScreen.tsx
@@ -1,18 +1,122 @@
 import React from 'react'
 
+import { formatUSDCValue } from '@audius/common/api'
+import { buySellMessages as baseMessages } from '@audius/common/messages'
+import type { SuccessDisplayData } from '@audius/common/store'
+import { useTokenAmountFormatting } from '@audius/common/store'
+
+import { Button, CompletionCheck, Flex, Text } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
+import { useNavigation } from 'app/hooks/useNavigation'
 
-// Success/error feedback (separate screen)
-// TODO: Implement in Phase 3
+import { SwapBalanceSection } from '../../components/buy-sell'
 
-export const TransactionResultScreen = () => {
-  return (
-    <Screen>
-      <ScreenContent>
-        {/* TODO: Success State - icon, message, transaction summary, Done button */}
-        {/* TODO: Error State - error icon, message, Try Again/Go Back buttons */}
-        <></>
-      </ScreenContent>
-    </Screen>
-  )
+const messages = {
+  ...baseMessages,
+  priceEach: (price: number) => {
+    const formatted = formatUSDCValue(price, { includeDollarSign: true })
+    return `(${formatted} ea.)`
+  }
+}
+
+type TransactionResult = {
+  status: 'success' | 'error'
+  data?: SuccessDisplayData
+  error?: { message?: string }
+}
+
+type TransactionResultScreenProps = {
+  route: {
+    params: {
+      result: TransactionResult
+    }
+  }
+}
+
+export const TransactionResultScreen = ({
+  route
+}: TransactionResultScreenProps) => {
+  const navigation = useNavigation()
+  const { result } = route.params
+
+  // Always call hooks at the top level to avoid conditional hook calls
+  const successData = result.status === 'success' ? result.data : null
+
+  const { formattedAmount: formattedPayAmount } = useTokenAmountFormatting({
+    amount: successData?.payAmount || 0,
+    availableBalance: successData?.payAmount || 0,
+    isStablecoin: !!successData?.payTokenInfo.isStablecoin
+  })
+
+  const { formattedAmount: formattedReceiveAmount } = useTokenAmountFormatting({
+    amount: successData?.receiveAmount || 0,
+    availableBalance: successData?.receiveAmount || 0,
+    isStablecoin: !!successData?.receiveTokenInfo.isStablecoin
+  })
+
+  const handleDone = () => {
+    // Navigate back to the wallet screen after successful transaction
+    navigation.navigate('wallet')
+  }
+
+  if (result.status === 'success' && successData) {
+    const {
+      payTokenInfo,
+      receiveTokenInfo,
+      pricePerBaseToken,
+      baseTokenSymbol
+    } = successData
+
+    const isReceivingBaseToken = receiveTokenInfo.symbol === baseTokenSymbol
+    const priceLabel = isReceivingBaseToken
+      ? messages.priceEach(pricePerBaseToken)
+      : undefined
+
+    if (!formattedPayAmount || !formattedReceiveAmount) return null
+
+    return (
+      <Screen
+        title={messages.modalSuccessTitle}
+        variant='white'
+        url='/buy-sell/success'
+      >
+        <ScreenContent>
+          <Flex direction='column' gap='xl' p='l'>
+            <Flex
+              direction='row'
+              gap='s'
+              alignItems='center'
+              justifyContent='center'
+            >
+              <CompletionCheck value='complete' />
+              <Text variant='heading' size='s' color='default'>
+                {messages.transactionComplete}
+              </Text>
+            </Flex>
+            <Flex direction='column' gap='xl' w='100%'>
+              <SwapBalanceSection
+                title={messages.youPaid}
+                tokenInfo={payTokenInfo}
+                amount={formattedPayAmount}
+              />
+              <SwapBalanceSection
+                title={messages.youReceived}
+                tokenInfo={receiveTokenInfo}
+                amount={formattedReceiveAmount}
+                priceLabel={priceLabel}
+              />
+            </Flex>
+
+            <Flex>
+              <Button variant='primary' fullWidth onPress={handleDone}>
+                {messages.done}
+              </Button>
+            </Flex>
+          </Flex>
+        </ScreenContent>
+      </Screen>
+    )
+  }
+
+  return null
 }

--- a/packages/mobile/src/screens/buy-sell-screen/components/BuyScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/components/BuyScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useMemo } from 'react'
+
+import { useTokenPrice, useUSDCBalance } from '@audius/common/api'
+import { Status } from '@audius/common/models'
+import type { TokenPair } from '@audius/common/store'
+import { getCurrencyDecimalPlaces } from '@audius/common/utils'
+
+import { SwapTab } from './SwapTab'
+
+type BuyScreenProps = {
+  tokenPair: TokenPair
+  onTransactionDataChange?: (data: {
+    inputAmount: number
+    outputAmount: number
+    isValid: boolean
+  }) => void
+  error?: boolean
+  errorMessage?: string
+  initialInputValue?: string
+  onInputValueChange?: (value: string) => void
+}
+
+export const BuyScreen = ({
+  tokenPair,
+  onTransactionDataChange,
+  error,
+  errorMessage,
+  initialInputValue,
+  onInputValueChange
+}: BuyScreenProps) => {
+  const { baseToken, quoteToken } = tokenPair
+  const { status: balanceStatus, data: usdcBalance } = useUSDCBalance()
+
+  const { data: tokenPriceData, isPending: isTokenPriceLoading } =
+    useTokenPrice(baseToken.address)
+
+  const tokenPrice = tokenPriceData?.price || null
+
+  const decimalPlaces = useMemo(() => {
+    if (!tokenPrice) return 2
+    return getCurrencyDecimalPlaces(parseFloat(tokenPrice))
+  }, [tokenPrice])
+
+  const getUsdcBalance = useMemo(() => {
+    return () => {
+      if (balanceStatus === Status.SUCCESS && usdcBalance) {
+        return parseFloat(usdcBalance.toString()) / 10 ** quoteToken.decimals
+      }
+      return undefined
+    }
+  }, [balanceStatus, usdcBalance, quoteToken.decimals])
+
+  return (
+    <SwapTab
+      inputToken={quoteToken}
+      outputToken={baseToken}
+      balance={{
+        get: getUsdcBalance,
+        loading: balanceStatus === Status.LOADING,
+        formatError: () => 'Insufficient balance'
+      }}
+      onTransactionDataChange={onTransactionDataChange}
+      error={error}
+      errorMessage={errorMessage}
+      tokenPrice={tokenPrice}
+      isTokenPriceLoading={isTokenPriceLoading}
+      tokenPriceDecimalPlaces={decimalPlaces}
+      initialInputValue={initialInputValue}
+      onInputValueChange={onInputValueChange}
+    />
+  )
+}

--- a/packages/mobile/src/screens/buy-sell-screen/components/SellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/components/SellScreen.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react'
+
+import { useAudioBalance } from '@audius/common/api'
+import type { TokenPair } from '@audius/common/store'
+import { isNullOrUndefined } from '@audius/common/utils'
+import { AUDIO } from '@audius/fixed-decimal'
+
+import { SwapTab } from './SwapTab'
+
+type SellScreenProps = {
+  tokenPair: TokenPair
+  onTransactionDataChange?: (data: {
+    inputAmount: number
+    outputAmount: number
+    isValid: boolean
+  }) => void
+  error?: boolean
+  errorMessage?: string
+  initialInputValue?: string
+  onInputValueChange?: (value: string) => void
+}
+
+export const SellScreen = ({
+  tokenPair,
+  onTransactionDataChange,
+  error,
+  errorMessage,
+  initialInputValue,
+  onInputValueChange
+}: SellScreenProps) => {
+  // Extract the tokens from the pair
+  const { baseToken, quoteToken } = tokenPair
+  const { accountBalance } = useAudioBalance({ includeConnectedWallets: false })
+  const isBalanceLoading = isNullOrUndefined(accountBalance)
+
+  // Get AUDIO balance in UI format
+  const getAudioBalance = useMemo(() => {
+    return () => {
+      if (!isBalanceLoading && accountBalance) {
+        return parseFloat(AUDIO(accountBalance).toString())
+      }
+      return undefined
+    }
+  }, [accountBalance, isBalanceLoading])
+
+  return (
+    <SwapTab
+      inputToken={baseToken}
+      outputToken={quoteToken}
+      balance={{
+        get: getAudioBalance,
+        loading: isBalanceLoading,
+        formatError: () => 'Insufficient balance'
+      }}
+      onTransactionDataChange={onTransactionDataChange}
+      isDefault={false}
+      error={error}
+      errorMessage={errorMessage}
+      initialInputValue={initialInputValue}
+      onInputValueChange={onInputValueChange}
+    />
+  )
+}

--- a/packages/mobile/src/screens/buy-sell-screen/components/SwapTab.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/components/SwapTab.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 
 import type { TokenInfo } from '@audius/common/store'
 
-import { Flex, Skeleton } from '@audius/harmony-native'
+import { Divider, Flex, Skeleton } from '@audius/harmony-native'
 
 import { TokenAmountSection } from '../../../components/buy-sell'
 
@@ -103,7 +103,7 @@ export const SwapTab = ({
     (isExchangeRateLoading && !hasRateEverBeenFetched.current)
 
   return (
-    <Flex direction='column'>
+    <Flex direction='column' gap='l'>
       {isInitialLoading ? (
         <SwapFormSkeleton />
       ) : (
@@ -121,7 +121,7 @@ export const SwapTab = ({
             error={error}
             errorMessage={errorMessage}
           />
-
+          <Divider flex={1} />
           <TokenAmountSection
             title={messages.youReceive}
             tokenInfo={outputToken}

--- a/packages/mobile/src/screens/buy-sell-screen/components/SwapTab.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/components/SwapTab.tsx
@@ -1,0 +1,140 @@
+import React, { useRef } from 'react'
+
+import type { TokenInfo } from '@audius/common/store'
+
+import { Flex, Skeleton } from '@audius/harmony-native'
+
+import { TokenAmountSection } from '../../../components/buy-sell'
+
+import { useTokenSwapForm } from './hooks/useTokenSwapForm'
+
+const messages = {
+  youPay: 'You Pay',
+  youReceive: 'You Receive',
+  placeholder: '0.00'
+}
+
+const TokenSectionSkeleton = ({ title }: { title: string }) => (
+  <Flex direction='column' gap='s'>
+    <Skeleton h='xl' w={title === 'input' ? 'unit20' : 'unit24'} />
+    <Skeleton h='unit14' w='100%' />
+  </Flex>
+)
+
+const SwapFormSkeleton = () => (
+  <Flex direction='column'>
+    <TokenSectionSkeleton title='input' />
+    <TokenSectionSkeleton title='output' />
+  </Flex>
+)
+
+export type SwapTabProps = {
+  inputToken: TokenInfo
+  outputToken: TokenInfo
+  min?: number
+  max?: number
+  balance: {
+    get: () => number | undefined
+    loading: boolean
+    formatError: () => string
+  }
+
+  onTransactionDataChange?: (data: {
+    inputAmount: number
+    outputAmount: number
+    isValid: boolean
+  }) => void
+  isDefault?: boolean
+  error?: boolean
+  errorMessage?: string
+  tokenPrice?: string | null
+  isTokenPriceLoading?: boolean
+  tokenPriceDecimalPlaces?: number
+  initialInputValue?: string
+  onInputValueChange?: (value: string) => void
+}
+
+export const SwapTab = ({
+  inputToken,
+  outputToken,
+  min,
+  max,
+  balance,
+  onTransactionDataChange,
+  isDefault = true,
+  error,
+  errorMessage,
+  tokenPrice,
+  isTokenPriceLoading,
+  tokenPriceDecimalPlaces = 2,
+  initialInputValue,
+  onInputValueChange
+}: SwapTabProps) => {
+  const {
+    inputAmount,
+    outputAmount,
+    isExchangeRateLoading,
+    isBalanceLoading,
+    availableBalance,
+    currentExchangeRate,
+    handleInputAmountChange,
+    handleMaxClick
+  } = useTokenSwapForm({
+    inputToken,
+    outputToken,
+    min,
+    max,
+    balance,
+    onTransactionDataChange,
+    initialInputValue,
+    onInputValueChange
+  })
+
+  // Track if an exchange rate has ever been successfully fetched
+  const hasRateEverBeenFetched = useRef(false)
+  if (currentExchangeRate !== null) {
+    hasRateEverBeenFetched.current = true
+  }
+
+  // Show initial loading state if balance is loading,
+  // OR if exchange rate is loading AND we've never fetched a rate before.
+  const isInitialLoading =
+    isBalanceLoading ||
+    (isExchangeRateLoading && !hasRateEverBeenFetched.current)
+
+  return (
+    <Flex direction='column'>
+      {isInitialLoading ? (
+        <SwapFormSkeleton />
+      ) : (
+        <>
+          <TokenAmountSection
+            title={messages.youPay}
+            tokenInfo={inputToken}
+            isInput={true}
+            amount={inputAmount}
+            onAmountChange={handleInputAmountChange}
+            onMaxClick={handleMaxClick}
+            availableBalance={availableBalance}
+            placeholder={messages.placeholder}
+            isDefault={isDefault}
+            error={error}
+            errorMessage={errorMessage}
+          />
+
+          <TokenAmountSection
+            title={messages.youReceive}
+            tokenInfo={outputToken}
+            isInput={false}
+            amount={outputAmount}
+            availableBalance={0}
+            exchangeRate={currentExchangeRate}
+            tokenPrice={tokenPrice}
+            isTokenPriceLoading={isTokenPriceLoading}
+            tokenPriceDecimalPlaces={tokenPriceDecimalPlaces}
+          />
+        </>
+      )}
+    </Flex>
+  )
+}

--- a/packages/mobile/src/screens/buy-sell-screen/components/hooks/index.ts
+++ b/packages/mobile/src/screens/buy-sell-screen/components/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useTokenSwapForm'
+export * from './swapFormSchema'

--- a/packages/mobile/src/screens/buy-sell-screen/components/hooks/swapFormSchema.ts
+++ b/packages/mobile/src/screens/buy-sell-screen/components/hooks/swapFormSchema.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+const messages = {
+  inputAmountRequired: 'Amount is required',
+  invalidAmount: 'Please enter a valid amount',
+  minAmount: (min: number, symbol: string) =>
+    `Minimum amount is ${min} ${symbol}`,
+  maxAmount: (max: number, symbol: string) =>
+    `Maximum amount is ${max} ${symbol}`,
+  insufficientBalance: (symbol: string) => `Insufficient ${symbol} balance`
+}
+
+/**
+ * Schema for validating token swap input
+ */
+export const createSwapFormSchema = (
+  min: number = 0,
+  max: number = Number.MAX_SAFE_INTEGER,
+  balance: number | undefined = undefined,
+  tokenSymbol: string = ''
+) =>
+  z.object({
+    inputAmount: z
+      .string()
+      .min(1, { message: messages.inputAmountRequired })
+      .refine((val) => !isNaN(parseFloat(val)), {
+        message: messages.invalidAmount
+      })
+      .refine((val) => parseFloat(val) >= min, {
+        message: messages.minAmount(min, tokenSymbol)
+      })
+      .refine((val) => parseFloat(val) <= max, {
+        message: messages.maxAmount(max, tokenSymbol)
+      })
+      .refine((val) => !balance || parseFloat(val) <= balance, {
+        message: messages.insufficientBalance(tokenSymbol)
+      }),
+    outputAmount: z.string().optional()
+  })
+
+export type SwapFormValues = {
+  inputAmount: string
+  outputAmount: string
+}

--- a/packages/mobile/src/screens/buy-sell-screen/components/hooks/useTokenSwapForm.ts
+++ b/packages/mobile/src/screens/buy-sell-screen/components/hooks/useTokenSwapForm.ts
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useMemo } from 'react'
+
+import { useTokenExchangeRate } from '@audius/common/api'
+import type { JupiterTokenSymbol, TokenInfo } from '@audius/common/store'
+import { useFormik } from 'formik'
+import { toFormikValidationSchema } from 'zod-formik-adapter'
+
+import { createSwapFormSchema, type SwapFormValues } from './swapFormSchema'
+
+export type BalanceConfig = {
+  get: () => number | undefined
+  loading: boolean
+  formatError: (amount: number) => string
+}
+
+export type TokenSwapFormProps = {
+  /**
+   * The token the user is paying with (input)
+   */
+  inputToken: TokenInfo
+  /**
+   * The token the user is receiving (output)
+   */
+  outputToken: TokenInfo
+  /**
+   * Minimum amount allowed for input (optional)
+   */
+  min?: number
+  /**
+   * Maximum amount allowed for input (optional)
+   */
+  max?: number
+  /**
+   * Configuration for handling the input token balance
+   */
+  balance: BalanceConfig
+  /**
+   * Callback for when transaction data changes
+   */
+  onTransactionDataChange?: (data: {
+    inputAmount: number
+    outputAmount: number
+    isValid: boolean
+  }) => void
+  /**
+   * Initial value for the input field
+   */
+  initialInputValue?: string
+  /**
+   * Callback for when input value changes (for persistence)
+   */
+  onInputValueChange?: (value: string) => void
+}
+
+/**
+ * A hook to manage the common functionality for token swaps
+ */
+export const useTokenSwapForm = ({
+  inputToken,
+  outputToken,
+  min = 0,
+  max = Number.MAX_SAFE_INTEGER,
+  balance,
+  onTransactionDataChange,
+  initialInputValue = '',
+  onInputValueChange
+}: TokenSwapFormProps) => {
+  // Get token symbols for the exchange rate API
+  const inputTokenSymbol = inputToken.symbol as JupiterTokenSymbol
+  const outputTokenSymbol = outputToken.symbol as JupiterTokenSymbol
+
+  const { get: getInputBalance, loading: isBalanceLoading } = balance
+
+  const availableBalance = useMemo(() => {
+    const balance = getInputBalance()
+    return balance !== undefined ? balance : (inputToken.balance ?? 0)
+  }, [getInputBalance, inputToken.balance])
+
+  // Create validation schema
+  const validationSchema = useMemo(() => {
+    return toFormikValidationSchema(
+      createSwapFormSchema(min, max, availableBalance, inputToken.symbol)
+    )
+  }, [min, max, availableBalance, inputToken.symbol])
+
+  // Initialize form with Formik
+  const formik = useFormik<SwapFormValues>({
+    initialValues: {
+      inputAmount: initialInputValue,
+      outputAmount: '0'
+    },
+    validationSchema,
+    validateOnBlur: true,
+    validateOnChange: true,
+    onSubmit: () => {
+      // The form is never actually submitted - we just use Formik for validation
+      // and state management
+    }
+  })
+
+  const { values, errors, touched, setFieldValue, setFieldTouched } = formik
+
+  // Update form value when initialInputValue changes (tab switch)
+  useEffect(() => {
+    if (initialInputValue !== values.inputAmount) {
+      setFieldValue('inputAmount', initialInputValue, false)
+    }
+  }, [initialInputValue, values.inputAmount, setFieldValue])
+
+  // Calculate the numeric value of the input amount
+  const numericInputAmount = useMemo(() => {
+    if (!values.inputAmount) return 0
+    const parsed = parseFloat(values.inputAmount)
+    return isNaN(parsed) ? 0 : parsed
+  }, [values.inputAmount])
+
+  const {
+    data: exchangeRateData,
+    isLoading: isExchangeRateLoading,
+    error: exchangeRateError
+  } = useTokenExchangeRate({
+    inputTokenSymbol,
+    outputTokenSymbol,
+    inputAmount: numericInputAmount > 0 ? numericInputAmount : 1
+  })
+
+  // Update output amount when exchange rate or input amount changes
+  useEffect(() => {
+    if (numericInputAmount <= 0) {
+      setFieldValue('outputAmount', '0', false)
+      return
+    }
+
+    if (!isExchangeRateLoading && exchangeRateData) {
+      const newAmount = exchangeRateData.rate * numericInputAmount
+      setFieldValue('outputAmount', newAmount.toString(), false)
+    }
+  }, [
+    numericInputAmount,
+    exchangeRateData,
+    isExchangeRateLoading,
+    setFieldValue
+  ])
+
+  const numericOutputAmount = useMemo(() => {
+    if (!values.outputAmount) return 0
+    const parsed = parseFloat(values.outputAmount)
+    return isNaN(parsed) ? 0 : parsed
+  }, [values.outputAmount])
+
+  useEffect(() => {
+    if (onTransactionDataChange) {
+      const isValid = numericInputAmount > 0 && !errors.inputAmount
+
+      onTransactionDataChange({
+        inputAmount: numericInputAmount,
+        outputAmount: numericOutputAmount,
+        isValid
+      })
+    }
+  }, [
+    numericInputAmount,
+    numericOutputAmount,
+    errors.inputAmount,
+    isExchangeRateLoading,
+    onTransactionDataChange
+  ])
+
+  // Handle input changes
+  const handleInputAmountChange = useCallback(
+    (value: string) => {
+      // Allow only valid number input with better decimal handling
+      if (value === '' || /^(\d*\.?\d*|\d+\.)$/.test(value)) {
+        setFieldValue('inputAmount', value, true)
+        setFieldTouched('inputAmount', true, false)
+        // Call the persistence callback
+        onInputValueChange?.(value)
+      }
+    },
+    [setFieldValue, setFieldTouched, onInputValueChange]
+  )
+
+  // Handle max button click
+  const handleMaxClick = useCallback(() => {
+    const balance = getInputBalance()
+    if (balance !== undefined) {
+      const finalAmount = Math.min(balance, max)
+      const finalAmountString = finalAmount.toString()
+      setFieldValue('inputAmount', finalAmountString, true)
+      setFieldTouched('inputAmount', true, false)
+      // Call the persistence callback
+      onInputValueChange?.(finalAmountString)
+    }
+  }, [getInputBalance, max, setFieldValue, setFieldTouched, onInputValueChange])
+
+  const currentExchangeRate = exchangeRateData ? exchangeRateData.rate : null
+
+  const error =
+    touched.inputAmount && errors.inputAmount ? errors.inputAmount : null
+
+  return {
+    inputAmount: values.inputAmount, // Raw string input for display
+    numericInputAmount,
+    outputAmount: values.outputAmount,
+    numericOutputAmount,
+    error,
+    exchangeRateError,
+    isExchangeRateLoading,
+    isBalanceLoading,
+    availableBalance,
+    currentExchangeRate,
+    handleInputAmountChange,
+    handleMaxClick,
+    formik,
+    inputToken,
+    outputToken
+  }
+}

--- a/packages/mobile/src/screens/buy-sell-screen/components/index.ts
+++ b/packages/mobile/src/screens/buy-sell-screen/components/index.ts
@@ -1,0 +1,3 @@
+export { SwapTab } from './SwapTab'
+export { BuyScreen } from './BuyScreen'
+export { SellScreen } from './SellScreen'

--- a/packages/mobile/src/screens/buy-sell-screen/components/types.ts
+++ b/packages/mobile/src/screens/buy-sell-screen/components/types.ts
@@ -1,0 +1,14 @@
+// Screen-specific types for buy-sell screens
+// TODO: Add types as needed during implementation
+
+export type SwapScreenProps = {
+  // TODO: Define props in Phase 2
+}
+
+export type BuyScreenProps = {
+  // TODO: Define props in Phase 4
+}
+
+export type SellScreenProps = {
+  // TODO: Define props in Phase 4
+}

--- a/packages/mobile/src/screens/buy-sell-screen/index.ts
+++ b/packages/mobile/src/screens/buy-sell-screen/index.ts
@@ -1,0 +1,4 @@
+export { BuySellScreen } from './BuySellScreen'
+export { BuySellFlow } from './BuySellFlow'
+export { ConfirmSwapScreen } from './ConfirmSwapScreen'
+export { TransactionResultScreen } from './TransactionResultScreen'

--- a/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback } from 'react'
 
 import {
   useFormattedUSDCBalance,
@@ -7,32 +7,23 @@ import {
 import { walletMessages } from '@audius/common/messages'
 import { Name } from '@audius/common/models'
 import { useAddCashModal } from '@audius/common/store'
-import { BottomSheetBackdrop, BottomSheetModal } from '@gorhom/bottom-sheet'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import {
   Box,
   Button,
   Flex,
-  IconButton,
-  IconInfo,
   IconLogoCircleUSDC,
   Paper,
   Skeleton,
-  Text,
-  useTheme
+  Text
 } from '@audius/harmony-native'
+import { TooltipInfoIcon } from 'app/components/buy-sell/TooltipInfoIcon'
 import { make, track } from 'app/services/analytics'
 
 export const CashWallet = () => {
   const isManagedAccount = useIsManagedAccount()
   const { onOpen: openAddCashModal } = useAddCashModal()
   const { balanceFormatted, isLoading } = useFormattedUSDCBalance()
-  const insets = useSafeAreaInsets()
-  const { color } = useTheme()
-
-  // Create a ref for the bottom sheet modal
-  const bottomSheetModalRef = useRef<BottomSheetModal>(null)
 
   const handleAddCash = useCallback(() => {
     openAddCashModal()
@@ -43,74 +34,39 @@ export const CashWallet = () => {
     )
   }, [openAddCashModal])
 
-  // Function to handle opening the bottom sheet
-  const handleOpenInfoModal = useCallback(() => {
-    bottomSheetModalRef.current?.present()
-  }, [])
-
   return (
-    <>
-      <Paper>
-        <Flex p='l' gap='s' direction='column'>
-          <Flex gap='xs' direction='row' alignItems='center'>
-            <Box mr='s'>
-              <IconLogoCircleUSDC size='l' />
-            </Box>
-            <Text variant='heading' size='s' color='subdued'>
-              {walletMessages.cashBalance}
-            </Text>
-            <IconButton
-              icon={IconInfo}
-              size='s'
-              color='subdued'
-              aria-label='Cash balance information'
-              onPress={handleOpenInfoModal}
-            />
-          </Flex>
-
-          <Flex h='4xl' justifyContent='center'>
-            {isLoading ? (
-              <Skeleton h='4xl' w='5xl' />
-            ) : (
-              <Text variant='display' size='m' color='default'>
-                {balanceFormatted}
-              </Text>
-            )}
-          </Flex>
-
-          {!isManagedAccount ? (
-            <Button variant='secondary' onPress={handleAddCash} fullWidth>
-              {walletMessages.addCash}
-            </Button>
-          ) : null}
-        </Flex>
-      </Paper>
-
-      <BottomSheetModal
-        ref={bottomSheetModalRef}
-        snapPoints={['25%']}
-        topInset={insets.top}
-        backgroundStyle={{ backgroundColor: color.background.white }}
-        backdropComponent={(props) => (
-          <BottomSheetBackdrop
-            {...props}
-            appearsOnIndex={0}
-            disappearsOnIndex={-1}
-            pressBehavior='close'
-          />
-        )}
-      >
-        <Flex p='l'>
-          <Text variant='title' size='m'>
+    <Paper>
+      <Flex p='l' gap='s' direction='column'>
+        <Flex gap='xs' direction='row' alignItems='center'>
+          <Box mr='s'>
+            <IconLogoCircleUSDC size='l' />
+          </Box>
+          <Text variant='heading' size='s' color='subdued'>
             {walletMessages.cashBalance}
           </Text>
-          <Box mt='m'>
-            <Text variant='body' size='m'>
-              {walletMessages.cashBalanceTooltip}
-            </Text>
-          </Box>
+          <TooltipInfoIcon
+            size='s'
+            color='subdued'
+            ariaLabel='Cash balance information'
+          />
         </Flex>
-      </BottomSheetModal>
-    </>
+
+        <Flex h='4xl' justifyContent='center'>
+          {isLoading ? (
+            <Skeleton h='4xl' w='5xl' />
+          ) : (
+            <Text variant='display' size='m' color='default'>
+              {balanceFormatted}
+            </Text>
+          )}
+        </Flex>
+
+        {!isManagedAccount ? (
+          <Button variant='secondary' onPress={handleAddCash} fullWidth>
+            {walletMessages.addCash}
+          </Button>
+        ) : null}
+      </Flex>
+    </Paper>
   )
 }

--- a/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react'
 import { useFeatureFlag, useFormattedAudioBalance } from '@audius/common/hooks'
 import { buySellMessages as messages } from '@audius/common/messages'
 import { FeatureFlags } from '@audius/common/services'
-import { useBuySellModal } from '@audius/common/store'
 
 import {
   Button,
@@ -18,11 +17,11 @@ import {
 import { useNavigation } from 'app/hooks/useNavigation'
 
 const TokensHeader = () => {
-  const { onOpen: openBuySellModal } = useBuySellModal()
+  const navigation = useNavigation()
 
   const handleBuySellClick = useCallback(() => {
-    openBuySellModal()
-  }, [openBuySellModal])
+    navigation.navigate('BuySellScreen', { initialTab: 'buy' })
+  }, [navigation])
 
   return (
     <Flex

--- a/packages/mobile/src/types/navigation.ts
+++ b/packages/mobile/src/types/navigation.ts
@@ -1,11 +1,13 @@
+import type { TokenInfo, SuccessDisplayData } from '@audius/common/store'
+
 export type BuySellScreenParams = {
   initialTab?: 'buy' | 'sell'
 }
 
 export type ConfirmSwapScreenParams = {
-  swapData: {
-    payTokenInfo: any // TokenInfo from common
-    receiveTokenInfo: any // TokenInfo from common
+  confirmationData: {
+    payTokenInfo: TokenInfo
+    receiveTokenInfo: TokenInfo
     payAmount: number
     receiveAmount: number
     pricePerBaseToken: number
@@ -16,21 +18,9 @@ export type ConfirmSwapScreenParams = {
 export type TransactionResultScreenParams = {
   result: {
     status: 'success' | 'error'
-    signature?: string
-    error?: {
-      type: string
-      message: string
-    }
-    inputAmount?: {
-      amount: number
-      uiAmount: number
-    }
-    outputAmount?: {
-      amount: number
-      uiAmount: number
-    }
+    data?: SuccessDisplayData
+    error?: { message?: string }
   }
-  type: 'swap' | 'buy' | 'sell'
 }
 
 // This will be extended with the main app navigation types when integrated

--- a/packages/mobile/src/types/navigation.ts
+++ b/packages/mobile/src/types/navigation.ts
@@ -1,0 +1,41 @@
+export type BuySellScreenParams = {
+  initialTab?: 'buy' | 'sell'
+}
+
+export type ConfirmSwapScreenParams = {
+  swapData: {
+    payTokenInfo: any // TokenInfo from common
+    receiveTokenInfo: any // TokenInfo from common
+    payAmount: number
+    receiveAmount: number
+    pricePerBaseToken: number
+    baseTokenSymbol: string
+  }
+}
+
+export type TransactionResultScreenParams = {
+  result: {
+    status: 'success' | 'error'
+    signature?: string
+    error?: {
+      type: string
+      message: string
+    }
+    inputAmount?: {
+      amount: number
+      uiAmount: number
+    }
+    outputAmount?: {
+      amount: number
+      uiAmount: number
+    }
+  }
+  type: 'swap' | 'buy' | 'sell'
+}
+
+// This will be extended with the main app navigation types when integrated
+export type BuySellStackParamList = {
+  BuySellScreen: BuySellScreenParams
+  ConfirmSwapScreen: ConfirmSwapScreenParams
+  TransactionResultScreen: TransactionResultScreenParams
+}

--- a/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { formatTokenPrice } from '@audius/common/api'
+import { buySellMessages as messages } from '@audius/common/messages'
 import { TokenAmountSectionProps, TokenInfo } from '@audius/common/store'
 import { Button, Divider, Flex, Text, TextInput } from '@audius/harmony'
 import { useTheme } from '@emotion/react'
@@ -8,19 +8,6 @@ import { TooltipPlacement } from 'antd/lib/tooltip'
 
 import { TooltipInfoIcon } from './TooltipInfoIcon'
 import { useTokenAmountFormatting } from './hooks'
-
-const messages = {
-  available: 'Available',
-  max: 'MAX',
-  amountInputLabel: (symbol: string) => `Amount (${symbol})`,
-  tokenPrice: (price: string, decimalPlaces: number) => {
-    return formatTokenPrice(price, decimalPlaces)
-  },
-  stackedBalance: (formattedAvailableBalance: string) =>
-    `${formattedAvailableBalance}  Available`,
-  tokenTicker: (symbol: string, isStablecoin: boolean) =>
-    isStablecoin ? symbol : `$${symbol}`
-}
 
 type BalanceSectionProps = {
   isStablecoin?: boolean


### PR DESCRIPTION
### Description

This PR implements the core mobile swap functionality for the Audius mobile app, adapting the existing Jupiter swap infrastructure from the web client for mobile UX patterns. This is the first phase of bringing buy/sell/swap capabilities to mobile users.

## Changes Summary

###  Core Features Added

- **Mobile Swap Components**: Complete mobile adaptation of web swap components
- **Token Amount Input**: Mobile-optimized token input with balance display and validation
- **Swap Balance Display**: Transaction confirmation and result display components
- **Navigation Integration**: Added swap screens to mobile navigation stack
- **Enhanced Messages**: Extended buy/sell messages with mobile-specific formatting

###  Navigation Updates

#### `packages/mobile/src/screens/app-screen/AppTabScreen.tsx`

- Added new screen routes for swap functionality:
  - `BuySellScreen` - Main swap interface
  - `ConfirmSwapScreen` - Transaction confirmation
  - `TransactionResultScreen` - Success/error feedback
- Moved `ChangeEmailModalScreen` to proper navigation group

### How Has This Been Tested?

`npm run ios:prod`

Navigate to Wallet page and perform a swap 
