### PR TITLE
Add remix contest card + minor fixes to mobile explore

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -179,7 +179,7 @@ export const FilterButton = forwardRef(function FilterButton<
             {...props}
           />
         )) as IconComponent)
-      : (iconRight ?? (hasOptions ? IconCaretDown : null))
+      : iconRight ?? (hasOptions ? IconCaretDown : null)
   }, [variant, value, iconRight, hasOptions, onClick, onChange, onReset])
 
   useEffect(() => {

--- a/packages/mobile/src/components/remix-carousel/RemixCarousel.tsx
+++ b/packages/mobile/src/components/remix-carousel/RemixCarousel.tsx
@@ -1,25 +1,8 @@
-import { useRemixContest, useTracks } from '@audius/common/api'
-import {
-  SquareSizes,
-  type ID,
-  type Track,
-  type TrackMetadata
-} from '@audius/common/models'
-import { formatCount } from '@audius/common/utils'
+import { useTracks } from '@audius/common/api'
+import { type ID, type Track } from '@audius/common/models'
 
-import {
-  Divider,
-  Flex,
-  IconHeart,
-  IconRepost,
-  Paper,
-  Text
-} from '@audius/harmony-native'
 import type { CardListProps } from 'app/components/core'
 import { CardList } from 'app/components/core'
-
-import { TrackImage } from '../image/TrackImage'
-import { UserLink } from '../user-link'
 
 import { RemixContestCard } from './RemixContestCard'
 
@@ -31,10 +14,8 @@ export type UserListProps = {
 } & Partial<ListProps>
 
 export const RemixCarousel = (props: UserListProps) => {
-  const { trackIds, onCardPress, ...other } = props
-  //   const { data: remixContest, isPending: isRemixContestPending } =
-  //     useRemixContest(id)
-  const { data: tracks, isPending: isTrackPending } = useTracks(trackIds)
+  const { trackIds, ...other } = props
+  const { data: tracks } = useTracks(trackIds)
   return (
     <CardList
       data={tracks}

--- a/packages/mobile/src/components/remix-carousel/RemixCarousel.tsx
+++ b/packages/mobile/src/components/remix-carousel/RemixCarousel.tsx
@@ -1,0 +1,47 @@
+import { useRemixContest, useTracks } from '@audius/common/api'
+import {
+  SquareSizes,
+  type ID,
+  type Track,
+  type TrackMetadata
+} from '@audius/common/models'
+import { formatCount } from '@audius/common/utils'
+
+import {
+  Divider,
+  Flex,
+  IconHeart,
+  IconRepost,
+  Paper,
+  Text
+} from '@audius/harmony-native'
+import type { CardListProps } from 'app/components/core'
+import { CardList } from 'app/components/core'
+
+import { TrackImage } from '../image/TrackImage'
+import { UserLink } from '../user-link'
+
+import { RemixContestCard } from './RemixContestCard'
+
+type ListProps = Omit<CardListProps<Track>, 'data'>
+
+export type UserListProps = {
+  trackIds: ID[] | undefined
+  onCardPress?: (user_id: ID) => void
+} & Partial<ListProps>
+
+export const RemixCarousel = (props: UserListProps) => {
+  const { trackIds, onCardPress, ...other } = props
+  //   const { data: remixContest, isPending: isRemixContestPending } =
+  //     useRemixContest(id)
+  const { data: tracks, isPending: isTrackPending } = useTracks(trackIds)
+  return (
+    <CardList
+      data={tracks}
+      renderItem={({ item }) => {
+        return <RemixContestCard track={item} />
+      }}
+      {...other}
+    />
+  )
+}

--- a/packages/mobile/src/components/remix-carousel/RemixContestCard.tsx
+++ b/packages/mobile/src/components/remix-carousel/RemixContestCard.tsx
@@ -1,0 +1,80 @@
+import { useCallback } from 'react'
+
+import { useRemixContest } from '@audius/common/api'
+import { SquareSizes } from '@audius/common/models'
+import type { TrackMetadata } from '@audius/common/models'
+import { formatDate } from '@audius/common/utils'
+import { useNavigation } from '@react-navigation/native'
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
+
+import {
+  Divider,
+  Flex,
+  Paper,
+  Text,
+  type PaperProps
+} from '@audius/harmony-native'
+import type { AppTabScreenParamList } from 'app/screens/app-screen'
+
+import { TrackImage } from '../image/TrackImage'
+import { UserLink } from '../user-link'
+
+const messages = {
+  deadline: (releaseDate?: string) =>
+    releaseDate
+      ? new Date(releaseDate) > new Date()
+        ? `Deadline: ${formatDate(releaseDate)}`
+        : 'Ended'
+      : releaseDate
+}
+
+type RemixContestCardProps = PaperProps & {
+  track: TrackMetadata
+  noNavigation?: boolean
+}
+
+type NavigationProp = NativeStackNavigationProp<AppTabScreenParamList>
+
+export const RemixContestCard = (props: RemixContestCardProps) => {
+  const { track } = props
+  const { data: remixContest } = useRemixContest(track?.track_id)
+  const navigation = useNavigation<NavigationProp>()
+  const handlePress = useCallback(() => {
+    navigation.navigate('Track', { trackId: track?.track_id })
+  }, [navigation, track?.track_id])
+
+  return (
+    <Paper onPress={handlePress}>
+      <Flex p='s' gap='s'>
+        <TrackImage
+          trackId={track?.track_id}
+          // style={styles.artwork}
+          size={SquareSizes.SIZE_480_BY_480}
+        />
+        <Text variant='title' textAlign='center' numberOfLines={1}>
+          {track?.title}
+        </Text>
+
+        <UserLink
+          userId={track?.owner_id}
+          textAlign='center'
+          style={{ justifyContent: 'center' }}
+        />
+      </Flex>
+      <Divider orientation='horizontal' />
+      <Flex
+        direction='row'
+        gap='l'
+        pv='s'
+        justifyContent='center'
+        backgroundColor='surface1'
+        borderBottomLeftRadius='m'
+        borderBottomRightRadius='m'
+      >
+        <Text strength='strong' size='s' color='subdued'>
+          {messages.deadline(remixContest?.endDate)}
+        </Text>
+      </Flex>
+    </Paper>
+  )
+}

--- a/packages/mobile/src/components/remix-carousel/RemixContestCard.tsx
+++ b/packages/mobile/src/components/remix-carousel/RemixContestCard.tsx
@@ -48,7 +48,6 @@ export const RemixContestCard = (props: RemixContestCardProps) => {
       <Flex p='s' gap='s'>
         <TrackImage
           trackId={track?.track_id}
-          // style={styles.artwork}
           size={SquareSizes.SIZE_480_BY_480}
         />
         <Text variant='title' textAlign='center' numberOfLines={1}>

--- a/packages/mobile/src/components/remix-carousel/index.ts
+++ b/packages/mobile/src/components/remix-carousel/index.ts
@@ -1,0 +1,1 @@
+export * from './RemixContestCard'

--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/useNavConfig.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/useNavConfig.tsx
@@ -106,13 +106,13 @@ export const useNavConfig = () => {
       }
     ]
 
-    if (env.ENVIRONMENT === 'staging' || isFeatureFlagAccessEnabled) {
-      items.push({
-        icon: IconEmbed,
-        label: messages.featureFlags,
-        to: 'FeatureFlagOverride' as const
-      })
-    }
+    // if (env.ENVIRONMENT === 'staging' || isFeatureFlagAccessEnabled) {
+    items.push({
+      icon: IconEmbed,
+      label: messages.featureFlags,
+      to: 'FeatureFlagOverride' as const
+    })
+    // }
 
     return items
   }, [

--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/useNavConfig.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/useNavConfig.tsx
@@ -106,13 +106,13 @@ export const useNavConfig = () => {
       }
     ]
 
-    // if (env.ENVIRONMENT === 'staging' || isFeatureFlagAccessEnabled) {
-    items.push({
-      icon: IconEmbed,
-      label: messages.featureFlags,
-      to: 'FeatureFlagOverride' as const
-    })
-    // }
+    if (env.ENVIRONMENT === 'staging' || isFeatureFlagAccessEnabled) {
+      items.push({
+        icon: IconEmbed,
+        label: messages.featureFlags,
+        to: 'FeatureFlagOverride' as const
+      })
+    }
 
     return items
   }, [

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useMemo, useState } from 'react'
-import { formatCount } from '@audius/common/utils'
 
 import type {
   SearchCategory,
@@ -13,7 +12,6 @@ import {
   searchSelectors
 } from '@audius/common/store'
 import type { Mood } from '@audius/sdk'
-import { filter } from 'lodash'
 import { MOODS } from 'pages/search-page/moods'
 import type { MoodInfo } from 'pages/search-page/types'
 import { ImageBackground, ScrollView, Image, View } from 'react-native'
@@ -119,7 +117,6 @@ export const SearchExploreScreen = () => {
   const hasAnyFilter = Object.values(filters).some(
     (value) => value !== undefined
   )
-  console.log('asdf hasAnyFilter', hasAnyFilter)
   const history = useSelector(getSearchHistory)
   const categoryKind: Kind | null = category
     ? itemKindByCategory[category]
@@ -208,7 +205,7 @@ export const SearchExploreScreen = () => {
               </Flex>
             </ImageBackground>
           </Flex>
-          {/* <SearchCategoriesAndFilters /> */}
+          <SearchCategoriesAndFilters />
 
           <ScrollView>
             {category !== 'all' || searchInput ? (
@@ -266,6 +263,7 @@ export const SearchExploreScreen = () => {
                     carouselSpacing={spacing.l}
                   />
                 </Flex>
+
                 <Flex justifyContent='center' gap='l'>
                   <Text variant='title' size='l' textAlign='center'>
                     {messages.exploreByMood}

--- a/packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx
@@ -108,6 +108,7 @@ export const SearchCategoriesAndFilters = () => {
         horizontal
         keyboardShouldPersistTaps='handled'
         ref={scrollViewRef}
+        showsHorizontalScrollIndicator={false}
       >
         <Flex direction='row' alignItems='center' gap='s' p='l'>
           <SearchCategory category='users' />


### PR DESCRIPTION
### Description
* Add remix contest carousel
* Fix mood tag filtering 
* Remove horizontal scroll bar on filters
* Add clear button on search input
* Adjust  user avatar placement and size
* Autofocus on header search icon

Fixes PE-6344
Fixes PE-6342
Fixes PE-6349
Fixes PE-6347
Fixes PE-6343
Fixes PE-6330
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran against stage + prod on ios sim. 