### PR TITLE
[API-167][API-229] Add user recommend tracks to sdk and fix urls for other explore endpoints

### DIFF
--- a/.changeset/strong-spies-hope.md
+++ b/.changeset/strong-spies-hope.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": minor
+---
+
+Adds user recommended tracks endpoint to SDK

--- a/packages/discovery-provider/src/api/v1/explore.py
+++ b/packages/discovery-provider/src/api/v1/explore.py
@@ -32,7 +32,7 @@ best_selling_parser.add_argument(
 )
 
 
-@ns.route("/best_selling")
+@ns.route("/best-selling")
 class BestSelling(Resource):
     @ns.doc(
         id="Get Best Selling",
@@ -47,7 +47,7 @@ class BestSelling(Resource):
         abort_not_found("best_selling", ns)
 
 
-@full_ns.route("/best_selling")
+@full_ns.route("/best-selling")
 class FullBestSelling(Resource):
     @full_ns.doc(
         id="Get Full Best Selling",

--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -2044,7 +2044,7 @@ class GetTrackAccessInfo(Resource):
         return success_response(track)
 
 
-@ns.route("/recent_premium")
+@ns.route("/recent-premium")
 class GetRecentPremiumTracks(Resource):
     @record_metrics
     @ns.doc(
@@ -2058,7 +2058,7 @@ class GetRecentPremiumTracks(Resource):
         abort_not_found("recent_premium", ns)
 
 
-@full_ns.route("/recent_premium")
+@full_ns.route("/recent-premium")
 class GetRecentPremiumTracksFull(Resource):
     @record_metrics
     @full_ns.doc(

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -3272,3 +3272,44 @@ class FullUserComments(Resource):
         )
 
         return success_response_with_related(user_comments)
+
+
+recommended_tracks_parser = pagination_with_current_user_parser.copy()
+recommended_tracks_parser.add_argument(
+    "time_range",
+    required=False,
+    default="week",
+    choices=("week", "month", "allTime"),
+    type=str,
+    description="The time range for the recommended tracks",
+)
+
+
+@ns.route("/<string:id>/recommended-tracks")
+class UserRecommendedTracks(Resource):
+    @ns.doc(
+        id="Get User Recommended Tracks",
+        description="Gets the recommended tracks for the user",
+        params={"id": "A User ID"},
+        responses={200: "Success", 400: "Bad request", 500: "Server error"},
+    )
+    @ns.expect(recommended_tracks_parser)
+    @ns.marshal_with(tracks_response)
+    def get(self, id):
+        # This is stubbed, just generating docs
+        abort_not_found("recommended_tracks", ns)
+
+
+@full_ns.route("/<string:id>/recommended-tracks")
+class FullUserRecommendedTracks(Resource):
+    @ns.doc(
+        id="Get User Recommended Tracks",
+        description="Gets the recommended tracks for the user",
+        params={"id": "A User ID"},
+        responses={200: "Success", 400: "Bad request", 500: "Server error"},
+    )
+    @full_ns.expect(recommended_tracks_parser)
+    @full_ns.marshal_with(full_tracks_response)
+    def get(self, id):
+        # This is stubbed, just generating docs
+        abort_not_found("recommended_tracks", full_ns)

--- a/packages/sdk/src/sdk/api/generated/default/apis/ExploreApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/ExploreApi.ts
@@ -62,7 +62,7 @@ export class ExploreApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/explore/best_selling`,
+            path: `/explore/best-selling`,
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/packages/sdk/src/sdk/api/generated/default/apis/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/TracksApi.ts
@@ -284,7 +284,7 @@ export class TracksApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/tracks/recent_premium`,
+            path: `/tracks/recent-premium`,
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -346,6 +346,14 @@ export interface GetUserMonthlyTrackListensRequest {
     endTime: string;
 }
 
+export interface GetUserRecommendedTracksRequest {
+    id: string;
+    offset?: number;
+    limit?: number;
+    userId?: string;
+    timeRange?: GetUserRecommendedTracksTimeRangeEnum;
+}
+
 export interface GetUserTracksRemixedRequest {
     id: string;
     offset?: number;
@@ -1826,6 +1834,53 @@ export class UsersApi extends runtime.BaseAPI {
 
     /**
      * @hidden
+     * Gets the recommended tracks for the user
+     */
+    async getUserRecommendedTracksRaw(params: GetUserRecommendedTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<TracksResponse>> {
+        if (params.id === null || params.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter params.id was null or undefined when calling getUserRecommendedTracks.');
+        }
+
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.timeRange !== undefined) {
+            queryParameters['time_range'] = params.timeRange;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/users/{id}/recommended-tracks`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => TracksResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the recommended tracks for the user
+     */
+    async getUserRecommendedTracks(params: GetUserRecommendedTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<TracksResponse> {
+        const response = await this.getUserRecommendedTracksRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
      * Gets tracks owned by the user which have been remixed by another track
      */
     async getUserTracksRemixedRaw(params: GetUserTracksRemixedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserTracksRemixedResponse>> {
@@ -2051,6 +2106,15 @@ export const GetTracksByUserFilterTracksEnum = {
     Unlisted: 'unlisted'
 } as const;
 export type GetTracksByUserFilterTracksEnum = typeof GetTracksByUserFilterTracksEnum[keyof typeof GetTracksByUserFilterTracksEnum];
+/**
+ * @export
+ */
+export const GetUserRecommendedTracksTimeRangeEnum = {
+    Week: 'week',
+    Month: 'month',
+    AllTime: 'allTime'
+} as const;
+export type GetUserRecommendedTracksTimeRangeEnum = typeof GetUserRecommendedTracksTimeRangeEnum[keyof typeof GetUserRecommendedTracksTimeRangeEnum];
 /**
  * @export
  */

--- a/packages/sdk/src/sdk/api/generated/full/apis/ExploreApi.ts
+++ b/packages/sdk/src/sdk/api/generated/full/apis/ExploreApi.ts
@@ -62,7 +62,7 @@ export class ExploreApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/explore/best_selling`,
+            path: `/explore/best-selling`,
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/packages/sdk/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -475,7 +475,7 @@ export class TracksApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/tracks/recent_premium`,
+            path: `/tracks/recent-premium`,
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/packages/sdk/src/sdk/api/generated/full/apis/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/generated/full/apis/UsersApi.ts
@@ -501,6 +501,14 @@ export interface GetUserLibraryTracksRequest {
     encodedDataSignature?: string;
 }
 
+export interface GetUserRecommendedTracksRequest {
+    id: string;
+    offset?: number;
+    limit?: number;
+    userId?: string;
+    timeRange?: GetUserRecommendedTracksTimeRangeEnum;
+}
+
 export interface GetUsersTrackHistoryRequest {
     id: string;
     offset?: number;
@@ -2736,6 +2744,53 @@ export class UsersApi extends runtime.BaseAPI {
 
     /**
      * @hidden
+     * Gets the recommended tracks for the user
+     */
+    async getUserRecommendedTracksRaw(params: GetUserRecommendedTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTracks>> {
+        if (params.id === null || params.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter params.id was null or undefined when calling getUserRecommendedTracks.');
+        }
+
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.timeRange !== undefined) {
+            queryParameters['time_range'] = params.timeRange;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/users/{id}/recommended-tracks`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => FullTracksFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the recommended tracks for the user
+     */
+    async getUserRecommendedTracks(params: GetUserRecommendedTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracks> {
+        const response = await this.getUserRecommendedTracksRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
      * Get the tracks the user recently listened to.
      */
     async getUsersTrackHistoryRaw(params: GetUsersTrackHistoryRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<HistoryResponseFull>> {
@@ -3158,6 +3213,15 @@ export const GetUserLibraryTracksTypeEnum = {
     Purchase: 'purchase'
 } as const;
 export type GetUserLibraryTracksTypeEnum = typeof GetUserLibraryTracksTypeEnum[keyof typeof GetUserLibraryTracksTypeEnum];
+/**
+ * @export
+ */
+export const GetUserRecommendedTracksTimeRangeEnum = {
+    Week: 'week',
+    Month: 'month',
+    AllTime: 'allTime'
+} as const;
+export type GetUserRecommendedTracksTimeRangeEnum = typeof GetUserRecommendedTracksTimeRangeEnum[keyof typeof GetUserRecommendedTracksTimeRangeEnum];
 /**
  * @export
  */


### PR DESCRIPTION
### Description
Adds the `/users/:userId/recommended-tracks` endpoint to SDK
Also updates the URLs for the other two new explore endpoints to be kebab-case.

### How Has This Been Tested?
N/A
