### PR TITLE
Use prime functions for entity updates

### DIFF
--- a/packages/common/src/api/tan-query/collection/useUpdateCollection.ts
+++ b/packages/common/src/api/tan-query/collection/useUpdateCollection.ts
@@ -179,10 +179,11 @@ export const useUpdateCollection = () => {
     onError: (_err, { collectionId }, context?: MutationContext) => {
       // If the mutation fails, roll back collection data
       if (context?.previousCollection) {
-        queryClient.setQueryData(
-          getCollectionQueryKey(collectionId),
-          context.previousCollection
-        )
+        primeCollectionData({
+          collections: [context.previousCollection],
+          queryClient,
+          forceReplace: true
+        })
       }
     },
     onSettled: (_, __, { collectionId }) => {

--- a/packages/common/src/api/tan-query/tracks/useFavoriteTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useFavoriteTrack.ts
@@ -155,7 +155,11 @@ export const useFavoriteTrack = () => {
       if (!context) return
 
       // Revert optimistic updates
-      queryClient.setQueryData(getTrackQueryKey(trackId), context.previousTrack)
+      primeTrackData({
+        tracks: [context.previousTrack],
+        queryClient,
+        forceReplace: true
+      })
       dispatch(accountActions.decrementTrackSaveCount())
 
       reportToSentry({

--- a/packages/common/src/api/tan-query/tracks/useUnfavoriteTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUnfavoriteTrack.ts
@@ -126,7 +126,11 @@ export const useUnfavoriteTrack = () => {
       if (!context) return
 
       // Revert optimistic updates
-      queryClient.setQueryData(getTrackQueryKey(trackId), context.previousTrack)
+      primeTrackData({
+        tracks: [context.previousTrack],
+        queryClient,
+        forceReplace: true
+      })
       dispatch(accountActions.incrementTrackSaveCount())
 
       reportToSentry({

--- a/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
@@ -111,10 +111,11 @@ export const useUpdateTrack = () => {
     ) => {
       // If the mutation fails, roll back track data
       if (context?.previousTrack) {
-        queryClient.setQueryData(
-          getTrackQueryKey(trackId),
-          context.previousTrack
-        )
+        primeTrackData({
+          tracks: [context.previousTrack],
+          queryClient,
+          forceReplace: true
+        })
       }
 
       // Roll back all collections that contain this track


### PR DESCRIPTION
### Description

Since primeEntityData functions do computed data on top of adding things to the cache, I went through and updated all instances of "setQueryData" related to entities and replaced them with primeEntityData