### PR TITLE
Add component error boundary to Avatar

### DIFF
--- a/packages/harmony/src/components/artwork/Artwork.tsx
+++ b/packages/harmony/src/components/artwork/Artwork.tsx
@@ -11,7 +11,8 @@ export type ArtworkProps = {
   borderWidth?: number
   'data-testid'?: string
   noLoading?: boolean
-} & Pick<ComponentProps<'img'>, 'src'> &
+  onError?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => void
+} & Pick<ComponentProps<'img'>, 'src' | 'onError'> &
   BoxProps
 
 /**
@@ -30,6 +31,7 @@ export const Artwork = (props: ArtworkProps) => {
     shadow,
     children,
     'data-testid': testId,
+    onError,
     ...other
   } = props
   const imgRef = useRef<HTMLImageElement | null>(null)
@@ -86,6 +88,10 @@ export const Artwork = (props: ArtworkProps) => {
             w='100%'
             onLoad={() => {
               setIsLoadingState(false)
+            }}
+            onError={(event) => {
+              setIsLoadingState(false)
+              onError?.(event)
             }}
             // @ts-ignore
             src={src}

--- a/packages/harmony/src/components/avatar/Avatar.tsx
+++ b/packages/harmony/src/components/avatar/Avatar.tsx
@@ -6,6 +6,8 @@ export type AvatarProps = ArtworkInnerProps & {
   variant?: 'default' | 'strong'
   size?: 'auto' | 'small' | 'medium' | 'large' | 'xl' | 'xxl'
   borderWidth?: 'thin' | 'default'
+  isLoading?: boolean
+  onError?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => void
 }
 
 const sizeMap = {
@@ -27,6 +29,9 @@ export const Avatar = (props: AvatarProps) => {
     variant,
     size = 'auto',
     borderWidth = size === 'small' ? 'thin' : 'default',
+    src,
+    isLoading,
+    onError,
     ...other
   } = props
 
@@ -38,6 +43,9 @@ export const Avatar = (props: AvatarProps) => {
       shadow={variant === 'strong' ? 'emphasis' : 'flat'}
       borderWidth={borderWidthMap[borderWidth]}
       css={variant === 'strong' ? { zIndex: 1 } : undefined}
+      src={src}
+      onError={onError}
+      isLoading={isLoading}
       {...other}
     />
   )

--- a/packages/web/src/components/error-wrapper/componentWithErrorBoundary.tsx
+++ b/packages/web/src/components/error-wrapper/componentWithErrorBoundary.tsx
@@ -1,0 +1,68 @@
+import React, { ReactNode, useCallback } from 'react'
+
+import { ErrorLevel } from '@audius/common/models'
+import {
+  ErrorBoundary,
+  ErrorBoundaryProps,
+  FallbackProps
+} from 'react-error-boundary'
+import { useDispatch } from 'react-redux'
+
+import { handleError as handleErrorAction } from 'store/errors/actions'
+
+interface ComponentWithErrorBoundaryOptions {
+  fallback?: ReactNode | null
+  /**
+   * Debugging name (for logs, error reporting)
+   */
+  name?: string
+}
+
+type HandleError = NonNullable<ErrorBoundaryProps['onError']>
+
+export function componentWithErrorBoundary<P extends object>(
+  WrappedComponent: React.ComponentType<P>,
+  options: ComponentWithErrorBoundaryOptions = {}
+) {
+  const {
+    fallback = null,
+    name = WrappedComponent.displayName || WrappedComponent.name || 'Unnamed'
+  } = options
+
+  const ComponentWithErrorBoundaryWrapper = (props: P) => {
+    const dispatch = useDispatch()
+
+    const handleError: HandleError = useCallback(
+      (error, errorInfo) => {
+        console.error(`ComponentErrorBoundary (${name}):`, error, errorInfo)
+        dispatch(
+          handleErrorAction({
+            name: `ComponentErrorBoundary: ${name}`,
+            message: error.message,
+            shouldRedirect: false,
+            additionalInfo: errorInfo,
+            level: ErrorLevel.Error
+          })
+        )
+      },
+      [dispatch]
+    )
+
+    const fallbackRender = useCallback((_: FallbackProps) => {
+      return React.isValidElement(fallback) ? fallback : <>{fallback}</>
+    }, [])
+
+    return (
+      <ErrorBoundary fallbackRender={fallbackRender} onError={handleError}>
+        <WrappedComponent {...props} />
+      </ErrorBoundary>
+    )
+  }
+
+  ComponentWithErrorBoundaryWrapper.displayName = `WithErrorBoundary(${name})`
+  if (WrappedComponent.displayName) {
+    ComponentWithErrorBoundaryWrapper.displayName += `|${WrappedComponent.displayName}`
+  }
+
+  return ComponentWithErrorBoundaryWrapper
+}


### PR DESCRIPTION
### Description

This pull request introduces component-level error boundaries and refines the fallback states of the Avatar component.

Key Changes:

- **Component Error Boundaries**: A new higher-order component, `componentWithErrorBoundary`, has been added to `packages/web/src/components/error-wrapper/componentWithErrorBoundary.tsx`. This HOC wraps components to catch rendering errors, logs them, and dispatches an error action to the Redux store, providing a robust error handling mechanism.
- **Avatar Component Enhancements**:
  - The `Avatar` component in `packages/web/src/components/avatar/Avatar.tsx` has been refactored. The core logic is now in `AvatarContent`, which is then wrapped by the `componentWithErrorBoundary` HOC.
  - Error handling for image loading within `AvatarContent` has been improved. It now manages a `hasError` state to switch to a fallback empty profile picture if an image fails to load.
  - The `HarmonyAvatar` component within `packages/harmony/src/components/avatar/Avatar.tsx` now accepts `isLoading` and `onError` props, which are propagated to the underlying `Artwork` component.
- **Artwork Component Updates**: The `Artwork` component in `packages/harmony/src/components/artwork/Artwork.tsx` now handles the `onError` event, setting its loading state to false and propagating the error.

### How Has This Been Tested?

`npm run web:prod`

- Manually threw an error during rendering to test fallback state
- Manually used messed up URL to test fallback state
