### PR TITLE
[PE-6379] Fix refetching collection by permalink

### DIFF
--- a/packages/common/src/api/tan-query/collection/useCollectionByPermalink.ts
+++ b/packages/common/src/api/tan-query/collection/useCollectionByPermalink.ts
@@ -10,11 +10,10 @@ import { TQCollection } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, QueryOptions, SelectableQueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 import { primeCollectionData } from '../utils/primeCollectionData'
 
 import { useCollection } from './useCollection'
-
-const STALE_TIME = Infinity
 
 export const getCollectionByPermalinkQueryKey = (
   permalink: string | undefined | null
@@ -88,7 +87,8 @@ export const useCollectionByPermalink = <TResult = TQCollection>(
         sdk
       )
     },
-    staleTime: simpleOptions?.staleTime ?? STALE_TIME,
+    ...entityCacheOptions,
+    ...simpleOptions,
     enabled: simpleOptions?.enabled !== false && !!permalink
   })
 

--- a/packages/common/src/api/tan-query/saga-utils/queryCollection.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryCollection.ts
@@ -11,6 +11,7 @@ import {
 import { getCollectionByPermalinkQueryFn } from '../collection/useCollectionByPermalink'
 import { TQCollection } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 import { isValidId } from '../utils/isValidId'
 
 import { queryCurrentUserId } from './queryAccount'
@@ -64,7 +65,7 @@ export function* queryCollectionByPermalink(
         queryClient,
         sdk
       ),
-    staleTime: forceFetch ? 0 : undefined
+    staleTime: forceFetch ? 0 : entityCacheOptions.staleTime
   })) as ID | undefined
   if (!collectionId) return undefined
   const collection = yield* call(queryCollection, collectionId, forceFetch)

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -1,9 +1,9 @@
 import { ChangeEvent, Component, ComponentType } from 'react'
 
 import {
-  useCurrentAccount,
   useCollectionByParams,
-  useUser
+  useUser,
+  useCurrentUserId
 } from '@audius/common/api'
 import { useCurrentTrack } from '@audius/common/hooks'
 import {
@@ -160,17 +160,9 @@ const CollectionPage = (props: CollectionPageProps) => {
   const pathname = getPathname(location)
   const params = parseCollectionRoute(pathname)
   // For now read-only
-  const { data: collection } = useCollectionByParams(params, { enabled: false })
-  const { data: accountData } = useCurrentAccount({
-    select: (account) => ({
-      userId: account?.userId,
-      userPlaylists: Object.values(account?.collections ?? {})?.filter(
-        (c) => !c.is_album
-      )
-    })
-  })
-  const { userId, userPlaylists } = accountData ?? {}
-  const { data: user } = useUser(userId)
+  const { data: collection } = useCollectionByParams(params)
+  const { data: user } = useUser(collection?.playlist_owner_id)
+  const { data: currentUserId } = useCurrentUserId()
   const trackCount = collection?.playlist_contents.track_ids.length ?? 0
   const playlistId = collection?.playlist_id
   const currentTrack = useCurrentTrack()
@@ -186,9 +178,8 @@ const CollectionPage = (props: CollectionPageProps) => {
       tracks={tracks}
       trackCount={trackCount}
       currentTrack={currentTrack}
-      userId={userId}
+      userId={currentUserId}
       user={user}
-      userPlaylists={userPlaylists}
     />
   )
 }


### PR DESCRIPTION
### Description

- Fixes issue where navigating to collection fetches even if collection already exists
- Fixes issue where loading app on collection page fails to load page, due to "enabled" flag set to off. now that we have caching working correctly, we can re-enable
- Fixes issue where the user passed to collection page was the account user not the collection user