### PR TITLE
Fix account wallet 404 crashing saga

### DIFF
--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -592,7 +592,9 @@ function* signUp() {
                 [queryClient, queryClient.fetchQuery],
                 {
                   queryKey: getWalletAccountQueryKey(wallet),
-                  queryFn: async () => getWalletAccountQueryFn(wallet!, sdk)
+                  queryFn: async () => getWalletAccountQueryFn(wallet!, sdk),
+                  staleTime: Infinity,
+                  gcTime: Infinity
                 }
               )) as AccountUserMetadata | undefined
               // TODO: Do I need to prime the accountUser slice here?
@@ -902,7 +904,9 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
     const account = (yield* call([queryClient, queryClient.fetchQuery], {
       queryKey: getWalletAccountQueryKey(signInResponse.walletAddress),
       queryFn: async () =>
-        getWalletAccountQueryFn(signInResponse.walletAddress, sdk)
+        getWalletAccountQueryFn(signInResponse.walletAddress, sdk),
+      staleTime: Infinity,
+      gcTime: Infinity
     })) as AccountUserMetadata | undefined
 
     // Login succeeded but we found no account for the user (incomplete signup)


### PR DESCRIPTION
### Description

Fixes the issue AJ encountered where he had a hedgehog-entropy-key set in localstorage that caused this queryFn to 404. This caused the saga to crash. Since no account data got set the whole app just doesnt load.

Additionally I noticed that it didn't have the staleTime/gcTime set to infinity so I updated that as well. Not really relevant since these are app load & sign on sagas but still good out of principle to do.

### How Has This Been Tested?

web:stage/prod - repro'd by setting hedgehog-entropy-key (using AJ's sample)