### PR TITLE
Fix mobile build dependencies step stall

### DIFF
--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -45,7 +45,11 @@ mobile-prepare-ios:
           echo export SENTRY_BINARY=/usr/local/bin/sentry-cli >> "$BASH_ENV"
     - run:
         name: Build dependencies
-        command: npx turbo run build --filter=@audius/mobile
+        command: |
+          (while true; do echo "Still building (or waiting for turbo cache) at $(date)"; sleep 10; done) &
+          KEEP_ALIVE_PID=$!
+          npx turbo run build --filter=@audius/mobile
+          kill $KEEP_ALIVE_PID
     - run:
         name: create bundle
         command: cd packages/mobile && npx turbo run bundle:ios
@@ -162,12 +166,11 @@ mobile-prepare-android:
         command: cd packages/mobile/android && sudo bundle update fastlane
     - run:
         name: Build dependencies
-        command: npx turbo run build --filter=@audius/mobile
-    - run:
-        name: fetch app fastlane json config to upload to play store
         command: |
-          echo "$FASTLANE_PLAYSTORE_JSON" > packages/mobile/android/app/api.txt
-          base64 --decode packages/mobile/android/app/api.txt > packages/mobile/android/app/api.json
+          (while true; do echo "Still building (or waiting for turbo cache) at $(date)"; sleep 10; done) &
+          KEEP_ALIVE_PID=$!
+          npx turbo run build --filter=@audius/mobile
+          kill $KEEP_ALIVE_PID
 
 # Build the android app
 mobile-build-android:
@@ -269,7 +272,11 @@ mobile-release-saga-dapp-store:
           pnpm install
     - run:
         name: Build dependencies
-        command: npx turbo run build --filter=@audius/mobile
+        command: |
+          (while true; do echo "Still building (or waiting for turbo cache) at $(date)"; sleep 10; done) &
+          KEEP_ALIVE_PID=$!
+          npx turbo run build --filter=@audius/mobile
+          kill $KEEP_ALIVE_PID
     - run:
         name: Install solana
         command: |

--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -45,7 +45,6 @@ mobile-prepare-ios:
           echo export SENTRY_BINARY=/usr/local/bin/sentry-cli >> "$BASH_ENV"
     - run:
         name: Build dependencies
-        no_output_timeout: 60m
         command: npx turbo run build --filter=@audius/mobile
     - run:
         name: create bundle
@@ -163,7 +162,6 @@ mobile-prepare-android:
         command: cd packages/mobile/android && sudo bundle update fastlane
     - run:
         name: Build dependencies
-        no_output_timeout: 60m
         command: npx turbo run build --filter=@audius/mobile
     - run:
         name: fetch app fastlane json config to upload to play store
@@ -271,7 +269,6 @@ mobile-release-saga-dapp-store:
           pnpm install
     - run:
         name: Build dependencies
-        no_output_timeout: 60m
         command: npx turbo run build --filter=@audius/mobile
     - run:
         name: Install solana

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -8,6 +8,7 @@
     "android:release": "ENVFILE=.env.prod turbo run android -- --mode=prodRelease",
     "android:stage": "ENVFILE=.env.stage turbo run android -- --mode=stagingDebug --appIdSuffix staging",
     "android": "react-native run-android",
+    "build": "echo 'No build step for mobile'",
     "build:e2e": "detox build --configuration ios.sim.debug",
     "build:ios:stage": "xcodebuild -workspace ios/AudiusReactNative.xcworkspace -scheme Staging -sdk iphoneos -configuration AppStoreDistribution archive -archivePath $PWD/build/AudiusReactNative.xcarchive",
     "build:ios": "xcodebuild -workspace ios/AudiusReactNative.xcworkspace -scheme AudiusReactNative -sdk iphoneos -configuration AppStoreDistribution archive -archivePath $PWD/build/AudiusReactNative.xcarchive",


### PR DESCRIPTION
### Description

Potentially fixes issue where "Build dependencies" step stalls out, which often affects Android

Example of the issue:
<img width="890" alt="image" src="https://github.com/user-attachments/assets/fa054954-9cb0-46d6-a3f9-22e6841186da" />
