### PR TITLE
[API-166] Add recently listed premium tracks API to SDK

### DIFF
--- a/.changeset/fifty-parrots-repeat.md
+++ b/.changeset/fifty-parrots-repeat.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": minor
+---
+
+add recently listed premium tracks API

--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -2042,3 +2042,31 @@ class GetTrackAccessInfo(Resource):
         track["stream_conditions"] = stream_conditions
         track["download_conditions"] = download_conditions
         return success_response(track)
+
+
+@ns.route("/recent_premium")
+class GetRecentPremiumTracks(Resource):
+    @record_metrics
+    @ns.doc(
+        id="Get Recent Premium Tracks",
+        description="Gets the most recently listed premium tracks",
+    )
+    @ns.expect(pagination_with_current_user_parser)
+    @ns.marshal_with(tracks_response)
+    def get(self):
+        # This is stubbed, just generating docs
+        abort_not_found("recent_premium", ns)
+
+
+@full_ns.route("/recent_premium")
+class GetRecentPremiumTracksFull(Resource):
+    @record_metrics
+    @full_ns.doc(
+        id="Get Recent Premium Tracks",
+        description="Gets the most recently listed premium tracks",
+    )
+    @full_ns.expect(pagination_with_current_user_parser)
+    @full_ns.marshal_with(full_tracks_response)
+    def get(self):
+        # This is stubbed, just generating docs
+        abort_not_found("recent_premium", full_ns)

--- a/packages/sdk/src/sdk/api/generated/default/apis/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/TracksApi.ts
@@ -71,6 +71,12 @@ export interface GetBulkTracksRequest {
     id?: Array<string>;
 }
 
+export interface GetRecentPremiumTracksRequest {
+    offset?: number;
+    limit?: number;
+    userId?: string;
+}
+
 export interface GetTrackRequest {
     trackId: string;
 }
@@ -253,6 +259,45 @@ export class TracksApi extends runtime.BaseAPI {
      */
     async getBulkTracks(params: GetBulkTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<TracksResponse> {
         const response = await this.getBulkTracksRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
+     * Gets the most recently listed premium tracks
+     */
+    async getRecentPremiumTracksRaw(params: GetRecentPremiumTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<TracksResponse>> {
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/tracks/recent_premium`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => TracksResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the most recently listed premium tracks
+     */
+    async getRecentPremiumTracks(params: GetRecentPremiumTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<TracksResponse> {
+        const response = await this.getRecentPremiumTracksRaw(params, initOverrides);
         return await response.value();
     }
 

--- a/packages/sdk/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -88,6 +88,12 @@ export interface GetNFTGatedTrackSignaturesRequest {
     tokenIds?: Array<string>;
 }
 
+export interface GetRecentPremiumTracksRequest {
+    offset?: number;
+    limit?: number;
+    userId?: string;
+}
+
 export interface GetRecommendedTracksRequest {
     limit?: number;
     genre?: string;
@@ -444,6 +450,45 @@ export class TracksApi extends runtime.BaseAPI {
      */
     async getNFTGatedTrackSignatures(params: GetNFTGatedTrackSignaturesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<NftGatedTrackSignaturesResponse> {
         const response = await this.getNFTGatedTrackSignaturesRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
+     * Gets the most recently listed premium tracks
+     */
+    async getRecentPremiumTracksRaw(params: GetRecentPremiumTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTracksResponse>> {
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/tracks/recent_premium`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => FullTracksResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the most recently listed premium tracks
+     */
+    async getRecentPremiumTracks(params: GetRecentPremiumTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracksResponse> {
+        const response = await this.getRecentPremiumTracksRaw(params, initOverrides);
         return await response.value();
     }
 


### PR DESCRIPTION
### Description
Adds support to SDK for the `/tracks/recent_premium` endpoint. It's a pretty basic limit/offset thing that just returns a track list. Similar to the new explore endpoint, this is just a stub in discovery to allow us to generate the SDK code. We are in discussion about how to update the swagger spec without needing to do this. More on that next week.

### How Has This Been Tested?
N/A
