### PR TITLE
Fix purchase flow stuck due to waitForValue

### DIFF
--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -63,7 +63,7 @@ import {
   coinflowOnrampModalActions,
   CoinflowPurchaseMetadata
 } from '~/store/ui/modals/coinflow-onramp-modal'
-import { waitForValue } from '~/utils'
+import { waitForQueryValue, waitForValue } from '~/utils'
 
 import { pollGatedContent } from '../gated-content/sagas'
 import { updateGatedContentStatus } from '../gated-content/slice'
@@ -644,7 +644,7 @@ function* doStartPurchaseContentFlow({
 
   // wait for guest account creation
   yield* call(
-    waitForValue,
+    waitForQueryValue,
     queryWalletAddresses,
     null,
     (value) => !!value?.currentUser


### PR DESCRIPTION
### Description

- waitForValue uses `select()` under the hood, we need to use `waitForQueryValue` instead
- this was stalling out the purchase flow indefinitely

### How Has This Been Tested?

web:prod