### PR TITLE
Update calculation to use fixed decimal

### DIFF
--- a/packages/common/src/services/Jupiter.ts
+++ b/packages/common/src/services/Jupiter.ts
@@ -1,3 +1,4 @@
+import { FixedDecimal } from '@audius/fixed-decimal'
 import {
   createJupiterApiClient,
   Instruction,
@@ -112,8 +113,8 @@ export const getJupiterQuoteByMint = async ({
 
   const amount =
     swapMode === 'ExactIn'
-      ? Math.ceil(amountUi * 10 ** inputDecimals)
-      : Math.floor(amountUi * 10 ** outputDecimals)
+      ? Number(new FixedDecimal(amountUi, inputDecimals).value.toString())
+      : Number(new FixedDecimal(amountUi, outputDecimals).value.toString())
 
   const quote = await jupiterInstance.quoteGet({
     inputMint,


### PR DESCRIPTION
### Description
Swaps were failing because of floating point miscalculations. Using fixed decimal now to prevent this. 

### How Has This Been Tested?

`npm run web:prod`

Try a swap with max amount and ensure it succeeds 
