### PR TITLE
[PE-6375] Add loading state for brief sign in state

### DIFF
--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -1,11 +1,13 @@
 import {
   selectIsAccountComplete,
   useCurrentAccount,
-  useCurrentAccountUser
+  useCurrentAccountUser,
+  useAccountStatus
 } from '@audius/common/api'
 import { useIsManagedAccount } from '@audius/common/hooks'
+import { Status } from '@audius/common/models'
 import { route } from '@audius/common/utils'
-import { Box, Flex, Text, useTheme } from '@audius/harmony'
+import { Box, Flex, Skeleton, Text, useTheme } from '@audius/harmony'
 
 import { Avatar } from 'components/avatar/Avatar'
 import { TextLink, UserLink } from 'components/link'
@@ -180,6 +182,18 @@ const GuestView = () => {
   )
 }
 
+const LoadingView = () => {
+  return (
+    <AccountContentWrapper>
+      <Skeleton w={48} h={48} css={{ borderRadius: '50%' }} />
+      <AccountInfo>
+        <Skeleton w='100%' h={20} />
+        <Skeleton w='100%' h={20} />
+      </AccountInfo>
+    </AccountContentWrapper>
+  )
+}
+
 export const AccountDetails = () => {
   const { data: user } = useCurrentAccountUser({
     select: (user) => ({
@@ -191,6 +205,7 @@ export const AccountDetails = () => {
   const { data: guestEmail } = useCurrentAccount({
     select: (account) => account?.guestEmail
   })
+  const { data: accountStatus } = useAccountStatus()
   const { data: hasCompletedAccount } = useCurrentAccountUser({
     select: selectIsAccountComplete
   })
@@ -213,6 +228,15 @@ export const AccountDetails = () => {
     return (
       <AccountDetailsContainer>
         <GuestView />
+      </AccountDetailsContainer>
+    )
+  }
+
+  // Only shows briefly when the account is currently being loaded in during sign in
+  if (accountStatus === Status.LOADING || accountStatus === Status.SUCCESS) {
+    return (
+      <AccountDetailsContainer>
+        <LoadingView />
       </AccountDetailsContainer>
     )
   }


### PR DESCRIPTION
### Description

- There's a brief state for a few seconds while account data loads in and gets put into cache slices where we just show "sign in" on your user. 
- Ideally this would be more instant, but for now just as a workaround I just threw in a little load state for now. Minimizing scope since this is also a bug on current prod

![2025-06-12 17 14 48](https://github.com/user-attachments/assets/8133fdd0-0264-4a54-b033-ab2861ab9a6a)


### How Has This Been Tested?

web:stage
