### PR TITLE
Fix album edit crashing - use playlist_contents for trackIds

### DIFF
--- a/packages/common/src/api/tan-query/batchers/getCollectionsBatcher.ts
+++ b/packages/common/src/api/tan-query/batchers/getCollectionsBatcher.ts
@@ -1,6 +1,6 @@
 import { Id, OptionalId } from '@audius/sdk'
 import { create, keyResolver, windowScheduler } from '@yornaath/batshit'
-import { memoize, omit } from 'lodash'
+import { memoize } from 'lodash'
 
 import { userCollectionMetadataFromSDK } from '~/adapters/collection'
 import { transformAndCleanList } from '~/adapters/utils'
@@ -29,17 +29,11 @@ export const getCollectionsBatcher = memoize(
           userCollectionMetadataFromSDK
         )
 
-        primeCollectionData({
+        return primeCollectionData({
           collections,
           queryClient,
           skipQueryData: true
         })
-
-        const tqCollections: TQCollection[] = collections.map((c) => ({
-          ...omit(c, ['tracks', 'user']),
-          trackIds: c.playlist_contents?.track_ids.map((t) => t.track) ?? []
-        }))
-        return tqCollections
       },
       resolver: keyResolver('playlist_id'),
       scheduler: windowScheduler(10)

--- a/packages/common/src/api/tan-query/utils/primeCollectionData.ts
+++ b/packages/common/src/api/tan-query/utils/primeCollectionData.ts
@@ -60,7 +60,8 @@ export const primeCollectionDataInternal = ({
     ) {
       const tqCollection = {
         ...omit(collection, ['tracks', 'user']),
-        trackIds: collection.tracks?.map((t) => t.track_id) ?? []
+        trackIds:
+          collection.playlist_contents?.track_ids?.map((t) => t.track) ?? []
       } as TQCollection
       queryClient.setQueryData(
         getCollectionQueryKey(collection.playlist_id),

--- a/packages/common/src/api/tan-query/utils/primeCollectionData.ts
+++ b/packages/common/src/api/tan-query/utils/primeCollectionData.ts
@@ -2,9 +2,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { omit } from 'lodash'
 import { getContext } from 'typed-redux-saga'
 
-import { Kind } from '~/models'
 import { CollectionMetadata, UserCollectionMetadata } from '~/models/Collection'
-import { EntriesByKind } from '~/store/cache/types'
 
 import { getCollectionQueryKey } from '../collection/useCollection'
 import { getCollectionByPermalinkQueryKey } from '../collection/useCollectionByPermalink'
@@ -23,33 +21,13 @@ export const primeCollectionData = ({
   queryClient: QueryClient
   forceReplace?: boolean
   skipQueryData?: boolean
-}) => {
-  primeCollectionDataInternal({
-    collections,
-    queryClient,
-    forceReplace,
-    skipQueryData
-  })
-  return collections
-}
-
-export const primeCollectionDataInternal = ({
-  collections,
-  queryClient,
-  forceReplace = false,
-  skipQueryData = false
-}: {
-  collections: (UserCollectionMetadata | CollectionMetadata)[]
-  queryClient: QueryClient
-  forceReplace?: boolean
-  skipQueryData?: boolean
-}): EntriesByKind => {
-  // Set up entries for Redux
-  const entries: EntriesByKind = {
-    [Kind.USERS]: {}
-  }
-
-  collections.forEach((collection) => {
+}): TQCollection[] => {
+  return collections.map((collection) => {
+    const tqCollection = {
+      ...omit(collection, ['tracks', 'user']),
+      trackIds:
+        collection.playlist_contents?.track_ids?.map((t) => t.track) ?? []
+    } as TQCollection
     // Prime collection data only if it doesn't exist and skipQueryData is false
     if (
       forceReplace ||
@@ -58,11 +36,6 @@ export const primeCollectionDataInternal = ({
           getCollectionQueryKey(collection.playlist_id)
         ))
     ) {
-      const tqCollection = {
-        ...omit(collection, ['tracks', 'user']),
-        trackIds:
-          collection.playlist_contents?.track_ids?.map((t) => t.track) ?? []
-      } as TQCollection
       queryClient.setQueryData(
         getCollectionQueryKey(collection.playlist_id),
         tqCollection
@@ -92,22 +65,14 @@ export const primeCollectionDataInternal = ({
 
     // Prime track and user data from tracks in collection
     if (collection.tracks?.length) {
-      const trackEntries = primeTrackDataInternal({
+      primeTrackDataInternal({
         tracks: collection.tracks,
         queryClient,
         forceReplace
       })
-
-      if (trackEntries[Kind.USERS]) {
-        entries[Kind.USERS] = {
-          ...entries[Kind.USERS],
-          ...trackEntries[Kind.USERS]
-        }
-      }
     }
+    return tqCollection
   })
-
-  return entries
 }
 
 export function* primeCollectionDataSaga(


### PR DESCRIPTION
### Description

- Use .playlist_contents instead of .tracks since in some scenarios tracks will not be present and other parts of the codebase are using playlist_contents directly

### How Has This Been Tested?

web:stage - go to profile -> album -> edit