### PR TITLE
[PE-6341] Fix remix contest track page displaying empty track lineup section

### DIFF
--- a/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
+++ b/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
@@ -60,7 +60,12 @@ export const TrackPageLineup = ({
       ? LineupVariant.SECTION
       : LineupVariant.CONDENSED
 
-  if (!indices) return null
+  const willRenderNothing =
+    isRemixContest &&
+    indices?.moreBySection.index === undefined &&
+    indices?.recommendedSection.index === undefined
+
+  if (!indices || willRenderNothing) return null
 
   const renderRemixParentSection = () => {
     if (indices.remixParentSection.index === undefined || !trackId) return null


### PR DESCRIPTION
### Description
There was a case for remix contests where nothing would display in the track lineup section so rendered null in that case

### How Has This Been Tested?
Manually Tested
