### PR TITLE
Add retries on swaps

### DIFF
--- a/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
+++ b/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
@@ -115,11 +115,11 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
     setIsRetrying(true)
     performSwap()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [transactionData, currentScreen])
+  }, [transactionData, currentScreen, activeTab])
 
   useEffect(() => {
     // Only process if we have new data (avoid processing the same result multiple times)
-    if (swapData === lastSwapDataRef.current && swapStatus !== 'error') {
+    if (swapData === lastSwapDataRef.current) {
       return
     }
     lastSwapDataRef.current = swapData
@@ -149,13 +149,21 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
         } else {
           resetAndReturnToInput()
         }
-      }
-    } else if (swapStatus === 'error' && isRetrying) {
-      // Network/API error, handle retry
-      if (retryCount < MAX_RETRIES) {
-        setRetryCount((prev) => prev + 1)
-        scheduleRetry()
       } else {
+        // Swap failed but not retrying - return to input screen (fallback)
+        resetAndReturnToInput()
+      }
+    } else if (swapStatus === 'error') {
+      if (isRetrying) {
+        // Network/API error, handle retry
+        if (retryCount < MAX_RETRIES) {
+          setRetryCount((prev) => prev + 1)
+          scheduleRetry()
+        } else {
+          resetAndReturnToInput()
+        }
+      } else {
+        // Network/API error but not retrying - return to input screen (fallback)
         resetAndReturnToInput()
       }
     }

--- a/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
+++ b/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
@@ -1,6 +1,11 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useRef } from 'react'
 
-import { SLIPPAGE_BPS, useSwapTokens } from '../../../api'
+import { useQueryClient } from '@tanstack/react-query'
+
+import { SLIPPAGE_BPS, useSwapTokens, useCurrentAccountUser } from '~/api'
+import { SwapStatus } from '~/api/tan-query/jupiter/types'
+import { QUERY_KEYS } from '~/api/tan-query/queryKeys'
+
 import { TOKEN_LISTING_MAP } from '../buy-audio/constants'
 
 import type { BuySellTab, Screen, SwapResult, TransactionData } from './types'
