### PR TITLE
[QA-2147] Fix user link with popover height

### DIFF
--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -76,14 +76,7 @@ export const ArtistPopover = ({
   }
 
   return (
-    <Component
-      className={cn(
-        className,
-        styles.popoverContainer,
-        'artistPopover',
-        containerClassName
-      )}
-    >
+    <Component className={cn(className, 'artistPopover', containerClassName)}>
       <Popover
         mouseEnterDelay={mouseEnterDelay}
         content={content}

--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -151,7 +151,8 @@ export const UserLink = (props: UserLinkProps) => {
           alignItems: 'center',
           lineHeight: 'normal',
           display: 'inline-flex',
-          flexWrap: 'nowrap'
+          // Negative margin is needed to fix user-link height
+          marginTop: '-4px'
         }}
       >
         <ArtistPopover


### PR DESCRIPTION
### Description

Fixes issue where popover user link height is 4px to large, causing track-tile layout issues, and likely layout issues in other places too.

Also removes unused style in artist-popover

Before:
<img width="497" alt="image" src="https://github.com/user-attachments/assets/eb789536-defc-4c77-adcb-455132cf28b1" />


After:
<img width="497" alt="image" src="https://github.com/user-attachments/assets/6143d1b8-f973-4ffa-8bc7-ee356c64a138" />
