### PR TITLE
Improve search input performance, collapse on search + more

### DIFF
--- a/packages/mobile/src/components/core/CardList.tsx
+++ b/packages/mobile/src/components/core/CardList.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles(({ spacing }) => ({
     flexGrow: 0
   },
   cardHorizontal: {
-    width: spacing(40),
+    width: spacing(43),
     paddingRight: spacing(3),
     paddingBottom: spacing(3)
   }

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -69,7 +69,7 @@ const AnimatedSectionList = forwardRef(function AnimatedSectionList<
   props: Animated.AnimatedProps<RNSectionListProps<ItemT, SectionT>>,
   ref: RefObject<RNSectionList<ItemT, SectionT>>
 ) {
-  const { refreshing, onRefresh, onScroll, Container = View, ...other } = props
+  const { refreshing, onRefresh, onScroll, ...other } = props
   const { neutral } = useThemeColors()
   const scrollResponder = ref?.current?.getScrollResponder()
   const {
@@ -88,7 +88,7 @@ const AnimatedSectionList = forwardRef(function AnimatedSectionList<
   })
 
   return (
-    <Container>
+    <View>
       {Platform.OS === 'ios' && handleRefresh ? (
         <PullToRefresh
           isRefreshing={isRefreshing}
@@ -117,7 +117,7 @@ const AnimatedSectionList = forwardRef(function AnimatedSectionList<
         onScrollBeginDrag={onScrollBeginDrag}
         onScrollEndDrag={onScrollEndDrag}
       />
-    </Container>
+    </View>
   )
 })
 

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -69,7 +69,7 @@ const AnimatedSectionList = forwardRef(function AnimatedSectionList<
   props: Animated.AnimatedProps<RNSectionListProps<ItemT, SectionT>>,
   ref: RefObject<RNSectionList<ItemT, SectionT>>
 ) {
-  const { refreshing, onRefresh, onScroll, ...other } = props
+  const { refreshing, onRefresh, onScroll, Container = View, ...other } = props
   const { neutral } = useThemeColors()
   const scrollResponder = ref?.current?.getScrollResponder()
   const {
@@ -88,7 +88,7 @@ const AnimatedSectionList = forwardRef(function AnimatedSectionList<
   })
 
   return (
-    <View>
+    <Container>
       {Platform.OS === 'ios' && handleRefresh ? (
         <PullToRefresh
           isRefreshing={isRefreshing}
@@ -117,7 +117,7 @@ const AnimatedSectionList = forwardRef(function AnimatedSectionList<
         onScrollBeginDrag={onScrollBeginDrag}
         onScrollEndDrag={onScrollEndDrag}
       />
-    </View>
+    </Container>
   )
 })
 

--- a/packages/mobile/src/components/remix-carousel/RemixContestCard.tsx
+++ b/packages/mobile/src/components/remix-carousel/RemixContestCard.tsx
@@ -49,7 +49,7 @@ export const RemixContestCard = (props: RemixContestCardProps) => {
     return <CollectionCardSkeleton />
   }
   return (
-    <Paper onPress={handlePress}>
+    <Paper border='default' onPress={handlePress}>
       <Flex p='s' gap='s'>
         <TrackImage trackId={trackId} size={SquareSizes.SIZE_480_BY_480} />
         <Text variant='title' textAlign='center' numberOfLines={1}>

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -55,33 +55,21 @@ export const SelectablePill = (props: SelectablePillProps) => {
 
   const pressed = useSharedValue(0)
   const selected = useSharedValue(isSelected ? 1 : 0)
+
   const handlePressIn = useCallback(() => {
     pressed.value = withTiming(1, motion.press)
-    if (!isSelected) {
-      selected.value = withTiming(1, motion.press)
-    }
     setIsPressing(true)
-  }, [pressed, motion.press, selected, setIsPressing, isSelected])
-
-  const handleTouchCancel = useCallback(() => {
-    pressed.value = withTiming(0, motion.press)
-    if (!isSelected) {
-      selected.value = withTiming(0, motion.press)
-    }
-    setIsPressing(false)
-  }, [pressed, motion.press, selected, setIsPressing, isSelected])
+  }, [pressed, motion.press, setIsPressing])
 
   const handlePressOut = useCallback(() => {
     pressed.value = withTiming(0, motion.press)
-    if (!isSelected) {
-      selected.value = withTiming(0, motion.press)
-    }
     setIsPressing(false)
-  }, [pressed, motion.press, selected, setIsPressing, isSelected])
+  }, [pressed, motion.press, setIsPressing])
 
-  const handleLongPress = useCallback(() => {
-    // necessary because it seems to modify how events bubble
-  }, [])
+  const handleTouchCancel = useCallback(() => {
+    pressed.value = withTiming(0, motion.press)
+    setIsPressing(false)
+  }, [pressed, motion.press, setIsPressing])
 
   const handlePress = useCallback(
     (e: GestureResponderEvent) => {
@@ -89,7 +77,6 @@ export const SelectablePill = (props: SelectablePillProps) => {
       if (value) {
         onChange?.(value, !isSelected)
       }
-      setIsPressing(false)
       setIsSelected(!isSelected)
     },
     [onChange, onPress, value, isSelected, setIsSelected]
@@ -144,9 +131,8 @@ export const SelectablePill = (props: SelectablePillProps) => {
   return (
     <Pressable
       onPressIn={handlePressIn}
-      onTouchCancel={handleTouchCancel}
       onPressOut={handlePressOut}
-      onLongPress={handleLongPress}
+      onTouchCancel={handleTouchCancel}
       onPress={handlePress}
       hitSlop={DEFAULT_HIT_SLOP}
       style={[

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -112,7 +112,7 @@ export const SelectablePill = (props: SelectablePillProps) => {
         [0, 1],
         [color.border.strong, color.secondary.s400]
       ),
-      transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.97]) }]
+      transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.95]) }]
     }),
     [disabled, themeType]
   )

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -112,7 +112,7 @@ export const SelectablePill = (props: SelectablePillProps) => {
         [0, 1],
         [color.border.strong, color.secondary.s400]
       ),
