### PR TITLE
Add avoidable keyboard to buy/sell flow

### DIFF
--- a/packages/mobile/src/components/core/FixedFooter.tsx
+++ b/packages/mobile/src/components/core/FixedFooter.tsx
@@ -17,7 +17,7 @@ type FixedFooterProps = {
  * The default height calculation for the fixed footer
  * Formula: button height (48) + footer padding (2*spacing.l) + extra padding (spacing.xl)
  */
-const FIXED_FOOTER_HEIGHT = 48 + spacing.l * 2 + spacing.xl
+export const FIXED_FOOTER_HEIGHT = 48 + spacing.l * 2 + spacing.xl
 
 /**
  * A fixed footer component that sticks to the bottom of the screen.

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellScreen.tsx
@@ -1,14 +1,17 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
+import { useKeyboard } from '@react-native-community/hooks'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { Flex } from '@audius/harmony-native'
 import {
   Screen as MobileScreen,
   ScreenContent,
   FixedFooter,
-  FixedFooterContent
+  ScrollView
 } from 'app/components/core'
+import { FIXED_FOOTER_HEIGHT } from 'app/components/core/FixedFooter'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import type { BuySellScreenParams } from '../../types/navigation'
@@ -25,6 +28,8 @@ type BuySellScreenProps = {
 export const BuySellScreen = ({ route }: BuySellScreenProps) => {
   const navigation = useNavigation()
   const { params } = route
+  const insets = useSafeAreaInsets()
+  const { keyboardHeight, keyboardShown } = useKeyboard()
 
   const handleClose = () => {
     navigation.goBack()
@@ -35,17 +40,34 @@ export const BuySellScreen = ({ route }: BuySellScreenProps) => {
     initialTab: params?.initialTab
   })
 
+  const dynamicPaddingBottom = useMemo(() => {
+    // We need to account for the FixedFooter's height and the safe area insets.
+    // Additionally, when the keyboard is shown, we need to add the keyboard height
+    // so the content scrolls above the keyboard.
+    return (
+      FIXED_FOOTER_HEIGHT + insets.bottom + (keyboardShown ? keyboardHeight : 0)
+    )
+  }, [insets.bottom, keyboardHeight, keyboardShown])
+
   return (
     <MobileScreen title={messages.title} variant='white' url='/buy-sell'>
       <ScreenContent>
-        <FixedFooterContent>
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{
+            flexGrow: 1,
+            paddingBottom: dynamicPaddingBottom
+          }}
+          keyboardShouldPersistTaps='handled'
+          showsVerticalScrollIndicator={false}
+        >
           <PoweredByJupiter />
           <Flex mt='xl' p='l'>
             {flowData.content}
           </Flex>
-        </FixedFooterContent>
+        </ScrollView>
 
-        <FixedFooter>{flowData.footer}</FixedFooter>
+        <FixedFooter avoidKeyboard>{flowData.footer}</FixedFooter>
       </ScreenContent>
     </MobileScreen>
   )


### PR DESCRIPTION
### Description

This PR addresses an issue where the keyboard would obstruct content on the Buy/Sell screen.

Changes include:

- Exporting `FIXED_FOOTER_HEIGHT` from `FixedFooter.tsx` to allow external access.
- Replacing `FixedFooterContent` with a `ScrollView` in `BuySellScreen.tsx` to enable scrolling when the keyboard is active.
- Implementing dynamic padding at the bottom of the `ScrollView` in `BuySellScreen.tsx` to account for the keyboard height and safe area insets, ensuring content remains visible.


### How Has This Been Tested?

`npm run ios:prod` and play with input
