### PR TITLE
Update tipping flow balance loading state

### DIFF
--- a/packages/mobile/src/screens/tip-artist-screen/AvailableAudio.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/AvailableAudio.tsx
@@ -1,15 +1,16 @@
-import type { BNWei } from '@audius/common/models'
-import { walletSelectors } from '@audius/common/store'
-import { isNullOrUndefined, formatWei } from '@audius/common/utils'
+import { useAudioBalance } from '@audius/common/api'
+import type { BNWei, StringWei } from '@audius/common/models'
+import {
+  isNullOrUndefined,
+  formatWei,
+  stringWeiToBN
+} from '@audius/common/utils'
 import { Image, Platform, View } from 'react-native'
-import { useSelector } from 'react-redux'
 
 import TokenBadgeNoTier from 'app/assets/images/tokenBadgeNoTier.png'
 import { Text } from 'app/components/core'
 import Skeleton from 'app/components/skeleton'
 import { makeStyles } from 'app/styles'
-
-const { getAccountBalance } = walletSelectors
 
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   root: {
@@ -42,7 +43,17 @@ const messages = {
 }
 
 export const AvailableAudio = () => {
-  const accountBalance = useSelector(getAccountBalance)
+  // Use the new useAudioBalance hook, excluding connected wallets since they can't be used for tipping
+  const { accountBalance: audioBalanceBigInt, isLoading: isBalanceLoading } =
+    useAudioBalance({
+      includeConnectedWallets: false
+    })
+
+  // Convert BigInt to BN for compatibility with existing code
+  const accountBalance = audioBalanceBigInt
+    ? stringWeiToBN(audioBalanceBigInt.toString() as StringWei)
+    : null
+
   const styles = useStyles()
 
   return (
@@ -52,7 +63,7 @@ export const AvailableAudio = () => {
           {messages.available}
         </Text>
         <Image style={styles.audioToken} source={TokenBadgeNoTier} />
-        {isNullOrUndefined(accountBalance) ? (
+        {isBalanceLoading || isNullOrUndefined(accountBalance) ? (
           <Skeleton width={24} height={13} />
         ) : (
           <Text variant='body' style={styles.text}>

--- a/packages/mobile/src/screens/tip-artist-screen/AvailableAudio.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/AvailableAudio.tsx
@@ -43,7 +43,6 @@ const messages = {
 }
 
 export const AvailableAudio = () => {
-  // Use the new useAudioBalance hook, excluding connected wallets since they can't be used for tipping
   const { accountBalance: audioBalanceBigInt, isLoading: isBalanceLoading } =
     useAudioBalance({
       includeConnectedWallets: false

--- a/packages/mobile/src/screens/tip-artist-screen/SendTipScreen.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/SendTipScreen.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useState } from 'react'
 
+import { useAudioBalance } from '@audius/common/api'
 import type { StringWei } from '@audius/common/models'
 import {
   tippingSelectors,
   tippingActions,
-  walletSelectors,
   walletActions
 } from '@audius/common/store'
 import { parseAudioInputToWei, stringWeiToBN } from '@audius/common/utils'
@@ -28,7 +28,6 @@ import { TipScreen } from './TipScreen'
 import type { TipArtistNavigationParamList } from './navigation'
 
 const { getBalance } = walletActions
-const { getAccountBalance } = walletSelectors
 const { sendTip } = tippingActions
 const { getSendUser } = tippingSelectors
 
@@ -50,7 +49,16 @@ const zeroWei = stringWeiToBN('0' as StringWei)
 export const SendTipScreen = () => {
   const styles = useStyles()
   const [tipAmount, setTipAmount] = useState('')
-  const accountBalance = useSelector(getAccountBalance) ?? zeroWei
+
+  const { accountBalance: audioBalanceBigInt } = useAudioBalance({
+    includeConnectedWallets: false
+  })
+
+  // Convert BigInt to BN for compatibility with existing code
+  const accountBalance = audioBalanceBigInt
+    ? stringWeiToBN(audioBalanceBigInt.toString() as StringWei)
+    : zeroWei
+
   const navigation = useNavigation<TipArtistNavigationParamList>()
   const dispatch = useDispatch()
 


### PR DESCRIPTION
### Description
Use the new audio balance hook that has a loading state, to show balance skeleton and disable the tip button

### How Has This Been Tested?
Confirmed e2e tip flow worked on both mobile and web stage

<img width="500" alt="Screenshot 2025-06-04 at 4 19 50 PM" src="https://github.com/user-attachments/assets/697059c7-101a-4ca5-a4ea-4efd3cfa03f3" />

![Simulator Screenshot - iPhone 16 Pro - 2025-06-04 at 16 22 38](https://github.com/user-attachments/assets/1ed0cb16-030d-40aa-97ea-567b1f9b9093)
