### PR TITLE
[QA-2167] Hide empty track page lineup for artists with one track

### DIFF
--- a/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
+++ b/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
@@ -60,8 +60,13 @@ export const TrackPageLineup = ({
       ? LineupVariant.SECTION
       : LineupVariant.CONDENSED
 
+  const hasRemixSection =
+    !isRemixContest &&
+    (indices?.remixParentSection.index !== undefined ||
+      indices?.remixesSection.index !== undefined)
+
   const willRenderNothing =
-    isRemixContest &&
+    !hasRemixSection &&
     indices?.moreBySection.index === undefined &&
     indices?.recommendedSection.index === undefined
 


### PR DESCRIPTION
### Description
Update the logic for willRenderNothing to hide in this case

### How Has This Been Tested?
Manually tested
