### PR TITLE
[QA-2188] Fix sign out not working

### DIFF
--- a/packages/mobile/src/store/sign-out/sagas.ts
+++ b/packages/mobile/src/store/sign-out/sagas.ts
@@ -41,7 +41,6 @@ function* signOut() {
   yield* call(waitForValue, getIsSettingUp, {}, (isSettingUp) => !isSettingUp)
 
   yield* put(resetAccount())
-  queryClient.clear()
   yield* put(feedPageLineupActions.reset())
 
   yield* put(clearHistory())
@@ -58,6 +57,11 @@ function* signOut() {
   for (const storageKey of storageKeysToRemove) {
     yield* call([localStorage, 'removeItem'], storageKey)
   }
+  // NOTE: Weird workaround here - queryClient.clear() is necessary to delete all of the cache
+  // HOWEVER, this does NOT trigger a rerender on any active queries.
+  // So we need to call resetQueries() to trigger a rerender and then clear the cache.
+  queryClient.resetQueries()
+  queryClient.clear() // ORDER MATTERS HERE - clear() must be called after resetQueries()
   // On web we reload the page to get the app into a state
   // where it is acting like first-load. On mobile, in order to
   // get the same behavior, call to set up the backend again,

--- a/packages/web/src/store/sign-out/sagas.ts
+++ b/packages/web/src/store/sign-out/sagas.ts
@@ -1,4 +1,3 @@
-import { QUERY_KEYS } from '@audius/common/api'
 import { Name } from '@audius/common/models'
 import { TRENDING_PAGE } from '@audius/common/src/utils/route'
 import {
@@ -29,7 +28,11 @@ function* watchSignOut() {
         yield call(disconnect, wagmiConfig)
       }
       yield put(resetAccount())
-      queryClient.resetQueries({ queryKey: [QUERY_KEYS.account] })
+      // NOTE: Weird workaround here - queryClient.clear() is necessary to delete all of the cache
+      // HOWEVER, this does NOT trigger a rerender on any active queries.
+      // So we need to call resetQueries() to trigger a rerender and then clear the cache.
+      queryClient.resetQueries()
+      queryClient.clear() // ORDER MATTERS HERE - clear() must be called after resetQueries()
       yield put(unsubscribeBrowserPushNotifications())
       yield put(
         make(Name.SETTINGS_LOG_OUT, {


### PR DESCRIPTION
### Description

- Turns out `queryClient.clear` doesn't trigger rerenders to active queries, so I added a `resetQueries` - and also moved the call below the local storage clear calls

### How Has This Been Tested?

ios:stage logging out

![2025-06-30 16 25 31](https://github.com/user-attachments/assets/7d8ac849-d2c2-43fe-9989-7b8a3d4c0c35)
