### PR TITLE
Pass session to extend_track when getting trending playlists

### DIFF
--- a/packages/discovery-provider/src/queries/get_trending_playlists.py
+++ b/packages/discovery-provider/src/queries/get_trending_playlists.py
@@ -189,7 +189,8 @@ def _get_trending_playlists_with_session(
         # Re-associate tracks with playlists
         # track_id -> populated_track
         populated_track_map = {
-            track["track_id"]: extend_track(track) for track in populated_tracks
+            track["track_id"]: extend_track(track, session)
+            for track in populated_tracks
         }
         for playlist in playlists_map.values():
             for i in range(len(playlist["tracks"])):


### PR DESCRIPTION
### Description
Noticed this is throwing error in production indexer. I think the tests somehow make the app context available so this got missed.

### How Has This Been Tested?
Unfortunately had to live patch a prod node to make sure it worked :-(
