### PR TITLE
Fix remixes header on mobile track remixes page

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -1,7 +1,6 @@
 import {
   useCurrentUserId,
   useRemixContest,
-  useRemixersCount,
   useRemixes,
   useRemixesLineup,
   useTrackByParams
@@ -71,8 +70,7 @@ export const TrackRemixesScreen = () => {
     FeatureFlags.REMIX_CONTEST_WINNERS_MILESTONE
   )
   const trackId = track?.track_id
-  const { data: count } = useRemixersCount({ trackId })
-  const { data, isFetching, isPending, loadNextPage, lineup, pageSize } =
+  const { data, count, isFetching, isPending, loadNextPage, lineup, pageSize } =
     useRemixesLineup({
       trackId: track?.track_id,
       includeOriginal: true,


### PR DESCRIPTION
### Description
Removed the usage of the remixes count hook in favor of grabbing the count from the lineup hook

### How Has This Been Tested?
Manually Tested