### PR TITLE
Add analytics to Buy/Sell flow

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -46,3 +46,6 @@ export * from './useFormattedAudioBalance'
 export * from './useCurrentTrack'
 export * from './useDebounce'
 export * from './useIsArtist'
+
+export * from './useAnalytics'
+export * from './useBuySellAnalytics'

--- a/packages/common/src/hooks/useAnalytics.ts
+++ b/packages/common/src/hooks/useAnalytics.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react'
+
+import { useAppContext } from '~/context/appContext'
+import { AnalyticsEvent, AllTrackingEvents } from '~/models/Analytics'
+
+/**
+ * Core analytics hook providing a consistent interface for tracking events
+ * across the application. This hook abstracts the analytics implementation
+ * and provides type-safe event tracking.
+ */
+export const useAnalytics = () => {
+  const { analytics } = useAppContext()
+
+  /**
+   * Track an analytics event
+   * @param event - The event to track (can be created with make() or passed directly)
+   * @param callback - Optional callback to execute after tracking
+   */
+  const track = useCallback(
+    async (event: AnalyticsEvent, callback?: () => void) => {
+      return analytics.track(event, callback)
+    },
+    [analytics]
+  )
+
+  /**
+   * Create an analytics event object from a typed event
+   * @param event - Typed event object
+   * @returns Analytics event ready for tracking
+   */
+  const make = useCallback(
+    <T extends AllTrackingEvents>(event: T) => {
+      return analytics.make(event)
+    },
+    [analytics]
+  )
+
+  /**
+   * Convenience method to create and track an event in one call
+   * @param event - Typed event object
+   * @param callback - Optional callback to execute after tracking
+   */
+  const trackEvent = useCallback(
+    async <T extends AllTrackingEvents>(event: T, callback?: () => void) => {
+      const analyticsEvent = analytics.make(event)
+      return analytics.track(analyticsEvent, callback)
+    },
+    [analytics]
+  )
+
+  return {
+    track,
+    make,
+    trackEvent
+  }
+}

