### PR TITLE
[QA-2138] Remove max-width on playlist tiles for mobile web

### DIFF
--- a/packages/web/src/components/track/mobile/PlaylistTile.module.css
+++ b/packages/web/src/components/track/mobile/PlaylistTile.module.css
@@ -10,7 +10,6 @@
   display: flex;
   overflow: hidden;
   border-radius: 8px;
-  max-width: 400px;
   cursor: pointer;
   transition: all 0.2 ease-in-out;
   user-select: none;


### PR DESCRIPTION
### Description
title

### How Has This Been Tested?
Manually tested
