### PR TITLE
[PE-6393] Normalize users in the wallet account slices & dep redundant hooks

### DIFF
--- a/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
+++ b/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
@@ -6,7 +6,7 @@ import {
 } from '@solana/web3.js'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-import { useGetCurrentUser, useQueryContext } from '~/api'
+import { useCurrentAccountUser, useQueryContext } from '~/api'
 import { Feature } from '~/models'
 import {
   convertJupiterInstructions,
@@ -33,7 +33,7 @@ import { addUserBankToAtaInstructions, getSwapErrorResponse } from './utils'
 export const useSwapTokens = () => {
   const queryClient = useQueryClient()
   const { solanaWalletService, reportToSentry, audiusSdk } = useQueryContext()
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
 
   return useMutation<SwapTokensResult, Error, SwapTokensParams>({
     mutationFn: async (params): Promise<SwapTokensResult> => {

--- a/packages/common/src/api/tan-query/users/account/useWalletUser.ts
+++ b/packages/common/src/api/tan-query/users/account/useWalletUser.ts
@@ -4,7 +4,7 @@ import { omit } from 'lodash'
 
 import { accountFromSDK } from '~/adapters/user'
 import { primeUserData, useQueryContext } from '~/api/tan-query/utils'
-import { AccountUserMetadata, User, UserMetadata } from '~/models'
+import { AccountUserMetadata, User } from '~/models'
 
 import { QUERY_KEYS } from '../../queryKeys'
 import { QueryKey, SelectableQueryOptions } from '../../types'
@@ -12,7 +12,10 @@ import { useUser } from '../useUser'
 
 import { useWalletAddresses } from './useWalletAddresses'
 
-type NormalizedAccountUserMetadata = Omit<AccountUserMetadata, 'user'> & {
+export type NormalizedAccountUserMetadata = Omit<
+  AccountUserMetadata,
+  'user'
+> & {
   userId: number | undefined
 }
 

--- a/packages/common/src/api/tan-query/users/account/useWalletUser.ts
+++ b/packages/common/src/api/tan-query/users/account/useWalletUser.ts
@@ -1,8 +1,9 @@
 import { AudiusSdk } from '@audius/sdk'
-import { useQuery } from '@tanstack/react-query'
+import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
+import { omit } from 'lodash'
 
 import { accountFromSDK } from '~/adapters/user'
-import { useQueryContext } from '~/api/tan-query/utils'
+import { primeUserData, useQueryContext } from '~/api/tan-query/utils'
 import { AccountUserMetadata, UserMetadata } from '~/models'
 
 import { QUERY_KEYS } from '../../queryKeys'
@@ -10,17 +11,22 @@ import { QueryKey, SelectableQueryOptions } from '../../types'
 
 import { useWalletAddresses } from './useWalletAddresses'
 
+type NormalizedAccountUserMetadata = Omit<AccountUserMetadata, 'user'> & {
+  userId: number | undefined
+}
+
 export const getWalletAccountQueryKey = (wallet: string | null | undefined) =>
   [
     QUERY_KEYS.account,
     QUERY_KEYS.walletAccount,
     wallet
-  ] as unknown as QueryKey<AccountUserMetadata | null>
+  ] as unknown as QueryKey<NormalizedAccountUserMetadata | null>
 
 // This queryFn is separate in order to be used in sagas
 export const getWalletAccountQueryFn = async (
   wallet: string,
-  sdk: AudiusSdk
+  sdk: AudiusSdk,
+  queryClient: QueryClient
 ) => {
   const { data } = await sdk.full.users.getUserAccount({
     wallet
@@ -31,29 +37,36 @@ export const getWalletAccountQueryFn = async (
     return null
   }
 
-  const account = accountFromSDK(data)
-  return account
+  const accountData = accountFromSDK(data)
+  if (accountData?.user) {
+    primeUserData({ users: [accountData.user], queryClient })
+  }
+  return {
+    ...omit(accountData, ['user']),
+    userId: accountData?.user?.user_id
+  }
 }
 
 /**
  * Hook to get the currently logged in user's data
  */
 export const useWalletAccount = <
-  TResult = AccountUserMetadata | null | undefined
+  TResult = NormalizedAccountUserMetadata | null | undefined
 >(
   wallet: string | null | undefined,
   options?: SelectableQueryOptions<
-    AccountUserMetadata | null | undefined,
+    NormalizedAccountUserMetadata | null | undefined,
     TResult
   >
 ) => {
   const { audiusSdk } = useQueryContext()
+  const queryClient = useQueryClient()
 
   return useQuery({
     queryKey: getWalletAccountQueryKey(wallet),
     queryFn: async () => {
       const sdk = await audiusSdk()
-      return await getWalletAccountQueryFn(wallet!, sdk)
+      return await getWalletAccountQueryFn(wallet!, sdk, queryClient)
     },
     ...options,
     staleTime: Infinity,
@@ -63,28 +76,10 @@ export const useWalletAccount = <
 }
 
 // Some helper selectors - these pull the current wallet addresses out of redux for you
-// NOTE: currentUser means the user that we are currently auth-ed into - i.e. the managed user
-export const useGetCurrentUser = <TResult = UserMetadata | undefined>(
-  options?: SelectableQueryOptions<
-    AccountUserMetadata | null | undefined,
-    TResult
-  >
-) => {
-  const { data: walletAddresses } = useWalletAddresses()
-  const { currentUser } = walletAddresses ?? {}
-
-  return useWalletAccount<TResult>(currentUser, {
-    select: (data: AccountUserMetadata | null | undefined): TResult =>
-      data?.user as TResult,
-    ...options
-  })
-}
-
-// Some helper selectors - these pull the current wallet addresses out of redux for you
 // NOTE: web3User means the user that signed in originally (i.e. could be a manager)
-export const useGetCurrentWeb3User = <TResult = UserMetadata | undefined>(
+export const useCurrentWeb3Account = <TResult = UserMetadata | undefined>(
   options?: SelectableQueryOptions<
-    AccountUserMetadata | null | undefined,
+    NormalizedAccountUserMetadata | null | undefined,
     TResult
   >
 ) => {
@@ -92,8 +87,8 @@ export const useGetCurrentWeb3User = <TResult = UserMetadata | undefined>(
   const { web3User } = walletAddresses ?? {}
 
   return useWalletAccount<TResult>(web3User, {
-    select: (data: AccountUserMetadata | null | undefined): TResult =>
-      data?.user as TResult,
+    select: (data: NormalizedAccountUserMetadata | null | undefined): TResult =>
+      data?.userId as TResult,
     ...options
   })
 }

--- a/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
+++ b/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
@@ -4,7 +4,7 @@ import { ChatBlast, ChatBlastAudience, OptionalHashId } from '@audius/sdk'
 
 import {
   useCollection,
-  useGetCurrentUser,
+  useCurrentAccountUser,
   usePurchasersCount,
   useRemixersCount,
   useTrack
@@ -27,7 +27,8 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
     ? OptionalHashId.parse(audienceContentId)
     : undefined
 
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
+  console.log({ user })
   const { data: trackTitle } = useTrack(decodedContentId, {
     enabled: !!decodedContentId && audienceContentType === 'track',
     select: (track) => track.title

--- a/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
+++ b/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
@@ -28,7 +28,6 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
     : undefined
 
   const { data: user } = useCurrentAccountUser()
-  console.log({ user })
   const { data: trackTitle } = useTrack(decodedContentId, {
     enabled: !!decodedContentId && audienceContentType === 'track',
     select: (track) => track.title

--- a/packages/common/src/hooks/chats/useFirstAvailableBlastAudience.ts
+++ b/packages/common/src/hooks/chats/useFirstAvailableBlastAudience.ts
@@ -2,7 +2,11 @@ import { useMemo } from 'react'
 
 import { ChatBlastAudience } from '@audius/sdk'
 
-import { useCurrentAccountUser, usePurchasersCount, useRemixersCount } from '~/api'
+import {
+  useCurrentAccountUser,
+  usePurchasersCount,
+  useRemixersCount
+} from '~/api'
 
 export const useFirstAvailableBlastAudience = () => {
   const { data: user } = useCurrentAccountUser()

--- a/packages/common/src/hooks/chats/useFirstAvailableBlastAudience.ts
+++ b/packages/common/src/hooks/chats/useFirstAvailableBlastAudience.ts
@@ -2,10 +2,10 @@ import { useMemo } from 'react'
 
 import { ChatBlastAudience } from '@audius/sdk'
 
-import { useGetCurrentUser, usePurchasersCount, useRemixersCount } from '~/api'
+import { useCurrentAccountUser, usePurchasersCount, useRemixersCount } from '~/api'
 
 export const useFirstAvailableBlastAudience = () => {
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
 
   const { data: purchasersCount } = usePurchasersCount()
   const { data: remixersCount } = useRemixersCount()

--- a/packages/common/src/hooks/purchaseContent/usePurchaseContentFormConfiguration.ts
+++ b/packages/common/src/hooks/purchaseContent/usePurchaseContentFormConfiguration.ts
@@ -6,7 +6,7 @@ import BN from 'bn.js'
 import { useDispatch, useSelector } from 'react-redux'
 import { z } from 'zod'
 
-import { useCurrentAccount, useGetCurrentUser, useUSDCBalance } from '~/api'
+import { useCurrentAccount, useCurrentAccountUser, useUSDCBalance } from '~/api'
 import { useQueryContext } from '~/api/tan-query/utils/QueryContext'
 import { UserCollectionMetadata } from '~/models'
 import { PurchaseMethod, PurchaseVendor } from '~/models/PurchaseContent'
@@ -72,7 +72,7 @@ export const usePurchaseContentFormConfiguration = ({
   const { data: guestEmail } = useCurrentAccount({
     select: (account) => account?.guestEmail
   })
-  const { data: currentUser } = useGetCurrentUser({})
+  const { data: currentUser } = useCurrentAccountUser()
   const { isEnabled: guestCheckoutEnabled } = useFeatureFlag(
     FeatureFlags.GUEST_CHECKOUT
   )

--- a/packages/common/src/hooks/useAccountSwitcher.ts
+++ b/packages/common/src/hooks/useAccountSwitcher.ts
@@ -1,13 +1,13 @@
 import { useCallback } from 'react'
 
-import { useCurrentUserId, useGetCurrentWeb3User } from '~/api'
+import { useCurrentUserId, useCurrentWeb3Account } from '~/api'
 import { useAppContext } from '~/context'
 import { Name } from '~/models/Analytics'
 import { UserMetadata } from '~/models/User'
 
 export const useAccountSwitcher = () => {
   const { localStorage } = useAppContext()
-  const { data: currentWeb3User } = useGetCurrentWeb3User({})
+  const { data: currentWeb3User } = useCurrentWeb3Account()
   const {
     analytics: { make, track }
   } = useAppContext()
@@ -54,7 +54,7 @@ export const useAccountSwitcher = () => {
 
 /** Determines if we are in Manager Mode, i.e. the current user is not the logged-in user */
 export const useIsManagedAccount = () => {
-  const { data: currentWeb3User } = useGetCurrentWeb3User({})
+  const { data: currentWeb3User } = useCurrentWeb3Account()
   const { data: currentUserId } = useCurrentUserId()
   return (
     !!currentWeb3User &&

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -122,7 +122,8 @@ function* initializeMetricsForUser({
   if (accountUser && accountUser.handle && web3WalletAddress) {
     const accountData = (yield* call([queryClient, queryClient.fetchQuery], {
       queryKey: getWalletAccountQueryKey(web3WalletAddress),
-      queryFn: async () => getWalletAccountQueryFn(web3WalletAddress, sdk),
+      queryFn: async () =>
+        getWalletAccountQueryFn(web3WalletAddress, sdk, queryClient),
       staleTime: Infinity,
       gcTime: Infinity
     })) as AccountUserMetadata | undefined
@@ -223,7 +224,7 @@ export function* fetchAccountAsync({
   try {
     accountData = (yield* call([queryClient, queryClient.fetchQuery], {
       queryKey: getWalletAccountQueryKey(wallet),
-      queryFn: async () => getWalletAccountQueryFn(wallet!, sdk),
+      queryFn: async () => getWalletAccountQueryFn(wallet!, sdk, queryClient),
       staleTime: Infinity,
       gcTime: Infinity
     })) as AccountUserMetadata | undefined

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -19,7 +19,8 @@ import {
   queryCurrentAccount,
   queryCurrentUserId,
   primeUserData,
-  getUserQueryKey
+  getUserQueryKey,
+  NormalizedAccountUserMetadata
 } from '~/api'
 import { getAccountStatusQueryKey } from '~/api/tan-query/users/account/useAccountStatus'
 import { AccountUserMetadata, ErrorLevel, Status, UserMetadata } from '~/models'
@@ -232,7 +233,7 @@ export function* fetchAccountAsync({
     const normalizedAccountData = {
       ...omit(accountData, ['user']),
       userId: accountData?.user?.user_id
-    }
+    } as NormalizedAccountUserMetadata
     queryClient.setQueryData(
       getWalletAccountQueryKey(wallet!),
       normalizedAccountData

--- a/packages/mobile/src/components/drawers/ArtistPickConfirmationDrawer.tsx
+++ b/packages/mobile/src/components/drawers/ArtistPickConfirmationDrawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import { useGetCurrentUser } from '@audius/common/api'
+import { useCurrentAccountUser } from '@audius/common/api'
 import { tracksSocialActions, useArtistPickModal } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
 
@@ -32,7 +32,7 @@ const { setArtistPick, unsetArtistPick } = tracksSocialActions
 export const ArtistPickConfirmationDrawer = () => {
   const { data } = useArtistPickModal()
   const { trackId } = data
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
 
   const dispatch = useDispatch()
 

--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { useGetCurrentUser } from '@audius/common/api'
+import { useCurrentAccountUser } from '@audius/common/api'
 import {
   usePurchasersAudience,
   useRemixersAudience
@@ -73,7 +73,7 @@ const LabelWithCount = (props: {
 }
 
 const FollowersMessageField = () => {
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
   const [{ value: targetAudience }] = useField(TARGET_AUDIENCE_FIELD)
   const isSelected = targetAudience === ChatBlastAudience.FOLLOWERS
 
@@ -96,7 +96,7 @@ const FollowersMessageField = () => {
 }
 
 const TipSupportersMessageField = () => {
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
   const [{ value: targetAudience }] = useField(TARGET_AUDIENCE_FIELD)
   const isSelected = targetAudience === ChatBlastAudience.TIPPERS
   const isDisabled = user?.supporter_count === 0

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -592,7 +592,8 @@ function* signUp() {
                 [queryClient, queryClient.fetchQuery],
                 {
                   queryKey: getWalletAccountQueryKey(wallet),
-                  queryFn: async () => getWalletAccountQueryFn(wallet!, sdk),
+                  queryFn: async () =>
+                    getWalletAccountQueryFn(wallet!, sdk, queryClient),
                   staleTime: Infinity,
                   gcTime: Infinity
                 }
@@ -904,7 +905,7 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
     const account = (yield* call([queryClient, queryClient.fetchQuery], {
       queryKey: getWalletAccountQueryKey(signInResponse.walletAddress),
       queryFn: async () =>
-        getWalletAccountQueryFn(signInResponse.walletAddress, sdk),
+        getWalletAccountQueryFn(signInResponse.walletAddress, sdk, queryClient),
       staleTime: Infinity,
       gcTime: Infinity
     })) as AccountUserMetadata | undefined

--- a/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
+++ b/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 
 import {
   useCurrentUserId,
-  useGetCurrentUser,
+  useCurrentAccountUser,
   useUserAlbums,
   useUserPlaylists
 } from '@audius/common/api'
@@ -64,7 +64,7 @@ const AddToCollectionModal = () => {
   const trackId = useSelector(getTrackId)
   const trackTitle = useSelector(getTrackTitle)
   const isAlbumType = collectionType === 'album'
-  const { data: currentUserHandle } = useGetCurrentUser({
+  const { data: currentUserHandle } = useCurrentAccountUser({
     select: (data) => data?.user.handle
   })
   const [searchValue, setSearchValue] = useState('')

--- a/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
+++ b/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
@@ -65,7 +65,7 @@ const AddToCollectionModal = () => {
   const trackTitle = useSelector(getTrackTitle)
   const isAlbumType = collectionType === 'album'
   const { data: currentUserHandle } = useCurrentAccountUser({
-    select: (data) => data?.user.handle
+    select: (user) => user?.handle
   })
   const [searchValue, setSearchValue] = useState('')
   const debouncedSearchValue = useDebounce(searchValue, 300)

--- a/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
+++ b/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
@@ -4,7 +4,7 @@ import {
   selectIsAccountComplete,
   useCurrentAccountUser,
   useCurrentUserId,
-  useGetCurrentWeb3User,
+  useCurrentWeb3Account,
   useManagedAccounts
 } from '@audius/common/api'
 import { useAccountSwitcher } from '@audius/common/hooks'
@@ -20,7 +20,7 @@ export const AccountSwitcher = () => {
   })
   const [checkedAccess, setCheckedAccess] = useState(false)
 
-  const { data: currentWeb3User } = useGetCurrentWeb3User({
+  const { data: currentWeb3User } = useCurrentWeb3Account({
     enabled: isAccountComplete
   })
   const { data: currentUserId } = useCurrentUserId()

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -5,7 +5,6 @@ import {
   useCollection,
   useCurrentAccount,
   useCurrentAccountUser,
-  useGetCurrentUser,
   useTrack,
   useUser
 } from '@audius/common/api'
@@ -216,7 +215,7 @@ export const PremiumContentPurchaseModal = () => {
   const error = useSelector(getPurchaseContentError)
   const isUnlocking = !error && isContentPurchaseInProgress(stage)
   const presetValues = usePayExtraPresets()
-  const { data: currentUser } = useGetCurrentUser({})
+  const { data: currentUser } = useCurrentAccountUser()
   const { isEnabled: guestCheckoutEnabled } = useFeatureFlag(
     FeatureFlags.GUEST_CHECKOUT
   )

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -1,4 +1,4 @@
-import { useGetCurrentUser } from '@audius/common/api'
+import { useCurrentAccountUser } from '@audius/common/api'
 import {
   useFirstAvailableBlastAudience,
   usePurchasersAudience,
@@ -191,7 +191,7 @@ const LabelWithCount = (props: {
 }
 
 const FollowersMessageField = () => {
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
   const [{ value }] = useField(TARGET_AUDIENCE_FIELD)
   const selected = value === ChatBlastAudience.FOLLOWERS
   const isDisabled = user?.follower_count === 0
@@ -219,7 +219,7 @@ const FollowersMessageField = () => {
 }
 
 const TipSupportersMessageField = () => {
-  const { data: user } = useGetCurrentUser({})
+  const { data: user } = useCurrentAccountUser()
   const [{ value }] = useField(TARGET_AUDIENCE_FIELD)
   const selected = value === ChatBlastAudience.TIPPERS
   const isDisabled = user?.supporter_count === 0

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
@@ -3,7 +3,7 @@ import { FormEvent, useCallback, useMemo, useState } from 'react'
 import { accountFromSDK } from '@audius/common/adapters'
 import {
   useCurrentUserId,
-  useGetCurrentWeb3User,
+  useCurrentWeb3Account,
   useManagedAccounts,
   useCurrentAccountUser
 } from '@audius/common/api'
@@ -261,7 +261,7 @@ export const OAuthLoginPage = () => {
     dispatch(signOut({ fromOAuth: true }))
   }
 
-  const { data: currentWeb3User } = useGetCurrentWeb3User({})
+  const { data: currentWeb3User } = useCurrentWeb3Account()
   const { data: currentUserId } = useCurrentUserId()
   const { switchAccount } = useAccountSwitcher()
 

--- a/packages/web/src/pages/pay-and-earn-page/components/SalesTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/SalesTab.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import {
-  useGetCurrentWeb3User,
+  useCurrentWeb3Account,
   useSales as useSalesQuery,
   useSalesCount,
   useCurrentUserId
@@ -88,7 +88,7 @@ export const useSales = () => {
   const { data: userId } = useCurrentUserId()
   const dispatch = useDispatch()
   const isManagerMode = useIsManagedAccount()
-  const { data: currentWeb3User } = useGetCurrentWeb3User({})
+  const { data: currentWeb3User } = useCurrentWeb3Account()
 
   // Defaults: sort method = date, sort direction = desc
   const [sortMethod, setSortMethod] =

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext, useEffect } from 'react'
 
 import {
   useCurrentUserId,
-  useGetCurrentWeb3User,
+  useCurrentWeb3Account,
   useRemoveManager
 } from '@audius/common/api'
 import { useAppContext } from '@audius/common/context'
@@ -41,7 +41,7 @@ export const RemoveManagerConfirmationContent = ({
     isSuccess,
     isError
   } = useRemoveManager()
-  const { data: currentWeb3User } = useGetCurrentWeb3User({})
+  const { data: currentWeb3User } = useCurrentWeb3Account()
   const { data: currentUserId } = useCurrentUserId()
   const managerIsCurrentWeb3User = currentWeb3User?.user_id === managerUserId
   const { switchToWeb3User } = useAccountSwitcher()


### PR DESCRIPTION
### Description

- These walletAccount slices came from audius-query and strayed from the implementation of the account stuff, this brings them back together
- useGetCurrentUser is unnecessary, and something was bugged about it? Either way I deleted that
- Normalized the user data in the wallet account slices  

### How Has This Been Tested?

web:stage