### PR TITLE
[PE-6419|PE-6434] Fix flash of sign up on mobile apps due to default account status

### DIFF
--- a/packages/common/src/api/tan-query/users/account/useAccountStatus.ts
+++ b/packages/common/src/api/tan-query/users/account/useAccountStatus.ts
@@ -12,7 +12,7 @@ export const useAccountStatus = () => {
   return useQuery({
     queryKey: getAccountStatusQueryKey(),
     // This query data will get updated by the useCurrentAccount hook - it should not hit this query fn so we treat this as an error
-    queryFn: () => Status.ERROR,
+    queryFn: () => Status.IDLE,
     staleTime: Infinity,
     gcTime: Infinity
   })


### PR DESCRIPTION
### Description

- Updates default account status from ERROR to IDLE
- My assumption was that we would never use this queryFn and thus it's correct to say it's an error if we do use it; however on mobile the queryFn gets called briefly before we update the slice manually in a saga (race condition). The bug is just that we're using the `ERROR` state which gets treated as the "signed out" state

### How Has This Been Tested?


android:stage & ios:stage