### PR TITLE
[QA-1758] Prevent bottom-bar translating above android keyboard

### DIFF
--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import type { BottomTabBarProps as RNBottomTabBarProps } from '@react-navigation/bottom-tabs'
 import type { BottomTabNavigationEventMap } from '@react-navigation/bottom-tabs/lib/typescript/src/types'
 import type { NavigationHelpers, ParamListBase } from '@react-navigation/native'
-import { Animated } from 'react-native'
+import { Animated, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { Flex } from '@audius/harmony-native'
@@ -102,11 +102,24 @@ export const BottomTabBar = (props: BottomTabBarProps) => {
     })
   }, [navigation])
 
+  const isAndroid = Platform.OS === 'android'
+
   return (
     <Animated.View
       style={[
-        { zIndex: 4, elevation: 4 },
-        interpolatePostion(translationAnim, insets.bottom)
+        {
+          zIndex: 4,
+          elevation: 4,
+          // If not absolutely positioned, the bottom tab bar will float above the keyboard
+          ...(isAndroid && {
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            backgroundColor: 'white'
+          })
+        },
+        !isAndroid && interpolatePostion(translationAnim, insets.bottom)
       ]}
     >
       <Flex

--- a/packages/mobile/src/components/core/Screen/ScreenContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenContent.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import React, { type ReactNode } from 'react'
 
 import { reachabilitySelectors } from '@audius/common/store'
 import Animated, { FadeIn } from 'react-native-reanimated'


### PR DESCRIPTION
### Description

Fixes issue where bottom bar translates above android keyboard, which gives us less space for content.