--- a/packages/common/src/hooks/useBuySellAnalytics.ts
+++ b/packages/common/src/hooks/useBuySellAnalytics.ts
@@ -10,7 +10,7 @@ export type SwapDetails = {
   outputToken: string
   inputAmount?: number
   outputAmount?: number
-  exchangeRate?: number
+  exchangeRate?: number | null
 }
 
 export type SwapError = {

--- a/packages/common/src/hooks/useBuySellAnalytics.ts
+++ b/packages/common/src/hooks/useBuySellAnalytics.ts
@@ -1,0 +1,126 @@
+import { useCallback } from 'react'
+
+import { Name } from '~/models/Analytics'
+
+import { useAnalytics } from './useAnalytics'
+
+export type SwapDetails = {
+  activeTab: 'buy' | 'sell'
+  inputToken: string
+  outputToken: string
+  inputAmount?: number
+  outputAmount?: number
+  exchangeRate?: number
+}
+
+export type SwapError = {
+  errorType: string
+  errorStage: string
+  errorMessage?: string
+}
+
+/**
+ * Specialized analytics hook for buy-sell swap flows.
+ * Provides pre-configured methods for common buy-sell analytics events.
+ */
+export const useBuySellAnalytics = () => {
+  const { trackEvent } = useAnalytics()
+
+  /**
+   * Track when a swap is initially requested by the user
+   */
+  const trackSwapRequested = useCallback(
+    (swapDetails: SwapDetails) => {
+      return trackEvent({
+        eventName: Name.BUY_SELL_SWAP_REQUESTED,
+        activeTab: swapDetails.activeTab,
+        inputToken: swapDetails.inputToken,
+        outputToken: swapDetails.outputToken,
+        inputAmount: swapDetails.inputAmount,
+        outputAmount: swapDetails.outputAmount,
+        exchangeRate: swapDetails.exchangeRate
+      })
+    },
+    [trackEvent]
+  )
+
+  /**
+   * Track when a swap is confirmed by the user
+   */
+  const trackSwapConfirmed = useCallback(
+    (swapDetails: SwapDetails & { slippageBps: number }) => {
+      return trackEvent({
+        eventName: Name.BUY_SELL_SWAP_CONFIRMED,
+        activeTab: swapDetails.activeTab,
+        inputToken: swapDetails.inputToken,
+        outputToken: swapDetails.outputToken,
+        inputAmount: swapDetails.inputAmount,
+        outputAmount: swapDetails.outputAmount,
+        exchangeRate: swapDetails.exchangeRate,
+        slippageBps: swapDetails.slippageBps
+      })
+    },
+    [trackEvent]
+  )
+
+  /**
+   * Track when a swap completes successfully
+   */
+  const trackSwapSuccess = useCallback(
+    (swapDetails: SwapDetails & { signature: string }) => {
+      return trackEvent({
+        eventName: Name.BUY_SELL_SWAP_SUCCESS,
+        activeTab: swapDetails.activeTab,
+        inputToken: swapDetails.inputToken,
+        outputToken: swapDetails.outputToken,
+        inputAmount: swapDetails.inputAmount,
+        outputAmount: swapDetails.outputAmount,
+        exchangeRate: swapDetails.exchangeRate,
+        signature: swapDetails.signature
+      })
+    },
+    [trackEvent]
+  )
+
+  /**
+   * Track when a swap fails
+   */
+  const trackSwapFailure = useCallback(
+    (swapDetails: SwapDetails, errorDetails: SwapError) => {
+      return trackEvent({
+        eventName: Name.BUY_SELL_SWAP_FAILURE,
+        activeTab: swapDetails.activeTab,
+        inputToken: swapDetails.inputToken,
+        outputToken: swapDetails.outputToken,
+        inputAmount: swapDetails.inputAmount,
+        outputAmount: swapDetails.outputAmount,
+        exchangeRate: swapDetails.exchangeRate,
+        errorType: errorDetails.errorType,
+        errorStage: errorDetails.errorStage,
+        errorMessage: errorDetails.errorMessage
+      })
+    },
+    [trackEvent]
+  )
+
+  /**
+   * Track when the user clicks to add funds
+   */
+  const trackAddFundsClicked = useCallback(
+    (source: 'insufficient_balance_hint' | 'input_screen') => {
+      return trackEvent({
+        eventName: Name.BUY_SELL_ADD_FUNDS_CLICKED,
+        source
+      })
+    },
+    [trackEvent]
+  )
+
+  return {
+    trackSwapRequested,
+    trackSwapConfirmed,
+    trackSwapSuccess,
+    trackSwapFailure,
+    trackAddFundsClicked
+  }
+}

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -425,6 +425,13 @@ export enum Name {
   BUY_USDC_RECOVERY_FAILURE = 'Buy USDC: Recovery Failure',
   BUY_USDC_ADD_FUNDS_MANUALLY = 'Buy USDC: Add Funds Manually',
 
+  // Buy/Sell Swap
+  BUY_SELL_SWAP_REQUESTED = 'Buy Sell Modal: Swap Requested',
+  BUY_SELL_SWAP_CONFIRMED = 'Buy Sell Modal: Swap Confirmed',
+  BUY_SELL_SWAP_SUCCESS = 'Buy Sell Modal: Swap Success',
+  BUY_SELL_SWAP_FAILURE = 'Buy Sell Modal: Swap Failure',
+  BUY_SELL_ADD_FUNDS_CLICKED = 'Buy Sell Modal: Add Funds Clicked',
+
   // Withdraw USDC
 
   WITHDRAW_USDC_MODAL_OPENED = 'Withdraw USDC: Modal Opened',
@@ -2104,6 +2111,43 @@ type BuyUSDCAddFundsManually = {
   eventName: Name.BUY_USDC_ADD_FUNDS_MANUALLY
 }
 
+// Buy/Sell Swap
+
+export type BuySellSwapEventFields = {
+  activeTab: 'buy' | 'sell'
+  inputToken: string
+  outputToken: string
+  inputAmount?: number
+  outputAmount?: number
+  exchangeRate?: number
+}
+
+type BuySellSwapRequested = BuySellSwapEventFields & {
+  eventName: Name.BUY_SELL_SWAP_REQUESTED
+}
+
+type BuySellSwapConfirmed = BuySellSwapEventFields & {
+  eventName: Name.BUY_SELL_SWAP_CONFIRMED
+  slippageBps: number
+}
+
+type BuySellSwapSuccess = BuySellSwapEventFields & {
+  eventName: Name.BUY_SELL_SWAP_SUCCESS
+  signature: string
+}
+
+type BuySellSwapFailure = BuySellSwapEventFields & {
+  eventName: Name.BUY_SELL_SWAP_FAILURE
+  errorType: string
+  errorStage: string
+  errorMessage?: string
+}
+
+type BuySellAddFundsClicked = {
+  eventName: Name.BUY_SELL_ADD_FUNDS_CLICKED
+  source: 'insufficient_balance_hint' | 'input_screen'
+}
+
 // Withdraw USDC
 
 export type WithdrawUSDCEventFields = {
@@ -3042,6 +3086,11 @@ export type AllTrackingEvents =
   | BuyUSDCRecoverySuccess
   | BuyUSDCRecoveryFailure
   | BuyUSDCAddFundsManually
+  | BuySellSwapRequested
+  | BuySellSwapConfirmed
+  | BuySellSwapSuccess
+  | BuySellSwapFailure
+  | BuySellAddFundsClicked
   | WithdrawUSDCModalOpened
   | WithdrawUSDCAddressPasted
   | WithdrawUSDCFormError

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -425,7 +425,6 @@ export enum Name {
   BUY_USDC_RECOVERY_FAILURE = 'Buy USDC: Recovery Failure',
   BUY_USDC_ADD_FUNDS_MANUALLY = 'Buy USDC: Add Funds Manually',
 
-  // Buy/Sell Swap
   BUY_SELL_SWAP_REQUESTED = 'Buy Sell Modal: Swap Requested',
   BUY_SELL_SWAP_CONFIRMED = 'Buy Sell Modal: Swap Confirmed',
   BUY_SELL_SWAP_SUCCESS = 'Buy Sell Modal: Swap Success',
@@ -2111,15 +2110,13 @@ type BuyUSDCAddFundsManually = {
   eventName: Name.BUY_USDC_ADD_FUNDS_MANUALLY
 }
 
-// Buy/Sell Swap
-
 export type BuySellSwapEventFields = {
   activeTab: 'buy' | 'sell'
   inputToken: string
   outputToken: string
   inputAmount?: number
   outputAmount?: number
-  exchangeRate?: number
+  exchangeRate?: number | null
 }
 
 type BuySellSwapRequested = BuySellSwapEventFields & {

--- a/packages/common/src/store/ui/buy-sell/types.ts
+++ b/packages/common/src/store/ui/buy-sell/types.ts
@@ -45,7 +45,6 @@ export type TokenAmountSectionProps = {
   tooltipPlacement?: TooltipPlacement
 }
 
-// Data structure for the transaction success screen
 export type SuccessDisplayData = {
   payTokenInfo: TokenInfo
   receiveTokenInfo: TokenInfo
@@ -53,6 +52,17 @@ export type SuccessDisplayData = {
   receiveAmount: number
   pricePerBaseToken: number
   baseTokenSymbol: string
+  exchangeRate?: number | null
+}
+
+export type ConfirmationScreenData = {
+  payTokenInfo: TokenInfo
+  receiveTokenInfo: TokenInfo
+  payAmount: number
+  receiveAmount: number
+  pricePerBaseToken: number
+  baseTokenSymbol: string
+  exchangeRate?: number | null
 }
 
 export type SwapResult = {
@@ -66,6 +76,7 @@ export type TransactionData = {
   outputAmount: number
   isValid: boolean
   error?: string | null
+  exchangeRate?: number | null
 } | null
 
 /**

--- a/packages/common/src/store/ui/buy-sell/types.ts
+++ b/packages/common/src/store/ui/buy-sell/types.ts
@@ -58,6 +58,7 @@ export type SuccessDisplayData = {
 export type SwapResult = {
   inputAmount: number
   outputAmount: number
+  signature?: string
 }
 
 export type TransactionData = {
@@ -66,3 +67,25 @@ export type TransactionData = {
   isValid: boolean
   error?: string | null
 } | null
+
+/**
+ * Utility function to get input and output tokens based on active tab and token pair
+ * For 'buy': user pays with quote token (e.g., USDC) to get base token (e.g., AUDIO)
+ * For 'sell': user pays with base token (e.g., AUDIO) to get quote token (e.g., USDC)
+ */
+export const getSwapTokens = (activeTab: BuySellTab, tokenPair: TokenPair) => {
+  return {
+    inputToken:
+      activeTab === 'buy'
+        ? tokenPair.quoteToken.symbol
+        : tokenPair.baseToken.symbol,
+    outputToken:
+      activeTab === 'buy'
+        ? tokenPair.baseToken.symbol
+        : tokenPair.quoteToken.symbol,
+    inputTokenInfo:
+      activeTab === 'buy' ? tokenPair.quoteToken : tokenPair.baseToken,
+    outputTokenInfo:
+      activeTab === 'buy' ? tokenPair.baseToken : tokenPair.quoteToken
+  }
+}

--- a/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
+++ b/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
@@ -82,7 +82,7 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
     retryTimeoutRef.current = setTimeout(() => {
       invalidateBalances()
       performSwap()
-    }, RETRY_DELAY)
+    }, RETRY_DELAY) as unknown as NodeJS.Timeout
   }
 
   const resetAndReturnToInput = useCallback(() => {
@@ -134,7 +134,8 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
             (transactionData?.inputAmount || 0),
           outputAmount:
             swapData.outputAmount?.uiAmount ??
-            (transactionData?.outputAmount || 0)
+            (transactionData?.outputAmount || 0),
+          signature: swapData.signature
         })
         setCurrentScreen('success')
         setRetryCount(0)

--- a/packages/common/src/store/ui/buy-sell/useSwapDisplayData.ts
+++ b/packages/common/src/store/ui/buy-sell/useSwapDisplayData.ts
@@ -4,6 +4,7 @@ import type {
   BuySellTab,
   Screen,
   SuccessDisplayData,
+  ConfirmationScreenData,
   TokenPair,
   SwapResult,
   TransactionData
@@ -60,8 +61,9 @@ export const useSwapDisplayData = ({
       pricePerBaseToken: calculatePriceInternal(transactionData, activeTab),
       baseTokenSymbol: selectedPair.baseToken.symbol,
       payAmount: transactionData.inputAmount,
-      receiveAmount: transactionData.outputAmount
-    }
+      receiveAmount: transactionData.outputAmount,
+      exchangeRate: transactionData.exchangeRate
+    } as ConfirmationScreenData
   }, [activeTab, selectedPair, transactionData])
 
   useEffect(() => {
@@ -95,7 +97,8 @@ export const useSwapDisplayData = ({
         ),
         baseTokenSymbol: selectedPair.baseToken.symbol,
         payAmount,
-        receiveAmount
+        receiveAmount,
+        exchangeRate: transactionData?.exchangeRate
       })
     }
   }, [

--- a/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
@@ -87,6 +87,7 @@ export type TokenSwapFormProps = {
     isValid: boolean
     error: string | null
     isInsufficientBalance: boolean
+    exchangeRate?: number | null
   }) => void
   /**
    * Initial value for the input field
@@ -241,7 +242,8 @@ export const useTokenSwapForm = ({
         outputAmount: numericOutputAmount,
         isValid,
         error,
-        isInsufficientBalance
+        isInsufficientBalance,
+        exchangeRate: currentExchangeRate
       })
     }
   }, [
@@ -251,7 +253,8 @@ export const useTokenSwapForm = ({
     error, // Use the filtered error
     isExchangeRateLoading,
     onTransactionDataChange,
-    isInsufficientBalance
+    isInsufficientBalance,
+    currentExchangeRate
   ])
 
   // Handle input changes

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
@@ -99,18 +99,14 @@ export const BuySellFlow = ({
   const [selectedPairIndex] = useState(0)
   const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
 
-  // Memoize swap tokens to avoid repeated calculations
-  const swapTokens = useMemo(() => 
-    getSwapTokens(activeTab, selectedPair), 
+  const swapTokens = useMemo(
+    () => getSwapTokens(activeTab, selectedPair),
     [activeTab, selectedPair]
   )
 
-  // Memoize exchange rate calculation for current transaction
-  const currentExchangeRate = useMemo(() =>
-    transactionData?.outputAmount && transactionData?.inputAmount
-      ? transactionData.outputAmount / transactionData.inputAmount
-      : undefined,
-    [transactionData?.outputAmount, transactionData?.inputAmount]
+  const currentExchangeRate = useMemo(
+    () => transactionData?.exchangeRate ?? undefined,
+    [transactionData?.exchangeRate]
   )
 
   const { confirmationScreenData } = useSwapDisplayData({
@@ -130,7 +126,6 @@ export const BuySellFlow = ({
   const handleContinueClick = useCallback(() => {
     setHasAttemptedSubmit(true)
     if (transactionData?.isValid && !isContinueButtonLoading) {
-      // Track swap requested
       trackSwapRequested({
         activeTab,
         inputToken: swapTokens.inputToken,

--- a/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
@@ -53,6 +53,7 @@ type ConfirmSwapScreenProps = {
         receiveAmount: number
         pricePerBaseToken: number
         baseTokenSymbol: string
+        exchangeRate?: number | null
       }
     }
   }
@@ -97,7 +98,8 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
       payAmount,
       receiveAmount,
       pricePerBaseToken,
-      baseTokenSymbol
+      baseTokenSymbol,
+      exchangeRate = null
     }
   } = route.params
 
@@ -148,12 +150,6 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
   const swapTokens = useMemo(
     () => getSwapTokens(activeTab, selectedPair),
     [activeTab, selectedPair]
-  )
-
-  // Memoize exchange rate calculation
-  const exchangeRate = useMemo(
-    () => (receiveAmount && payAmount ? receiveAmount / payAmount : undefined),
-    [receiveAmount, payAmount]
   )
 
   const { successDisplayData } = useSwapDisplayData({

--- a/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
@@ -146,7 +146,6 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
   const [selectedPairIndex] = useState(0)
   const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
 
-  // Memoize swap tokens to avoid repeated calculations
   const swapTokens = useMemo(
     () => getSwapTokens(activeTab, selectedPair),
     [activeTab, selectedPair]
@@ -163,7 +162,6 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
 
   useEffect(() => {
     if (currentScreen === 'success' && successDisplayData) {
-      // Track swap success
       trackSwapSuccess({
         activeTab,
         inputToken: swapTokens.inputToken,
@@ -197,7 +195,6 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
   // Handle swap error
   useEffect(() => {
     if (swapStatus === 'error' && swapError) {
-      // Track swap failure
       trackSwapFailure(
         {
           activeTab,
@@ -258,7 +255,6 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
   }
 
   const handleConfirm = () => {
-    // Track swap confirmed
     trackSwapConfirmed({
       activeTab,
       inputToken: swapTokens.inputToken,

--- a/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { formatUSDCValue } from '@audius/common/api'
+import { formatUSDCValue, SLIPPAGE_BPS } from '@audius/common/api'
+import { useBuySellAnalytics } from '@audius/common/hooks'
 import { buySellMessages as baseMessages } from '@audius/common/messages'
 import type { TokenInfo } from '@audius/common/store'
 import {
@@ -8,7 +9,8 @@ import {
   useBuySellScreen,
   useBuySellSwap,
   useSwapDisplayData,
-  useTokenAmountFormatting
+  useTokenAmountFormatting,
+  getSwapTokens
 } from '@audius/common/store'
 
 import {
@@ -85,6 +87,9 @@ const LoadingScreen = () => (
 
 export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
   const navigation = useNavigation()
+  const { trackSwapConfirmed, trackSwapSuccess, trackSwapFailure } =
+    useBuySellAnalytics()
+
   const {
     confirmationData: {
       payTokenInfo,
@@ -139,6 +144,18 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
   const [selectedPairIndex] = useState(0)
   const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
 
+  // Memoize swap tokens to avoid repeated calculations
+  const swapTokens = useMemo(
+    () => getSwapTokens(activeTab, selectedPair),
+    [activeTab, selectedPair]
+  )
+
+  // Memoize exchange rate calculation
+  const exchangeRate = useMemo(
+    () => (receiveAmount && payAmount ? receiveAmount / payAmount : undefined),
+    [receiveAmount, payAmount]
+  )
+
   const { successDisplayData } = useSwapDisplayData({
     swapStatus,
     currentScreen,
@@ -150,6 +167,17 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
 
   useEffect(() => {
     if (currentScreen === 'success' && successDisplayData) {
+      // Track swap success
+      trackSwapSuccess({
+        activeTab,
+        inputToken: swapTokens.inputToken,
+        outputToken: swapTokens.outputToken,
+        inputAmount: swapResult?.inputAmount || payAmount,
+        outputAmount: swapResult?.outputAmount || receiveAmount,
+        exchangeRate,
+        signature: swapResult?.signature || ''
+      })
+
       navigation.navigate('TransactionResultScreen', {
         result: {
           status: 'success' as const,
@@ -157,11 +185,41 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
         }
       })
     }
-  }, [currentScreen, successDisplayData, navigation])
+  }, [
+    currentScreen,
+    successDisplayData,
+    navigation,
+    activeTab,
+    swapResult,
+    payAmount,
+    receiveAmount,
+    swapTokens,
+    exchangeRate,
+    trackSwapSuccess
+  ])
 
   // Handle swap error
   useEffect(() => {
     if (swapStatus === 'error' && swapError) {
+      // Track swap failure
+      trackSwapFailure(
+        {
+          activeTab,
+          inputToken: swapTokens.inputToken,
+          outputToken: swapTokens.outputToken,
+          inputAmount: payAmount,
+          outputAmount: receiveAmount,
+          exchangeRate
+        },
+        {
+          errorType: 'swap_error',
+          errorStage: 'transaction',
+          errorMessage: swapError?.message
+            ? swapError.message.substring(0, 500)
+            : 'Unknown error'
+        }
+      )
+
       navigation.navigate('TransactionResultScreen', {
         result: {
           status: 'error' as const,
@@ -169,7 +227,17 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
         }
       })
     }
-  }, [swapStatus, swapError, navigation])
+  }, [
+    swapStatus,
+    swapError,
+    navigation,
+    activeTab,
+    payAmount,
+    receiveAmount,
+    swapTokens,
+    exchangeRate,
+    trackSwapFailure
+  ])
 
   // balance isn't needed so we pass 0
   const { formattedAmount: formattedPayAmount } = useTokenAmountFormatting({
@@ -194,6 +262,17 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
   }
 
   const handleConfirm = () => {
+    // Track swap confirmed
+    trackSwapConfirmed({
+      activeTab,
+      inputToken: swapTokens.inputToken,
+      outputToken: swapTokens.outputToken,
+      inputAmount: payAmount,
+      outputAmount: receiveAmount,
+      exchangeRate,
+      slippageBps: SLIPPAGE_BPS
+    })
+
     handleConfirmSwap()
   }
 

--- a/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
@@ -114,7 +114,6 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
 
   useEffect(() => {
     if (swapStatus === 'error' && swapError) {
-      // Track swap failure
       trackSwapFailure(
         {
           activeTab,

--- a/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
@@ -98,19 +98,14 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
   const [selectedPairIndex] = useState(0)
   const selectedPair = SUPPORTED_TOKEN_PAIRS[selectedPairIndex]
 
-  // Memoize swap tokens to avoid repeated calculations
   const swapTokens = useMemo(
     () => getSwapTokens(activeTab, selectedPair),
     [activeTab, selectedPair]
   )
 
-  // Memoize exchange rate calculation for current transaction
   const currentExchangeRate = useMemo(
-    () =>
-      transactionData?.outputAmount && transactionData?.inputAmount
-        ? transactionData.outputAmount / transactionData.inputAmount
-        : undefined,
-    [transactionData?.outputAmount, transactionData?.inputAmount]
+    () => transactionData?.exchangeRate ?? undefined,
+    [transactionData?.exchangeRate]
   )
 
   useEffect(() => {
@@ -178,10 +173,7 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
         outputToken: swapTokens.outputToken,
         inputAmount: swapResult.inputAmount,
         outputAmount: swapResult.outputAmount,
-        exchangeRate:
-          swapResult.outputAmount && swapResult.inputAmount
-            ? swapResult.outputAmount / swapResult.inputAmount
-            : undefined,
+        exchangeRate: successDisplayData.exchangeRate ?? undefined,
         signature: swapResult.signature || ''
       })
     }

--- a/packages/web/src/components/buy-sell-modal/ConfirmSwapScreen.tsx
+++ b/packages/web/src/components/buy-sell-modal/ConfirmSwapScreen.tsx
@@ -24,6 +24,7 @@ type ConfirmSwapScreenProps = {
   receiveAmount: number
   pricePerBaseToken: number
   baseTokenSymbol: string
+  exchangeRate?: number | null
   onBack: () => void
   onConfirm: () => void
   isConfirming: boolean
@@ -39,6 +40,7 @@ export const ConfirmSwapScreen = (props: ConfirmSwapScreenProps) => {
     receiveAmount,
     pricePerBaseToken,
     baseTokenSymbol,
+    exchangeRate,
     onBack,
     onConfirm,
     isConfirming,
@@ -52,12 +54,6 @@ export const ConfirmSwapScreen = (props: ConfirmSwapScreenProps) => {
   const swapTokens = useMemo(
     () => getSwapTokens(activeTab, selectedPair),
     [activeTab, selectedPair]
-  )
-
-  // Memoize exchange rate calculation
-  const exchangeRate = useMemo(
-    () => (receiveAmount && payAmount ? receiveAmount / payAmount : undefined),
-    [receiveAmount, payAmount]
   )
 
   // balance isn't needed so we pass 0

--- a/packages/web/src/components/buy-sell-modal/ConfirmSwapScreen.tsx
+++ b/packages/web/src/components/buy-sell-modal/ConfirmSwapScreen.tsx
@@ -50,7 +50,6 @@ export const ConfirmSwapScreen = (props: ConfirmSwapScreenProps) => {
 
   const { trackSwapConfirmed } = useBuySellAnalytics()
 
-  // Memoize swap tokens to avoid repeated calculations
   const swapTokens = useMemo(
     () => getSwapTokens(activeTab, selectedPair),
     [activeTab, selectedPair]
@@ -75,7 +74,6 @@ export const ConfirmSwapScreen = (props: ConfirmSwapScreenProps) => {
     : undefined
 
   const handleConfirm = () => {
-    // Track swap confirmed
     trackSwapConfirmed({
       activeTab,
       inputToken: swapTokens.inputToken,


### PR DESCRIPTION
### Description

This PR introduces new analytics tracking for the buy and sell flows within the application. It leverages a new `useBuySellAnalytics` hook to provide consistent and type-safe event tracking for various stages of the swap process.

## Changes:

- **New Analytics Hooks**:

  - `useAnalytics.ts`: A core analytics hook providing a consistent interface for tracking events.
  - `useBuySellAnalytics.ts`: A specialized hook for buy-sell swap flows, with pre-configured methods for events like `trackSwapRequested`, `trackSwapConfirmed`, `trackSwapSuccess`, `trackSwapFailure`, and `trackAddFundsClicked`.

- **Analytics Event Definitions**:

  - Added new `Name` enums and corresponding types (`BuySellSwapEventFields`, `BuySellSwapRequested`, `BuySellSwapConfirmed`, `BuySellSwapSuccess`, `BuySellSwapFailure`, `BuySellAddFundsClicked`) in `packages/common/src/models/Analytics.ts` to support the new buy/sell analytics events.

- **Integration into Buy/Sell Flow**:

  - Updated `packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx` to utilize the `useBuySellAnalytics` hook for tracking `trackSwapRequested` and `trackAddFundsClicked` events.
  - Removed direct `make` and `track` calls in `BuySellFlow.tsx` in favor of the new specialized hook.

- **Store Updates**:
  - Modified `packages/common/src/store/ui/buy-sell/types.ts` to include `ConfirmationScreenData` and `exchangeRate` in `SuccessDisplayData`, and `signature` in `SwapResult`. Also added `getSwapTokens` utility.
  - Adjusted `packages/common/src/store/ui/buy-sell/useBuySellSwap.ts` to pass `signature` in `trackSwapSuccess`.
  - Updated `packages/common/src/store/ui/buy-sell/useSwapDisplayData.ts` and `packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts` to handle `exchangeRate` more consistently.

These changes ensure that all critical actions within the buy and sell flows are properly instrumented for analytics, providing better insights into user behavior.

