### PR TITLE
[PE-6391] Actually fix confetti this time (localstorage account data issue)

### DIFF
--- a/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
@@ -13,6 +13,7 @@ import { AccountState } from '~/store'
 
 import { QUERY_KEYS } from '../../queryKeys'
 import { QueryKey, SelectableQueryOptions } from '../../types'
+import { getUserQueryKey } from '../useUser'
 
 import { getAccountStatusQueryKey } from './useAccountStatus'
 import { useWalletAddresses } from './useWalletAddresses'
@@ -31,7 +32,10 @@ const getLocalAccount = (
   const localAccountUser =
     localStorage.getAudiusAccountUserSync?.() as UserMetadata
   if (localAccount && localAccountUser) {
-    if (localAccountUser) {
+    if (
+      localAccountUser &&
+      !queryClient.getQueryData(getUserQueryKey(localAccountUser.user_id))
+    ) {
       primeUserData({ users: [localAccountUser], queryClient })
     }
     // feature-tan-query TODO: when removing account sagas,
@@ -47,7 +51,7 @@ const getLocalAccount = (
       walletAddresses: { currentUser: null, web3User: null },
       playlistLibrary: localAccount.playlistLibrary ?? null,
       trackSaveCount: localAccount.trackSaveCount,
-      guestEmail: null
+      guestEmail: localAccount.guestEmail
     } as AccountState
   }
   return null

--- a/packages/common/src/api/tan-query/users/account/useSyncLocalStorageUser.tsx
+++ b/packages/common/src/api/tan-query/users/account/useSyncLocalStorageUser.tsx
@@ -1,16 +1,23 @@
 import { PropsWithChildren, useEffect } from 'react'
 
-import { useCurrentAccountUser } from '~/api'
+import { useCurrentAccount, useCurrentAccountUser } from '~/api'
 import { LocalStorage } from '~/services'
 
 export const useSyncLocalStorageUser = (localStorage: LocalStorage) => {
   const { data: accountUser } = useCurrentAccountUser()
+  const { data: account } = useCurrentAccount()
 
   useEffect(() => {
     if (accountUser) {
       localStorage.setAudiusAccountUser(accountUser)
     }
   }, [accountUser, localStorage])
+
+  useEffect(() => {
+    if (account) {
+      localStorage.setAudiusAccount(account)
+    }
+  }, [account, localStorage])
 }
 
 export const SyncLocalStorageUserProvider = ({

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -390,34 +390,21 @@ function* setLocalStorageAccountAndUser(
     user: accountUser,
     playlist_library: playlistLibrary,
     playlists: collections,
-    guestEmail
+    guestEmail,
+    track_save_count: trackSaveCount
   } = account
   const localStorage = yield* getContext('localStorage')
 
-  const formattedAccount = {
+  const formattedAccount: Partial<AccountState> = {
     userId: accountUser.user_id,
     collections,
     playlistLibrary,
-    guestEmail
+    guestEmail,
+    trackSaveCount
   }
 
   yield* call([localStorage, localStorage.setAudiusAccount], formattedAccount)
   yield* call([localStorage, localStorage.setAudiusAccountUser], accountUser)
-}
-
-/** Used to synchronize account to localStorage when values in the slice
- * change.
- */
-function* syncAccountToLocalStorage() {
-  const localStorage = yield* getContext('localStorage')
-  const { userId, collections, playlistLibrary, guestEmail } =
-    (yield* call(queryCurrentAccount)) ?? {}
-  yield* call([localStorage, localStorage.setAudiusAccount], {
-    userId,
-    collections,
-    playlistLibrary,
-    guestEmail
-  })
 }
 
 function* recordIPIfNotRecent(handle: string): SagaIterator {
@@ -651,10 +638,6 @@ function* watchTikTokLogin() {
   yield* takeEvery(tikTokLogin.type, associateTikTokAccount)
 }
 
-function* watchUpdatePlaylistLibrary() {
-  yield* takeEvery(updatePlaylistLibrary.type, syncAccountToLocalStorage)
-}
-
 export function* watchFetchTrackCount() {
   yield* takeLatest(fetchHasTracks, handleFetchTrackCount)
 }
@@ -723,7 +706,6 @@ export default function sagas() {
     watchTikTokLogin,
     watchTwitterLogin,
     watchUploadTrack,
-    watchUpdatePlaylistLibrary,
     syncAccountToQueryClient
   ]
 }

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -16,7 +16,6 @@ import {
   getWalletAddressesQueryKey,
   queryAccountUser,
   getCurrentAccountQueryKey,
-  queryCurrentAccount,
   queryCurrentUserId,
   primeUserData,
   getUserQueryKey,


### PR DESCRIPTION
### Description

Fixes the confetti bug on staging web where if you have a 100% complete account your account first shows as "87% complete" then completes immediately. Localstorage account data was missing data which caused the profile to "complete" as it later loads in the full account. 

This was annoying to track down because it wasn't happening on local dev (only staging) until I realized it's just because of how slow the `web:stage` loads on first render - the account data was getting fully loaded in during that long load time. Was able to repro using a local compiled build.

### How Has This Been Tested?

`build:stage + serve`