-      transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.9]) }]
+      transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.97]) }]
     }),
     [disabled, themeType]
   )

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -78,8 +78,23 @@ export const SelectablePill = (props: SelectablePillProps) => {
         onChange?.(value, !isSelected)
       }
       setIsSelected(!isSelected)
+      if (isSelected) {
+        // avoids flashing purple when deselecting
+        selected.value = disableUnselectAnimation
+          ? 0
+          : withTiming(0, motion.press)
+      }
     },
-    [onChange, onPress, value, isSelected, setIsSelected]
+    [
+      onPress,
+      value,
+      setIsSelected,
+      isSelected,
+      onChange,
+      selected,
+      disableUnselectAnimation,
+      motion.press
+    ]
   )
 
   useEffect(() => {

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -112,7 +112,7 @@ export const SelectablePill = (props: SelectablePillProps) => {
         [0, 1],
         [color.border.strong, color.secondary.s400]
       ),
-      transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.97]) }]
+      transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.9]) }]
     }),
     [disabled, themeType]
   )

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -55,7 +55,6 @@ export const SelectablePill = (props: SelectablePillProps) => {
 
   const pressed = useSharedValue(0)
   const selected = useSharedValue(isSelected ? 1 : 0)
-
   const handlePressIn = useCallback(() => {
     pressed.value = withTiming(1, motion.press)
     if (!isSelected) {
@@ -71,6 +70,18 @@ export const SelectablePill = (props: SelectablePillProps) => {
     }
     setIsPressing(false)
   }, [pressed, motion.press, selected, setIsPressing, isSelected])
+
+  const handlePressOut = useCallback(() => {
+    pressed.value = withTiming(0, motion.press)
+    if (!isSelected) {
+      selected.value = withTiming(0, motion.press)
+    }
+    setIsPressing(false)
+  }, [pressed, motion.press, selected, setIsPressing, isSelected])
+
+  const handleLongPress = useCallback(() => {
+    // necessary because it seems to modify how events bubble
+  }, [])
 
   const handlePress = useCallback(
     (e: GestureResponderEvent) => {
@@ -134,6 +145,8 @@ export const SelectablePill = (props: SelectablePillProps) => {
     <Pressable
       onPressIn={handlePressIn}
       onTouchCancel={handleTouchCancel}
+      onPressOut={handlePressOut}
+      onLongPress={handleLongPress}
       onPress={handlePress}
       hitSlop={DEFAULT_HIT_SLOP}
       style={[

--- a/packages/mobile/src/screens/app-screen/ExploreTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/ExploreTabScreen.tsx
@@ -34,6 +34,7 @@ import { createAppTabScreenStack } from './createAppTabScreenStack'
 
 export type ExploreTabScreenParamList = AppTabScreenParamList & {
   Explore: undefined
+  SearchExplore: { autoFocus?: boolean }
   // Smart Collection Screens
   UnderTheRadar: undefined
   MostLoved: undefined

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useContext } from 'react'
 
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import type { ParamListBase, RouteProp } from '@react-navigation/core'
 import type {
   NativeStackNavigationOptions,
@@ -56,14 +58,24 @@ export const useAppScreenOptions = (
   const styles = useStyles()
   const navigation = useNavigation()
   const { drawerHelpers } = useContext(AppDrawerContext)
+  const { isEnabled: isSearchExploreMobileEnabled } = useFeatureFlag(
+    FeatureFlags.SEARCH_EXPLORE_MOBILE
+  )
 
   const handleOpenLeftNavDrawer = useCallback(() => {
     drawerHelpers?.openDrawer()
   }, [drawerHelpers])
 
   const handlePressSearch = useCallback(() => {
-    navigation.navigate('Search', { autoFocus: true })
-  }, [navigation])
+    if (isSearchExploreMobileEnabled) {
+      navigation.navigate('explore', {
+        screen: 'SearchExplore',
+        params: { autoFocus: true }
+      })
+    } else {
+      navigation.navigate('Search', { autoFocus: true })
+    }
+  }, [isSearchExploreMobileEnabled, navigation])
 
   const screenOptions: (options: Options) => NativeStackNavigationOptions =
     useCallback(

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -23,7 +23,7 @@ import {
   SearchProvider,
   useSearchCategory,
   useSearchFilters,
-  useSearchDebouncedQuery
+  useSearchQuery
 } from '../search-screen/searchState'
 
 import { ExploreContent } from './components/ExploreContent'
@@ -42,8 +42,7 @@ const SearchExploreContent = () => {
   // Get state from context
   const [category, setCategory] = useSearchCategory()
   const [filters, setFilters] = useSearchFilters()
-  const debouncedQuery = useSearchDebouncedQuery()
-
+  const [query] = useSearchQuery()
   // Animation state
   const scrollY = useSharedValue(0)
   const filterTranslateY = useSharedValue(0)
@@ -119,35 +118,33 @@ const SearchExploreContent = () => {
   }))
 
   return (
-    <Screen url='Explore' header={() => <></>}>
-      <ScreenContent>
-        <SearchExploreHeader
-          scrollY={scrollY}
-          filterTranslateY={filterTranslateY}
-          scrollRef={scrollRef}
-        />
+    <ScreenContent>
+      <SearchExploreHeader
+        scrollY={scrollY}
+        filterTranslateY={filterTranslateY}
+        scrollRef={scrollRef}
+      />
 
-        <Animated.ScrollView
-          ref={scrollRef}
-          onScroll={scrollHandler}
-          style={[contentSlideAnimatedStyle]}
-        >
-          {category !== 'all' || debouncedQuery ? (
-            <>
-              {debouncedQuery || hasAnyFilter ? (
-                <SearchResults />
-              ) : showRecentSearches ? (
-                <RecentSearches ListHeaderComponent={<SearchCatalogTile />} />
-              ) : (
-                <SearchCatalogTile />
-              )}
-            </>
-          ) : (
-            <ExploreContent />
-          )}
-        </Animated.ScrollView>
-      </ScreenContent>
-    </Screen>
+      <Animated.ScrollView
+        ref={scrollRef}
+        onScroll={scrollHandler}
+        style={[contentSlideAnimatedStyle]}
+      >
+        {category !== 'all' || query ? (
+          <>
+            {query || hasAnyFilter ? (
+              <SearchResults />
+            ) : showRecentSearches ? (
+              <RecentSearches ListHeaderComponent={<SearchCatalogTile />} />
+            ) : (
+              <SearchCatalogTile />
+            )}
+          </>
+        ) : (
+          <ExploreContent />
+        )}
+      </Animated.ScrollView>
+    </ScreenContent>
   )
 }
 
@@ -161,7 +158,9 @@ export const SearchExploreScreen = () => {
       initialAutoFocus={params?.autoFocus ?? false}
       initialQuery={params?.query ?? ''}
     >
-      <SearchExploreContent />
+      <Screen url='Explore' header={() => <></>}>
+        <SearchExploreContent />
+      </Screen>
     </SearchProvider>
   )
 }

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -68,6 +68,14 @@ const SearchExploreContent = () => {
       const contentHeight = event.contentSize.height
       const layoutHeight = event.layoutMeasurement.height
       const isAtBottom = y + layoutHeight >= contentHeight
+      const canScroll = contentHeight > layoutHeight
+
+      // Only apply scroll animations if there's enough content to scroll
+      // fixes jitter when content is small
+      if (!canScroll) {
+        scrollY.value = 0
+        return
+      }
 
       // Only update scroll direction if we're not at the bottom
       // to prevent bounce from interfering
@@ -122,7 +130,9 @@ const SearchExploreContent = () => {
       : scrollY.value === 0
         ? withTiming(0, motion.calm)
         : interpolate(scrollY.value, [0, 80], [0, 80], Extrapolation.CLAMP) +
-          filterTranslateY.value
+          filterTranslateY.value,
+    // Add minimum height to prevent jitter with small content
+    minHeight: '100%'
   }))
 
   return (

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -55,7 +55,6 @@ const SearchExploreContent = () => {
     (value) => value !== undefined
   )
   const history = useSelector(getSearchHistory)
-  const showRecentSearches = history.length > 0
 
   useScrollToTop(() => {
     scrollRef.current?.scrollTo({
@@ -135,10 +134,8 @@ const SearchExploreContent = () => {
           <>
             {query || hasAnyFilter ? (
               <SearchResults />
-            ) : showRecentSearches ? (
-              <RecentSearches ListHeaderComponent={<SearchCatalogTile />} />
             ) : (
-              <SearchCatalogTile />
+              <RecentSearches ListHeaderComponent={<SearchCatalogTile />} />
             )}
           </>
         ) : (

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import type { LayoutChangeEvent, View } from 'react-native'
 import Animated, {
@@ -34,7 +34,7 @@ const FILTER_SCROLL_THRESHOLD = 300
 const HEADER_COLLAPSE_THRESHOLD = 50
 
 const SearchExploreContent = () => {
-  const { spacing } = useTheme()
+  const { spacing, motion } = useTheme()
 
   // Get state from context
   const [category, setCategory] = useSearchCategory()
@@ -46,8 +46,6 @@ const SearchExploreContent = () => {
   const prevScrollY = useSharedValue(0)
   const scrollDirection = useSharedValue<'up' | 'down'>('down')
   const scrollRef = useRef<Animated.ScrollView>(null)
-  const headerRef = useRef<View>(null)
-  const headerHeight = useSharedValue(0)
 
   // Derived data
   const hasAnyFilter = Object.values(filters).some(
@@ -86,23 +84,22 @@ const SearchExploreContent = () => {
 
       // Handle filter animation
       if (y > FILTER_SCROLL_THRESHOLD && scrollDirection.value === 'down') {
-        filterTranslateY.value = withTiming(-spacing['4xl'])
+        filterTranslateY.value = withTiming(-spacing['4xl'], motion.calm)
       } else if (
         y < FILTER_SCROLL_THRESHOLD ||
         scrollDirection.value === 'up'
       ) {
-        filterTranslateY.value = withTiming(0)
+        filterTranslateY.value = withTiming(0, motion.calm)
       }
     }
   })
 
   // content margin expands when header / filter collapses
-  console.log('asdf query: ', query)
   const contentSlideAnimatedStyle = useAnimatedStyle(() => ({
     marginTop: query
-      ? withTiming(-HEADER_COLLAPSE_THRESHOLD * 2.5)
+      ? withTiming(-HEADER_COLLAPSE_THRESHOLD * 2.5, motion.calm)
       : scrollY.value === 0
-        ? withTiming(0)
+        ? withTiming(0, motion.calm)
         : interpolate(
             scrollY.value,
             [0, HEADER_COLLAPSE_THRESHOLD],
@@ -122,9 +119,9 @@ const SearchExploreContent = () => {
 
   const contentPaddingStyle = useAnimatedStyle(() => ({
     paddingTop: query
-      ? withTiming(80)
+      ? withTiming(80, motion.calm)
       : scrollY.value === 0
-        ? withTiming(0)
+        ? withTiming(0, motion.calm)
         : interpolate(scrollY.value, [0, 80], [0, 80], Extrapolation.CLAMP) +
           filterTranslateY.value
   }))

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import Animated, {
   useAnimatedScrollHandler,
@@ -59,6 +59,13 @@ const SearchExploreContent = () => {
     setQuery('')
     setCategory('all')
     setFilters({})
+  })
+
+  useEffect(() => {
+    if (query.length <= 1) {
+      // Reset scroll on new or empty queries
+      scrollRef.current?.scrollTo?.({ y: 0, animated: false })
+    }
   })
 
   // Animations

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react'
 
-import { searchSelectors } from '@audius/common/store'
 import Animated, {
   useAnimatedScrollHandler,
   useSharedValue,
@@ -9,7 +8,6 @@ import Animated, {
   Extrapolation,
   withTiming
 } from 'react-native-reanimated'
-import { useSelector } from 'react-redux'
 
 import { useTheme } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
@@ -28,8 +26,6 @@ import {
 
 import { ExploreContent } from './components/ExploreContent'
 import { SearchExploreHeader } from './components/SearchExploreHeader'
-
-const { getSearchHistory } = searchSelectors
 
 // Animation parameters
 const HEADER_SLIDE_HEIGHT = 46

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -54,7 +54,6 @@ const SearchExploreContent = () => {
   const hasAnyFilter = Object.values(filters).some(
     (value) => value !== undefined
   )
-  const history = useSelector(getSearchHistory)
 
   useScrollToTop(() => {
     scrollRef.current?.scrollTo({

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useRef } from 'react'
 
-import type { LayoutChangeEvent, View } from 'react-native'
 import Animated, {
   useAnimatedScrollHandler,
   useSharedValue,

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -42,7 +42,7 @@ const SearchExploreContent = () => {
   // Get state from context
   const [category, setCategory] = useSearchCategory()
   const [filters, setFilters] = useSearchFilters()
-  const [query] = useSearchQuery()
+  const [query, setQuery] = useSearchQuery()
   // Animation state
   const scrollY = useSharedValue(0)
   const filterTranslateY = useSharedValue(0)
@@ -62,6 +62,7 @@ const SearchExploreContent = () => {
       y: 0,
       animated: false
     })
+    setQuery('')
     setCategory('all')
     setFilters({})
   })

--- a/packages/mobile/src/screens/explore-screen/components/ProgressiveScrollView.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ProgressiveScrollView.tsx
@@ -86,7 +86,7 @@ export const ProgressiveScrollView = ({
       onScroll={handleScroll}
       scrollEventThrottle={16}
     >
-      <Flex direction='column' ph='l' pt='xl' pb='3xl'>
+      <Flex direction='column' ph='l' pt='s' pb='3xl'>
         {childrenArray.map((child, index) => {
           if (isValidElement(child)) {
             return renderChild(child, index)

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 
 import { exploreMessages as messages } from '@audius/common/messages'
 import type { ScrollView } from 'react-native'
@@ -55,13 +55,14 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   // Get state from context
   const [query, setQuery] = useSearchQuery()
   const [inputValue, setInputValue] = useState(query)
+  useEffect(() => {
+    setInputValue(query)
+  }, [query])
 
   // State
   const [autoFocus] = useState(params?.autoFocus ?? false)
   // Data fetching
   const animatedFilterPaddingVertical = useSharedValue(spacing.l)
-
-  // Derived data
 
   // Handlers
   const handleOpenLeftNavDrawer = useCallback(() => {

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -60,7 +60,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   }, [query])
 
   // State
-  const [autoFocus] = useState(params?.autoFocus ?? false)
+
   // Data fetching
   const animatedFilterPaddingVertical = useSharedValue(spacing.l)
 
@@ -285,7 +285,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
             <Animated.View style={inputAnimatedStyle}>
               <TextInput
                 label='Search'
-                autoFocus={autoFocus}
+                autoFocus={params.autoFocus}
                 autoCorrect={false}
                 placeholder={messages.searchPlaceholder}
                 size={TextInputSize.SMALL}

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react'
 
 import { exploreMessages as messages } from '@audius/common/messages'
+import { motion } from '@audius/harmony'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import type { ScrollView } from 'react-native'
 import { ImageBackground, Keyboard } from 'react-native'
@@ -124,11 +125,22 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
     [scrollRef]
   )
 
+  // Immediate update for first character
+  useEffect(() => {
+    if (inputValue.length < 2) {
+      setQuery(inputValue)
+    }
+  }, [inputValue, query, setQuery])
+
+  // Normal debounced update for everything else
   useDebounce(
     () => {
-      setQuery(inputValue)
+      // Skip if we already handled the first character
+      if (inputValue.length >= 2) {
+        setQuery(inputValue)
+      }
     },
-    400,
+    200,
     [inputValue]
   )
 
@@ -138,7 +150,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   // Height shrinks to collapse rows for avatar + input
   const headerTextAnimatedStyle = useAnimatedStyle(() => ({
     opacity: inputValue
-      ? withTiming(0)
+      ? withTiming(0, motion.calm)
       : scrollY.value === 0
         ? withTiming(1)
         : interpolate(
@@ -148,7 +160,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
             Extrapolation.CLAMP
           ),
     height: inputValue
-      ? withTiming(0)
+      ? withTiming(0, motion.calm)
       : scrollY.value === 0
         ? withTiming(48)
         : interpolate(
@@ -163,9 +175,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
     transform: [
       {
         scale: inputValue
-          ? withTiming(0.83)
+          ? withTiming(0.83, motion.calm)
           : scrollY.value === 0
-            ? withTiming(1)
+            ? withTiming(1, motion.calm)
             : interpolate(
                 scrollY.value,
                 [0, HEADER_COLLAPSE_THRESHOLD],
@@ -175,9 +187,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
       },
       {
         translateX: inputValue
-          ? withTiming(30)
+          ? withTiming(30, motion.calm)
           : scrollY.value === 0
-            ? withTiming(0)
+            ? withTiming(0, motion.calm)
             : interpolate(
                 scrollY.value,
                 [0, HEADER_COLLAPSE_THRESHOLD],
@@ -193,9 +205,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
     transform: [
       {
         translateY: inputValue
-          ? withTiming(-HEADER_SLIDE_HEIGHT)
+          ? withTiming(-HEADER_SLIDE_HEIGHT, motion.calm)
           : scrollY.value === 0
-            ? withTiming(0)
+            ? withTiming(0, motion.calm)
             : interpolate(
                 scrollY.value,
                 [0, HEADER_COLLAPSE_THRESHOLD],
@@ -212,9 +224,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
     transform: [
       {
         translateY: inputValue
-          ? withTiming(HEADER_SLIDE_HEIGHT)
+          ? withTiming(HEADER_SLIDE_HEIGHT, motion.calm)
           : scrollY.value === 0
-            ? withTiming(0)
+            ? withTiming(0, motion.calm)
             : interpolate(
                 scrollY.value,
                 [0, HEADER_COLLAPSE_THRESHOLD],
@@ -228,9 +240,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   // Header padding and gap shrink when collapsing
   const headerPaddingShrinkStyle = useAnimatedStyle(() => ({
     paddingVertical: inputValue
-      ? withTiming(spacing.s)
+      ? withTiming(spacing.s, motion.calm)
       : scrollY.value === 0
-        ? withTiming(spacing.l)
+        ? withTiming(spacing.l, motion.calm)
         : interpolate(
             scrollY.value,
             [0, HEADER_COLLAPSE_THRESHOLD],
@@ -238,9 +250,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
             Extrapolation.CLAMP
           ),
     gap: inputValue
-      ? withTiming(0)
+      ? withTiming(0, motion.calm)
       : scrollY.value === 0
-        ? withTiming(spacing.l)
+        ? withTiming(spacing.l, motion.calm)
         : interpolate(
             scrollY.value,
             [0, HEADER_COLLAPSE_THRESHOLD],
@@ -255,9 +267,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
     transform: [
       {
         translateY: inputValue
-          ? withTiming(-HEADER_SLIDE_HEIGHT)
+          ? withTiming(-HEADER_SLIDE_HEIGHT, motion.calm)
           : scrollY.value === 0
-            ? withTiming(0)
+            ? withTiming(0, motion.calm)
             : interpolate(
                 scrollY.value,
                 [0, HEADER_COLLAPSE_THRESHOLD],
@@ -268,7 +280,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
     ],
     backgroundColor:
       scrollY.value === 0
-        ? withTiming(color.background.default)
+        ? withTiming('transparent', motion.calm)
         : interpolateColor(
             scrollY.value,
             [0, HEADER_COLLAPSE_THRESHOLD],
@@ -276,7 +288,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
           ),
     borderColor:
       scrollY.value === 0
-        ? withTiming(color.background.default)
+        ? withTiming('transparent', motion.calm)
         : interpolateColor(
             scrollY.value,
             [0, HEADER_COLLAPSE_THRESHOLD],

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+import React, { useCallback, useContext, useState, useEffect } from 'react'
 
 import { exploreMessages as messages } from '@audius/common/messages'
 import type { ScrollView } from 'react-native'
@@ -13,6 +13,7 @@ import Animated, {
   withTiming,
   useDerivedValue
 } from 'react-native-reanimated'
+import { useDebounce } from 'react-use'
 
 import {
   Flex,
@@ -53,6 +54,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
 
   // Get state from context
   const [query, setQuery] = useSearchQuery()
+  const [inputValue, setInputValue] = useState(query)
 
   // State
   const [autoFocus] = useState(params?.autoFocus ?? false)
@@ -67,21 +69,29 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   }, [drawerHelpers])
 
   const handleClearSearch = useCallback(() => {
-    setQuery('')
+    setInputValue('')
     scrollRef.current?.scrollTo({
       y: 0,
       animated: false
     })
-  }, [setQuery, scrollRef])
+  }, [setInputValue, scrollRef])
 
   const handleSearchInputChange = useCallback(
     (text: string) => {
-      setQuery(text)
+      setInputValue(text)
       if (text === '') {
         scrollRef.current?.scrollTo?.({ y: 0, animated: false })
       }
     },
-    [setQuery, scrollRef]
+    [scrollRef]
+  )
+
+  useDebounce(
+    () => {
+      setQuery(inputValue)
+    },
+    400,
+    [inputValue]
   )
 
   // Animated styles
@@ -275,13 +285,14 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
               <TextInput
                 label='Search'
                 autoFocus={autoFocus}
+                autoCorrect={false}
                 placeholder={messages.searchPlaceholder}
                 size={TextInputSize.SMALL}
                 startIcon={IconSearch}
                 onChangeText={handleSearchInputChange}
-                value={query}
+                value={inputValue}
                 endIcon={(props) =>
-                  query ? (
+                  inputValue ? (
                     <IconButton
                       icon={IconCloseAlt}
                       color='subdued'

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -119,9 +119,13 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
       setInputValue(text)
       if (text === '') {
         scrollRef.current?.scrollTo?.({ y: 0, animated: false })
+      } else if (inputValue === '' && text.length === 1) {
+        // If the input was empty and now has at least 2 characters,
+        // scroll to the top to show results
+        scrollRef.current?.scrollTo?.({ y: 0, animated: false })
       }
     },
-    [scrollRef]
+    [inputValue, scrollRef]
   )
 
   // Immediate update for first character

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -55,7 +55,7 @@ type SearchExploreHeaderProps = {
 
 export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   const { filterTranslateY, scrollY, scrollRef } = props
-  const { spacing, color } = useTheme()
+  const { spacing, color, motion } = useTheme()
   const { params } = useRoute<'Search'>()
   const { drawerHelpers } = useContext(AppDrawerContext)
   const navigation = useNavigation()
@@ -137,8 +137,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   // Header text fades out when collapsing
   // Height shrinks to collapse rows for avatar + input
   const headerTextAnimatedStyle = useAnimatedStyle(() => ({
-    opacity:
-      scrollY.value === 0
+    opacity: inputValue
+      ? withTiming(0)
+      : scrollY.value === 0
         ? withTiming(1)
         : interpolate(
             scrollY.value,
@@ -146,8 +147,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
             [1, 0],
             Extrapolation.CLAMP
           ),
-    height:
-      scrollY.value === 0
+    height: inputValue
+      ? withTiming(0)
+      : scrollY.value === 0
         ? withTiming(48)
         : interpolate(
             scrollY.value,
@@ -160,8 +162,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   const inputAnimatedStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        scale:
-          scrollY.value === 0
+        scale: inputValue
+          ? withTiming(0.83)
+          : scrollY.value === 0
             ? withTiming(1)
             : interpolate(
                 scrollY.value,
@@ -171,8 +174,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
               )
       },
       {
-        translateX:
-          scrollY.value === 0
+        translateX: inputValue
+          ? withTiming(30)
+          : scrollY.value === 0
             ? withTiming(0)
             : interpolate(
                 scrollY.value,
@@ -188,8 +192,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   const headerSlideAnimatedStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        translateY:
-          scrollY.value === 0
+        translateY: inputValue
+          ? withTiming(-HEADER_SLIDE_HEIGHT)
+          : scrollY.value === 0
             ? withTiming(0)
             : interpolate(
                 scrollY.value,
@@ -206,8 +211,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   const avatarSlideAnimatedStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        translateY:
-          scrollY.value === 0
+        translateY: inputValue
+          ? withTiming(HEADER_SLIDE_HEIGHT)
+          : scrollY.value === 0
             ? withTiming(0)
             : interpolate(
                 scrollY.value,
@@ -221,8 +227,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
 
   // Header padding and gap shrink when collapsing
   const headerPaddingShrinkStyle = useAnimatedStyle(() => ({
-    paddingVertical:
-      scrollY.value === 0
+    paddingVertical: inputValue
+      ? withTiming(spacing.s)
+      : scrollY.value === 0
         ? withTiming(spacing.l)
         : interpolate(
             scrollY.value,
@@ -230,8 +237,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
             [spacing.l, spacing.s],
             Extrapolation.CLAMP
           ),
-    gap:
-      scrollY.value === 0
+    gap: inputValue
+      ? withTiming(0)
+      : scrollY.value === 0
         ? withTiming(spacing.l)
         : interpolate(
             scrollY.value,
@@ -246,8 +254,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   const filtersAnimatedStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        translateY:
-          scrollY.value === 0
+        translateY: inputValue
+          ? withTiming(-HEADER_SLIDE_HEIGHT)
+          : scrollY.value === 0
             ? withTiming(0)
             : interpolate(
                 scrollY.value,

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react'
 
 import { exploreMessages as messages } from '@audius/common/messages'
-import { motion } from '@audius/harmony'
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import type { ScrollView } from 'react-native'
 import { ImageBackground, Keyboard } from 'react-native'

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -119,13 +119,9 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
       setInputValue(text)
       if (text === '') {
         scrollRef.current?.scrollTo?.({ y: 0, animated: false })
-      } else if (inputValue === '' && text.length === 1) {
-        // If the input was empty and now has at least 2 characters,
-        // scroll to the top to show results
-        scrollRef.current?.scrollTo?.({ y: 0, animated: false })
       }
     },
-    [inputValue, scrollRef]
+    [scrollRef]
   )
 
   // Immediate update for first character

--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState, useEffect } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 
 import { exploreMessages as messages } from '@audius/common/messages'
 import type { ScrollView } from 'react-native'

--- a/packages/mobile/src/screens/search-screen/RecentSearches.tsx
+++ b/packages/mobile/src/screens/search-screen/RecentSearches.tsx
@@ -53,7 +53,7 @@ export const RecentSearches = (props: RecentSearchesProps) => {
     dispatch(clearHistory())
   }, [dispatch])
 
-  if (filteredSearchItems.length === 0) return ListHeaderComponent
+  if (filteredSearchItems.length === 0) return ListHeaderComponent || null
 
   return (
     <>

--- a/packages/mobile/src/screens/search-screen/RecentSearches.tsx
+++ b/packages/mobile/src/screens/search-screen/RecentSearches.tsx
@@ -6,14 +6,7 @@ import { Kind } from '@audius/common/models'
 import { searchActions, searchSelectors } from '@audius/common/store'
 import { useDispatch, useSelector } from 'react-redux'
 
-import {
-  Button,
-  Flex,
-  IconCloseAlt,
-  Paper,
-  PlainButton,
-  Text
-} from '@audius/harmony-native'
+import { Button, Flex, IconCloseAlt, Paper, Text } from '@audius/harmony-native'
 import { FlatList } from 'app/components/core'
 
 import { SearchItem } from './SearchItem'

--- a/packages/mobile/src/screens/search-screen/RecentSearches.tsx
+++ b/packages/mobile/src/screens/search-screen/RecentSearches.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactElement } from 'react'
 import { useCallback, useMemo } from 'react'
 
 import { recentSearchMessages as messages } from '@audius/common/messages'
@@ -6,11 +6,18 @@ import { Kind } from '@audius/common/models'
 import { searchActions, searchSelectors } from '@audius/common/store'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Flex, IconCloseAlt, PlainButton, Text } from '@audius/harmony-native'
+import {
+  Button,
+  Flex,
+  IconCloseAlt,
+  Paper,
+  PlainButton,
+  Text
+} from '@audius/harmony-native'
 import { FlatList } from 'app/components/core'
 
 import { SearchItem } from './SearchItem'
-import { useSearchCategory } from './searchState'
+import { useSearchCategory } from './searchState.tsx'
 
 const { removeItem, clearHistory } = searchActions
 const { getSearchHistory } = searchSelectors
@@ -26,7 +33,7 @@ const itemKindByCategory: Record<string, Kind | null> = {
 }
 
 type RecentSearchesProps = {
-  ListHeaderComponent?: ReactNode
+  ListHeaderComponent?: ReactElement
 }
 
 export const RecentSearches = (props: RecentSearchesProps) => {
@@ -53,37 +60,52 @@ export const RecentSearches = (props: RecentSearchesProps) => {
     dispatch(clearHistory())
   }, [dispatch])
 
-  if (filteredSearchItems.length === 0) return null
+  if (filteredSearchItems.length === 0) return ListHeaderComponent
 
   return (
-    <FlatList
-      ListHeaderComponent={
-        <Flex gap='l'>
+    <>
+      {ListHeaderComponent && (
+        <Flex ph='xs' pv='l'>
           {ListHeaderComponent}
-          <Flex ph='l'>
-            <Text variant='title'>{messages.title}</Text>
-          </Flex>
         </Flex>
-      }
-      data={filteredSearchItems}
-      keyExtractor={({ id, kind }) => `${kind}-${id}`}
-      renderItem={({ item }) => (
-        <SearchItem
-          searchItem={item}
-          icon={IconCloseAlt}
-          onPressIcon={() => dispatch(removeItem({ searchItem: item }))}
-        />
       )}
-      ListFooterComponent={
-        <Flex pv='l' ph='l'>
-          <PlainButton
-            style={{ alignSelf: 'center' }}
-            onPress={handleClearSearchHistory}
-          >
-            {messages.clear}
-          </PlainButton>
+      <Paper
+        pv='l'
+        mh='l'
+        direction='column'
+        shadow='flat'
+        backgroundColor='surface1'
+        border='default'
+        gap='m'
+      >
+        <Flex ph='l'>
+          <Text variant='title'>{messages.title}</Text>
         </Flex>
-      }
-    />
+
+        <FlatList
+          data={filteredSearchItems}
+          keyExtractor={({ id, kind }) => `${kind}-${id}`}
+          renderItem={({ item }) => (
+            <SearchItem
+              searchItem={item}
+              icon={IconCloseAlt}
+              onPressIcon={() => dispatch(removeItem({ searchItem: item }))}
+            />
+          )}
+          ListFooterComponent={
+            <Flex pt='l' ph='l'>
+              <Button
+                variant='secondary'
+                size='small'
+                style={{ alignSelf: 'center' }}
+                onPress={handleClearSearchHistory}
+              >
+                {messages.clear}
+              </Button>
+            </Flex>
+          }
+        />
+      </Paper>
+    </>
   )
 }

--- a/packages/mobile/src/screens/search-screen/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchItem.tsx
@@ -6,14 +6,7 @@ import { pick } from 'lodash'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 
 import type { IconComponent } from '@audius/harmony-native'
-import {
-  Flex,
-  IconButton,
-  IconCaretRight,
-  Text,
-  spacing,
-  useTheme
-} from '@audius/harmony-native'
+import { Flex, Text, spacing, useTheme } from '@audius/harmony-native'
 import { ProfilePicture } from 'app/components/core'
 import { CollectionImage } from 'app/components/image/CollectionImage'
 import { TrackImage } from 'app/components/image/TrackImage'
@@ -33,7 +26,7 @@ type SearchItemContainerProps = {
 } & SearchItemProps
 
 const SearchItemContainer = (props: SearchItemContainerProps) => {
-  const { children, icon: Icon = IconCaretRight, onPressIcon, onPress } = props
+  const { children, onPress } = props
 
   return (
     <TouchableOpacity onPress={onPress}>
@@ -47,7 +40,7 @@ const SearchItemContainer = (props: SearchItemContainerProps) => {
         gap='m'
       >
         {children}
-        {onPressIcon ? (
+        {/* {onPressIcon ? (
           <IconButton
             icon={Icon}
             color='subdued'
@@ -56,7 +49,7 @@ const SearchItemContainer = (props: SearchItemContainerProps) => {
           />
         ) : (
           <Icon size='s' color='subdued' />
-        )}
+        )} */}
       </Flex>
     </TouchableOpacity>
   )

--- a/packages/mobile/src/screens/search-screen/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchItem.tsx
@@ -40,16 +40,6 @@ const SearchItemContainer = (props: SearchItemContainerProps) => {
         gap='m'
       >
         {children}
-        {/* {onPressIcon ? (
-          <IconButton
-            icon={Icon}
-            color='subdued'
-            size='s'
-            onPress={onPressIcon}
-          />
-        ) : (
-          <Icon size='s' color='subdued' />
-        )} */}
       </Flex>
     </TouchableOpacity>
   )

--- a/packages/mobile/src/screens/search-screen/search-results/AllResults.tsx
+++ b/packages/mobile/src/screens/search-screen/search-results/AllResults.tsx
@@ -157,20 +157,21 @@ export const AllResults = () => {
       ) : (
         <Flex mh='l' gap='l' mb='xl'>
           {(isLoading ? skeletonSections : sections).map((section, index) => (
-            <SectionList<SearchItemType>
-              key={`${section.title}-${index}`}
-              keyboardShouldPersistTaps='always'
-              stickySectionHeadersEnabled={false}
-              sections={[section]}
-              keyExtractor={({ id, kind }) => `${kind}-${id}`}
-              renderItem={({ item }) => <AllResultsItem item={item} />}
-              renderSectionHeader={({ section: { title } }) => (
-                <Flex ph='l' mt='l'>
-                  <SearchSectionHeader title={title} />
-                </Flex>
-              )}
-              Container={Paper}
-            />
+            <Paper key={`${section.title}`} border='default' shadow='mid'>
+              <SectionList<SearchItemType>
+                key={`${section.title}-${index}`}
+                keyboardShouldPersistTaps='always'
+                stickySectionHeadersEnabled={false}
+                sections={[section]}
+                keyExtractor={({ id, kind }) => `${kind}-${id}`}
+                renderItem={({ item }) => <AllResultsItem item={item} />}
+                renderSectionHeader={({ section: { title } }) => (
+                  <Flex ph='l' mt='l'>
+                    <SearchSectionHeader title={title} />
+                  </Flex>
+                )}
+              />
+            </Paper>
           ))}
         </Flex>
       )}

--- a/packages/mobile/src/screens/search-screen/search-results/AllResults.tsx
+++ b/packages/mobile/src/screens/search-screen/search-results/AllResults.tsx
@@ -10,7 +10,7 @@ import { range } from 'lodash'
 import { Keyboard } from 'react-native'
 import { useDispatch } from 'react-redux'
 
-import { Divider, Flex, Text } from '@audius/harmony-native'
+import { Flex, Paper, Text } from '@audius/harmony-native'
 import { SectionList } from 'app/components/core'
 import { make, track as record } from 'app/services/analytics'
 
@@ -30,9 +30,6 @@ export const SearchSectionHeader = (props: SearchSectionHeaderProps) => {
       <Text variant='label' size='s' textTransform='uppercase'>
         {title}
       </Text>
-      <Flex flex={1}>
-        <Divider />
-      </Flex>
     </Flex>
   )
 }
@@ -158,18 +155,24 @@ export const AllResults = () => {
       {hasNoResults ? (
         <NoResultsTile />
       ) : (
-        <SectionList<SearchItemType>
-          keyboardShouldPersistTaps='always'
-          stickySectionHeadersEnabled={false}
-          sections={isLoading ? skeletonSections : sections}
-          keyExtractor={({ id, kind }) => `${kind}-${id}`}
-          renderItem={({ item }) => <AllResultsItem item={item} />}
-          renderSectionHeader={({ section: { title } }) => (
-            <Flex ph='l' mt='l'>
-              <SearchSectionHeader title={title} />
-            </Flex>
-          )}
-        />
+        <Flex mh='l' gap='l' mb='xl'>
+          {(isLoading ? skeletonSections : sections).map((section, index) => (
+            <SectionList<SearchItemType>
+              key={`${section.title}-${index}`}
+              keyboardShouldPersistTaps='always'
+              stickySectionHeadersEnabled={false}
+              sections={[section]}
+              keyExtractor={({ id, kind }) => `${kind}-${id}`}
+              renderItem={({ item }) => <AllResultsItem item={item} />}
+              renderSectionHeader={({ section: { title } }) => (
+                <Flex ph='l' mt='l'>
+                  <SearchSectionHeader title={title} />
+                </Flex>
+              )}
+              Container={Paper}
+            />
+          ))}
+        </Flex>
       )}
     </Flex>
   )

--- a/packages/mobile/src/screens/search-screen/searchState.tsx
+++ b/packages/mobile/src/screens/search-screen/searchState.tsx
@@ -9,14 +9,12 @@ import {
 
 import { type SearchCategory, type SearchFilters } from '@audius/common/api'
 import { isEmpty } from 'lodash'
-import { useDebounce } from 'react-use'
 
 export const ALL_RESULTS_LIMIT = 5
 
 type SearchContextType = {
   query: string
   setQuery: Dispatch<SetStateAction<string>>
-  debouncedQuery: string
   category: SearchCategory
   setCategory: Dispatch<SetStateAction<SearchCategory>>
   filters: SearchFilters
@@ -31,7 +29,6 @@ type SearchContextType = {
 export const SearchContext = createContext<SearchContextType>({
   query: '',
   setQuery: (_) => {},
-  debouncedQuery: '',
   category: 'all',
   setCategory: (_) => {},
   filters: {},
@@ -66,21 +63,11 @@ export const SearchProvider = ({
   const [bpmType, setBpmType] = useState<'range' | 'target'>('range')
   const [autoFocus, setAutoFocus] = useState(initialAutoFocus)
   const [searchInput, setSearchInput] = useState(initialQuery)
-  const [debouncedQuery, setDebouncedQuery] = useState(searchInput)
-
-  useDebounce(
-    () => {
-      setDebouncedQuery(searchInput)
-    },
-    200, // debounce delay in ms
-    [searchInput]
-  )
 
   const contextValue = useMemo(
     () => ({
       query: searchInput,
       setQuery: setSearchInput,
-      debouncedQuery,
       category,
       setCategory,
       filters,
@@ -91,7 +78,7 @@ export const SearchProvider = ({
       setAutoFocus,
       active: true
     }),
-    [searchInput, debouncedQuery, category, filters, bpmType, autoFocus]
+    [searchInput, category, filters, bpmType, autoFocus]
   )
 
   return (
@@ -99,11 +86,6 @@ export const SearchProvider = ({
       {children}
     </SearchContext.Provider>
   )
-}
-
-export const useSearchDebouncedQuery = () => {
-  const { debouncedQuery } = useContext(SearchContext)
-  return debouncedQuery
 }
 
 export const useIsEmptySearch = () => {


### PR DESCRIPTION
### Description

* Disable autocorrect on search input which prevents search clearing.
* Use local state to show input changes before debouncing it and setting it in search context.
* Fix filter pill behavior where multiple filters appear active.
* Add paper background to better highlight skeletons
* Fix layout from ProgressiveScrollView
* Make sure header right search icon switches to Explore tab and autofocuses instead of using the stack it's on.
* Fixes search results empty state without recent searches. And some layout issues around that.
* Collapse header when searching.
* Only scroll content after header collapses and fix some scrolling behavior

Fixes PE-6356
Fixes PE-6396
Fixes PE-6371
Fixes PE-6365
Fixes PE-6402
Fixes PE-6373
Fixes PE-6404
Fixes PE-6399
Fixes PE-6409

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Added logs to search input changes and confirmed it's updating faster and able to clear search immediately after typing.