### PR TITLE
Standardize query-collection options, fix refresh

### DIFF
--- a/packages/common/src/api/tan-query/saga-utils/queryCollection.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryCollection.ts
@@ -16,9 +16,14 @@ import { isValidId } from '../utils/isValidId'
 
 import { queryCurrentUserId } from './queryAccount'
 
+type QueryOptions = {
+  force?: boolean
+  staleTime?: number
+}
+
 export function* queryCollection(
   id: ID | null | undefined,
-  forceFetch = false
+  queryOptions?: QueryOptions
 ) {
   if (!isValidId(id)) return undefined
   const queryClient = yield* getContext('queryClient')
@@ -30,17 +35,18 @@ export function* queryCollection(
     queryKey: getCollectionQueryKey(id),
     queryFn: async () =>
       getCollectionQueryFn(id!, currentUserId, queryClient, sdk, dispatch),
-    staleTime: forceFetch ? 0 : undefined
+    ...entityCacheOptions,
+    ...queryOptions
   })
 
   return queryData as TQCollection | undefined
 }
 
-export function* queryCollections(ids: ID[], forceFetch = false) {
+export function* queryCollections(ids: ID[], queryOptions?: QueryOptions) {
   const collections = {} as Record<ID, TQCollection>
   for (const id of ids) {
     // Call each queryCollection individually. They will be batched together in the queryFn (if necessary)
-    const collection = yield* call(queryCollection, id, forceFetch)
+    const collection = yield* call(queryCollection, id, queryOptions)
     if (collection) {
       collections[id] = collection
     }
@@ -50,7 +56,7 @@ export function* queryCollections(ids: ID[], forceFetch = false) {
 
 export function* queryCollectionByPermalink(
   permalink: string | null | undefined,
-  forceFetch = false
+  queryOptions?: QueryOptions
 ) {
   if (!permalink) return undefined
   const queryClient = yield* getContext('queryClient')
@@ -65,16 +71,17 @@ export function* queryCollectionByPermalink(
         queryClient,
         sdk
       ),
-    staleTime: forceFetch ? 0 : entityCacheOptions.staleTime
+    ...entityCacheOptions,
+    ...queryOptions
   })) as ID | undefined
   if (!collectionId) return undefined
-  const collection = yield* call(queryCollection, collectionId, forceFetch)
+  const collection = yield* call(queryCollection, collectionId, queryOptions)
   return collection
 }
 
 export function* queryCollectionsByPermalink(
   permalinks: string[],
-  forceFetch = false
+  queryOptions?: QueryOptions
 ) {
   const collections = {} as Record<string, TQCollection>
   for (const permalink of permalinks) {
@@ -82,7 +89,7 @@ export function* queryCollectionsByPermalink(
     const collection = yield* call(
       queryCollectionByPermalink,
       permalink,
-      forceFetch
+      queryOptions
     )
     if (collection) {
       collections[permalink] = collection

--- a/packages/common/src/api/tan-query/saga-utils/queryTrack.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryTrack.ts
@@ -76,12 +76,13 @@ export function* queryTrackByUid(uid: string | null | undefined) {
 }
 
 export function* queryCollectionTracks(
-  collectionId: ID | null | undefined
+  collectionId: ID | null | undefined,
+  queryOptions?: QueryOptions
 ): Generator<any, Track[], any> {
   if (!collectionId) return [] as Track[]
 
   // Get collection data
-  const collection = yield* call(queryCollection, collectionId)
+  const collection = yield* call(queryCollection, collectionId, queryOptions)
   if (!collection) return [] as Track[]
 
   // Extract track IDs from collection
@@ -90,5 +91,5 @@ export function* queryCollectionTracks(
   )
 
   // Query all tracks in parallel
-  return yield* call(queryTracks, trackIds)
+  return yield* call(queryTracks, trackIds, queryOptions)
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -109,10 +109,15 @@ export const ProfileScreen = () => {
     }
   }) as ProfilePageTabs
 
-  const fetchProfile = useCallback(() => {
-    if (!isScreenReady) return
-    dispatch(fetchProfileAction(handleLower, id ?? null, true, true, false))
-  }, [dispatch, handleLower, id, isScreenReady])
+  const fetchProfile = useCallback(
+    (forceFetch = false) => {
+      if (!isScreenReady) return
+      dispatch(
+        fetchProfileAction(handleLower, id ?? null, forceFetch, true, false)
+      )
+    },
+    [dispatch, handleLower, id, isScreenReady]
+  )
 
   useFocusEffect(setCurrentUser)
 
@@ -124,7 +129,7 @@ export const ProfileScreen = () => {
     // TODO: Investigate why this function over-fires when you pull to refresh
     if (profile) {
       setIsRefreshing(true)
-      fetchProfile()
+      fetchProfile(true)
       switch (currentTab) {
         case ProfilePageTabs.TRACKS:
           queryClient.resetQueries({

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -20,11 +20,17 @@ const { getIsReachable } = reachabilitySelectors
 function* watchFetchCollection() {
   yield takeLatest(collectionActions.FETCH_COLLECTION, function* (action) {
     const { id: collectionId, permalink, fetchLineup, forceFetch } = action
+    const queryOptions = forceFetch ? { force: true, staleTime: 0 } : undefined
+
     let collection
     if (permalink) {
-      collection = yield call(queryCollectionByPermalink, permalink, forceFetch)
+      collection = yield call(
+        queryCollectionByPermalink,
+        permalink,
+        queryOptions
+      )
     } else {
-      collection = yield call(queryCollection, collectionId, forceFetch)
+      collection = yield call(queryCollection, collectionId, queryOptions)
     }
 
     const isReachable = yield select(getIsReachable)

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -259,10 +259,18 @@ export function* fetchSolanaCollectibles(user) {
 function* fetchProfileAsync(action) {
   try {
     let user
+    const queryOptions = action.forceUpdate
+      ? { force: true, staleTime: 0 }
+      : undefined
+
     if (action.userId) {
-      user = yield call(queryUser, action.userId)
+      user = yield call(queryUser, action.userId, queryOptions)
     } else if (action.handle) {
-      user = yield call(queryUserByHandle, action.handle?.replace('/', ''))
+      user = yield call(
+        queryUserByHandle,
+        action.handle?.replace('/', ''),
+        queryOptions
+      )
     }
     if (!user) {
       const isReachable = yield select(getIsReachable)


### PR DESCRIPTION
### Description

Standardizes the query-entity functions to have query-options
Refactor queryCollection to use query-options instead of force-fetch
Update profile-screen to actually refetch user on refresh