@@ -15,7 +20,16 @@ type UseBuySellSwapProps = {
 
 export const useBuySellSwap = (props: UseBuySellSwapProps) => {
   const { transactionData, currentScreen, setCurrentScreen, activeTab } = props
+  const queryClient = useQueryClient()
+  const { data: user } = useCurrentAccountUser()
   const [swapResult, setSwapResult] = useState<SwapResult | null>(null)
+  const [retryCount, setRetryCount] = useState(0)
+  const [isRetrying, setIsRetrying] = useState(false)
+  const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const lastSwapDataRef = useRef<any>(null)
+
+  const MAX_RETRIES = 3
+  const RETRY_DELAY = 2000
 
   const {
     mutate: swapTokens,
@@ -23,6 +37,61 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
     error: swapError,
     data: swapData
   } = useSwapTokens()
+
+  const performSwap = () => {
+    if (!transactionData || !transactionData.isValid) return
+
+    const { inputAmount } = transactionData
+
+    if (activeTab === 'buy') {
+      swapTokens({
+        inputMint: TOKEN_LISTING_MAP.USDC.address,
+        outputMint: TOKEN_LISTING_MAP.AUDIO.address,
+        amountUi: inputAmount,
+        slippageBps: SLIPPAGE_BPS
+      })
+    } else {
+      swapTokens({
+        inputMint: TOKEN_LISTING_MAP.AUDIO.address,
+        outputMint: TOKEN_LISTING_MAP.USDC.address,
+        amountUi: inputAmount,
+        slippageBps: SLIPPAGE_BPS
+      })
+    }
+  }
+
+  const invalidateBalances = () => {
+    if (user?.wallet) {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.usdcBalance, user.wallet]
+      })
+    }
+    if (user?.spl_wallet) {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.audioBalance, user.spl_wallet]
+      })
+    }
+  }
+
+  const scheduleRetry = () => {
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current)
+    }
+
+    retryTimeoutRef.current = setTimeout(() => {
+      invalidateBalances()
+      performSwap()
+    }, RETRY_DELAY)
+  }
+
+  const resetAndReturnToInput = useCallback(() => {
+    setCurrentScreen('input')
+    setRetryCount(0)
+    setIsRetrying(false)
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current)
+    }
+  }, [setCurrentScreen])
 
   const handleShowConfirmation = useCallback(() => {
     if (
@@ -42,44 +111,77 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
     )
       return
 
-    const { inputAmount } = transactionData
-
-    if (activeTab === 'buy') {
-      swapTokens({
-        inputMint: TOKEN_LISTING_MAP.USDC.address,
-        outputMint: TOKEN_LISTING_MAP.AUDIO.address,
-        amountUi: inputAmount,
-        slippageBps: SLIPPAGE_BPS
-      })
-    } else {
-      swapTokens({
-        inputMint: TOKEN_LISTING_MAP.AUDIO.address,
-        outputMint: TOKEN_LISTING_MAP.USDC.address,
-        amountUi: inputAmount,
-        slippageBps: SLIPPAGE_BPS
-      })
-    }
-  }, [activeTab, transactionData, swapTokens, currentScreen])
+    setRetryCount(0)
+    setIsRetrying(true)
+    performSwap()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [transactionData, currentScreen])
 
   useEffect(() => {
-    if (swapStatus === 'success' && swapData) {
-      setSwapResult({
-        inputAmount:
-          swapData.inputAmount?.uiAmount ?? (transactionData?.inputAmount || 0),
-        outputAmount:
-          swapData.outputAmount?.uiAmount ??
-          (transactionData?.outputAmount || 0)
-      })
-      setCurrentScreen('success')
-    } else if (swapStatus === 'error') {
-      setCurrentScreen('input')
+    // Only process if we have new data (avoid processing the same result multiple times)
+    if (swapData === lastSwapDataRef.current && swapStatus !== 'error') {
+      return
     }
-  }, [swapStatus, swapError, swapData, setCurrentScreen, transactionData])
+    lastSwapDataRef.current = swapData
+
+    if (swapStatus === 'success' && swapData) {
+      if (swapData.status === SwapStatus.SUCCESS) {
+        // Success - navigate to success screen
+        setSwapResult({
+          inputAmount:
+            swapData.inputAmount?.uiAmount ??
+            (transactionData?.inputAmount || 0),
+          outputAmount:
+            swapData.outputAmount?.uiAmount ??
+            (transactionData?.outputAmount || 0)
+        })
+        setCurrentScreen('success')
+        setRetryCount(0)
+        setIsRetrying(false)
+        if (retryTimeoutRef.current) {
+          clearTimeout(retryTimeoutRef.current)
+        }
+      } else if (isRetrying) {
+        // Swap failed, handle retry
+        if (retryCount < MAX_RETRIES) {
+          setRetryCount((prev) => prev + 1)
+          scheduleRetry()
+        } else {
+          resetAndReturnToInput()
+        }
+      }
+    } else if (swapStatus === 'error' && isRetrying) {
+      // Network/API error, handle retry
+      if (retryCount < MAX_RETRIES) {
+        setRetryCount((prev) => prev + 1)
+        scheduleRetry()
+      } else {
+        resetAndReturnToInput()
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    swapStatus,
+    swapData,
+    setCurrentScreen,
+    transactionData,
+    retryCount,
+    isRetrying,
+    resetAndReturnToInput
+  ])
+
+  useEffect(() => {
+    return () => {
+      if (retryTimeoutRef.current) {
+        clearTimeout(retryTimeoutRef.current)
+      }
+    }
+  }, [])
 
   const isContinueButtonLoading =
     swapStatus === 'pending' && currentScreen === 'input'
   const isConfirmButtonLoading =
-    swapStatus === 'pending' && currentScreen === 'confirm'
+    (swapStatus === 'pending' || isRetrying) && currentScreen === 'confirm'
 
   return {
     handleShowConfirmation,

--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
@@ -7,7 +7,12 @@ import type {
   TextInputChangeEventData,
   TextInputFocusEventData
 } from 'react-native'
-import { Platform, Pressable, TextInput as RNTextInput } from 'react-native'
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  TextInput as RNTextInput
+} from 'react-native'
 import { Gesture, GestureDetector, State } from 'react-native-gesture-handler'
 import InsetShadow from 'react-native-inset-shadow'
 import Animated, {
@@ -87,7 +92,8 @@ export const TextInput = forwardRef(
 
     const innerInputRef = useRef<RNTextInput>(null)
 
-    const { typography, color, motion, cornerRadius, type } = useTheme()
+    const { typography, color, motion, cornerRadius, type, spacing } =
+      useTheme()
 
     let endAdornment: null | ReactNode
     if (EndIcon != null) {
@@ -243,14 +249,14 @@ export const TextInput = forwardRef(
         >
           <GestureDetector gesture={tap}>
             <InsetShadow
-              containerStyle={[
+              containerStyle={StyleSheet.flatten([
                 css({
                   width: '100%',
-                  height: isSmall ? 48 : 64,
+                  height: isSmall ? spacing['3xl'] : spacing['4xl'],
                   borderRadius: cornerRadius.s
                 }),
                 inputStyle
-              ]}
+              ])}
               shadowOpacity={0.05}
               shadowColor='#000000'
               shadowRadius={4}

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellModalScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellModalScreen.tsx
@@ -23,7 +23,7 @@ export const BuySellModalScreen = () => {
       <BottomSheetModalProvider>
         <Stack.Navigator screenOptions={screenOptions}>
           <Stack.Screen
-            name='BuySell'
+            name='BuySellMain'
             component={BuySellScreen}
             initialParams={params}
           />

--- a/packages/mobile/src/types/navigation.ts
+++ b/packages/mobile/src/types/navigation.ts
@@ -25,7 +25,7 @@ export type TransactionResultScreenParams = {
 
 // This will be extended with the main app navigation types when integrated
 export type BuySellStackParamList = {
-  BuySellScreen: BuySellScreenParams
+  BuySellMain: BuySellScreenParams
   ConfirmSwapScreen: ConfirmSwapScreenParams
   TransactionResultScreen: TransactionResultScreenParams
 }


### PR DESCRIPTION
### Description

This PR introduces retry logic for failed swap transactions in the buy/sell flow and makes minor UI adjustments.

Changes:

- **Retry Logic for Buy/Sell Swaps (`packages/common/src/store/ui/buy-sell/useBuySellSwap.ts`)**:

  - Implemented automatic retry mechanism for failed swap transactions, allowing up to 3 retries with a 2-second delay between attempts.
  - Introduced state variables and refs (`retryCount`, `isRetrying`, `retryTimeoutRef`, `lastSwapDataRef`) to manage the retry process.
  - Ensured balance invalidation (`invalidateBalances`) before each retry to fetch fresh token balances.
  - Adjusted loading states (`isConfirmButtonLoading`) to remain active throughout the retry process.

- **UI Adjustments (Mobile)**:
  - In `packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx`, text input height calculations were updated to use theme spacing values.
  - The `BuySellModalScreen` and its corresponding navigation type `BuySellStackParamList` were updated to use the screen name `BuySellMain` for clarity in `packages/mobile/src/screens/buy-sell-screen/BuySellModalScreen.tsx` and `packages/mobile/src/types/navigation.ts`. to avoid circular screen names


### How Has This Been Tested?

`npm run ios:prod` and perform back to back swaps using the `max` button
