### PR TITLE
Prime search results to improve autocomplete performance

### DIFF
--- a/packages/common/src/adapters/search.ts
+++ b/packages/common/src/adapters/search.ts
@@ -1,5 +1,9 @@
 import { full } from '@audius/sdk'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 
+import { primeCollectionData } from '~/api/tan-query/utils/primeCollectionData'
+import { primeTrackData } from '~/api/tan-query/utils/primeTrackData'
+import { primeUserData } from '~/api/tan-query/utils/primeUserData'
 import {
   UserTrackMetadata,
   UserCollectionMetadata,
@@ -23,47 +27,74 @@ export type SearchResults = {
 }
 
 export const searchResultsFromSDK = (
-  input?: full.SearchModel
+  input?: full.SearchModel,
+  queryClient?: QueryClient
 ): SearchResults => {
-  return input
-    ? {
-        tracks: transformAndCleanList(input.tracks, userTrackMetadataFromSDK),
-        saved_tracks: transformAndCleanList(
-          input.savedTracks,
-          userTrackMetadataFromSDK
-        ),
-        users: transformAndCleanList(input.users, userMetadataFromSDK),
-        followed_users: transformAndCleanList(
-          input.followedUsers,
-          userMetadataFromSDK
-        ),
-        playlists: transformAndCleanList(
-          input.playlists,
-          userCollectionMetadataFromSDK
-        ),
-        saved_playlists: transformAndCleanList(
-          input.savedPlaylists ?? [],
-          userCollectionMetadataFromSDK
-        ),
-        albums: transformAndCleanList(
-          input.albums,
-          userCollectionMetadataFromSDK
-        ),
-        saved_albums: transformAndCleanList(
-          input.savedAlbums,
-          userCollectionMetadataFromSDK
-        )
-      }
-    : {
-        users: [],
-        followed_users: [],
-        tracks: [],
-        saved_tracks: [],
-        playlists: [],
-        saved_playlists: [],
-        saved_albums: [],
-        albums: []
-      }
+  if (!input) {
+    return {
+      users: [],
+      followed_users: [],
+      tracks: [],
+      saved_tracks: [],
+      playlists: [],
+      saved_playlists: [],
+      saved_albums: [],
+      albums: []
+    }
+  }
+
+  const tracks = transformAndCleanList(input.tracks, userTrackMetadataFromSDK)
+  const saved_tracks = transformAndCleanList(
+    input.savedTracks,
+    userTrackMetadataFromSDK
+  )
+
+  const users = transformAndCleanList(input.users, userMetadataFromSDK)
+  const followed_users = transformAndCleanList(
+    input.followedUsers,
+    userMetadataFromSDK
+  )
+
+  const playlists = transformAndCleanList(
+    input.playlists,
+    userCollectionMetadataFromSDK
+  )
+  const saved_playlists = transformAndCleanList(
+    input.savedPlaylists ?? [],
+    userCollectionMetadataFromSDK
+  )
+
+  const albums = transformAndCleanList(
+    input.albums,
+    userCollectionMetadataFromSDK
+  )
+  if (queryClient) primeCollectionData({ collections: albums, queryClient })
+  const saved_albums = transformAndCleanList(
+    input.savedAlbums,
+    userCollectionMetadataFromSDK
+  )
+  if (queryClient)
+    primeCollectionData({ collections: saved_albums, queryClient })
+
+  if (queryClient) {
+    primeTrackData({ tracks, queryClient })
+    primeTrackData({ tracks: saved_tracks, queryClient })
+    primeUserData({ users, queryClient })
+    primeUserData({ users: followed_users, queryClient })
+    primeCollectionData({ collections: playlists, queryClient })
+    primeCollectionData({ collections: saved_playlists, queryClient })
+  }
+
+  return {
+    tracks,
+    saved_tracks,
+    users,
+    followed_users,
+    playlists,
+    saved_playlists,
+    albums,
+    saved_albums
+  }
 }
 
 export const AUTOCOMPLETE_TOTAL_RESULTS = 3

--- a/packages/common/src/adapters/search.ts
+++ b/packages/common/src/adapters/search.ts
@@ -68,13 +68,10 @@ export const searchResultsFromSDK = (
     input.albums,
     userCollectionMetadataFromSDK
   )
-  if (queryClient) primeCollectionData({ collections: albums, queryClient })
   const saved_albums = transformAndCleanList(
     input.savedAlbums,
     userCollectionMetadataFromSDK
   )
-  if (queryClient)
-    primeCollectionData({ collections: saved_albums, queryClient })
 
   if (queryClient) {
     primeTrackData({ tracks, queryClient })
@@ -83,6 +80,8 @@ export const searchResultsFromSDK = (
     primeUserData({ users: followed_users, queryClient })
     primeCollectionData({ collections: playlists, queryClient })
     primeCollectionData({ collections: saved_playlists, queryClient })
+    primeCollectionData({ collections: albums, queryClient })
+    primeCollectionData({ collections: saved_albums, queryClient })
   }
 
   return {

--- a/packages/common/src/adapters/search.ts
+++ b/packages/common/src/adapters/search.ts
@@ -1,5 +1,5 @@
 import { full } from '@audius/sdk'
-import { useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { type QueryClient } from '@tanstack/react-query'
 
 import { primeCollectionData } from '~/api/tan-query/utils/primeCollectionData'
 import { primeTrackData } from '~/api/tan-query/utils/primeTrackData'

--- a/packages/common/src/api/tan-query/search/useSearchAutocomplete.ts
+++ b/packages/common/src/api/tan-query/search/useSearchAutocomplete.ts
@@ -1,5 +1,5 @@
 import { OptionalId } from '@audius/sdk'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { SearchResults, searchResultsFromSDK } from '~/adapters/search'
 import { useQueryContext } from '~/api/tan-query/utils'
@@ -32,6 +32,7 @@ export const useSearchAutocomplete = (
   const { isEnabled: isUSDCEnabled } = useFeatureFlag(
     FeatureFlags.USDC_PURCHASES
   )
+  const queryClient = useQueryClient()
 
   return useQuery({
     queryKey: getSearchAutocompleteQueryKey({ query, limit }),
@@ -43,8 +44,7 @@ export const useSearchAutocomplete = (
         limit,
         includePurchaseable: isUSDCEnabled
       })
-
-      return searchResultsFromSDK(data)
+      return searchResultsFromSDK(data, queryClient)
     },
     placeholderData: (prev) => (query === '' ? undefined : prev),
     ...options,

--- a/packages/common/src/api/tan-query/search/useSearchResults.ts
+++ b/packages/common/src/api/tan-query/search/useSearchResults.ts
@@ -204,7 +204,10 @@ const useSearchQueryProps = <T>(
         ? await sdk.full.search.searchTags(searchParams)
         : await sdk.full.search.search(searchParams)
 
-      const { tracks, playlists, albums, users } = searchResultsFromSDK(data)
+      const { tracks, playlists, albums, users } = searchResultsFromSDK(
+        data,
+        queryClient
+      )
 
       const primeSearchSlice = <
         T extends LineupData | UserMetadata | UserCollectionMetadata


### PR DESCRIPTION
### Description

Prime the cache for search results so the hooks don't have to do an extra fetch when rendering autocomplete search results.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed autocomplete loads in at once without extra network requests. Local web against prod