### PR TITLE
Fix publish playlist button on missing track count

### DIFF
--- a/packages/web/src/components/collection/desktop/PublishButton.tsx
+++ b/packages/web/src/components/collection/desktop/PublishButton.tsx
@@ -31,21 +31,22 @@ export const PublishButton = (props: PublishButtonProps) => {
         '_is_publishing',
         'is_scheduled_release',
         'is_album',
-        'track_count',
-        'cover_art_sizes'
+        'cover_art_sizes',
+        'playlist_contents'
       ])
   })
   const { _is_publishing, is_scheduled_release, is_album } =
     partialCollection ?? {}
-
-  const { track_count, cover_art_sizes } = partialCollection ?? {}
+  const { cover_art_sizes } = partialCollection ?? {}
+  const track_count =
+    partialCollection?.playlist_contents?.track_ids.length ?? 0
 
   const { onOpen: openPublishConfirmation } = usePublishConfirmationModal()
   const { onOpen: openEarlyReleaseConfirmation } =
     useEarlyReleaseConfirmationModal()
 
   const dispatch = useDispatch()
-  const isDisabled = !track_count || track_count === 0 || !cover_art_sizes
+  const isDisabled = !track_count || !cover_art_sizes
 
   const publishRelease = useCallback(() => {
     dispatch(

--- a/packages/web/src/components/collection/desktop/ViewerActionButtons.tsx
+++ b/packages/web/src/components/collection/desktop/ViewerActionButtons.tsx
@@ -15,11 +15,13 @@ export const ViewerActionButtons = (props: ViewerActionButtonsProps) => {
   const { collectionId } = props
   const { data: partialCollection } = useCollection(collectionId, {
     select: (collection) =>
-      pick(collection, 'track_count', 'is_private', 'access')
+      pick(collection, 'playlist_contents', 'is_private', 'access')
   })
-  const { track_count, is_private: isPrivate, access } = partialCollection ?? {}
+  const { is_private: isPrivate, access } = partialCollection ?? {}
+  const track_count =
+    partialCollection?.playlist_contents?.track_ids.length ?? 0
 
-  const isDisabled = !partialCollection || track_count === 0 || isPrivate
+  const isDisabled = !partialCollection || !track_count || isPrivate
   const hasStreamAccess = access?.stream
 
   return isPrivate ? null : (


### PR DESCRIPTION
### Description

`track_count` is undefined so publish is always disabled. This would also be the case for repost / favorite but we're only checking against 0 there.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Able to add tracks to an empty playlist and publish on web.