### PR TITLE
Fix mobile profile screen

### DIFF
--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/AccountDetails.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/AccountDetails.tsx
@@ -40,9 +40,11 @@ export const AccountDetails = () => {
   const navigation = useAppDrawerNavigation()
 
   const handlePressAccount = useCallback(() => {
-    navigation.push('Profile', { handle: 'accountUser' })
-    drawerHelpers.closeDrawer()
-  }, [navigation, drawerHelpers])
+    if (handle) {
+      navigation.push('Profile', { handle })
+      drawerHelpers.closeDrawer()
+    }
+  }, [handle, navigation, drawerHelpers])
 
   return (
     <TouchableOpacity onPress={handlePressAccount}>


### PR DESCRIPTION
### Description
tan-query migration fallout - when clicking on left nav profile header to navigate to one's own profile, the screen was stuck on loading.

### How Has This Been Tested?

Tested on local ios stage