### PR TITLE
Fix listening history not showing items

### DIFF
--- a/packages/common/src/api/tan-query/tracks/useTrackHistory.ts
+++ b/packages/common/src/api/tan-query/tracks/useTrackHistory.ts
@@ -98,7 +98,7 @@ export const useTrackHistory = (
           pageParam,
           pageSize,
           false,
-          { tracks }
+          { items: tracks }
         )
       )
 


### PR DESCRIPTION
### Description

- Fixes listening history not showing anything after first load
- We changed the args name here from `tracks` to `items` but there's no typing on the lineup class methods to catch this stuff unfortunately

### How Has This Been Tested?

web:stage /history