### PR TITLE
Fix remix contest section initial tab

### DIFF
--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -96,7 +96,7 @@ export const RemixContestSection = ({
     isRemixContestWinnersMilestoneEnabled &&
     (remixContest?.eventData?.winners?.length ?? 0) > 0
 
-  const [index, setIndex] = useState(hasWinners ? 2 : 0)
+  const [index, setIndex] = useState(hasWinners ? (hasPrizeInfo ? 2 : 1) : 0)
   const [routes, setRoutes] = useState<Route[]>([])
   const [heights, setHeights] = useState({})
   const [firstRender, setFirstRender] = useState(true)


### PR DESCRIPTION
### Description

Some remix sections failed to render due to index error on tabs when user has selected winners but has no prize section