### PR TITLE
[QA-1985] Remove multiselect prop to fix upload tag delete on click functionality

### DIFF
--- a/packages/web/src/components/data-entry/TagInput.jsx
+++ b/packages/web/src/components/data-entry/TagInput.jsx
@@ -153,7 +153,6 @@ const TagInput = ({
     <Tag
       className={cn({ [styles.flash]: displayFlashExistingTag === tag })}
       key={tag}
-      multiselect
       variant='default'
       onClick={(e) => deleteTag(tag, e)}
     >


### PR DESCRIPTION
### Description
It doesn't seem like the multiselect prop was doing anything for the tags in the upload flow, but was preventing the onClick handler so I removed it

### How Has This Been Tested?
Manually tested
