### PR TITLE
[QA-2189] Fix DM blast crash while users are loading

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx
@@ -120,7 +120,7 @@ const TrackItem = (props: TrackItemProps) => {
                 ]}
                 numberOfLines={1}
               >
-                {`${messages.by} ${track.user.name}`}
+                {`${messages.by} ${track.user?.name}`}
               </Text>
             ) : null}
             {deleted ? (

--- a/packages/mobile/src/screens/chat-screen/ChatMessagePlaylist.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessagePlaylist.tsx
@@ -34,8 +34,12 @@ export const ChatMessagePlaylist = ({
   const { data: collection } = useCollectionByPermalink(permalink)
 
   const trackIds = collection?.trackIds ?? []
-  const { data: tracks } = useTracks(trackIds)
-  const { byId: usersById } = useUsers(tracks?.map((t) => t.owner_id))
+  const { data: tracks, isPending: isTracksPending } = useTracks(trackIds)
+  const { byId: usersById, isPending: isUsersPending } = useUsers(
+    tracks?.map((t) => t.owner_id)
+  )
+
+  const isLoading = isTracksPending || isUsersPending
 
   const collectionId = collection?.playlist_id
 
@@ -129,7 +133,7 @@ export const ChatMessagePlaylist = ({
     }
   }, [collectionExists, uid, onSuccess, onEmpty])
 
-  return collectionId && uid ? (
+  return collectionId && uid && !isLoading ? (
     <CollectionTile
       index={0}
       id={collectionId}


### PR DESCRIPTION
### Description

- Fix ChatListItem crashing due to `track.user.name` caused by the user still loading (occurs in DMs that sent a playlist)

### How Has This Been Tested?

ios:prod w/Kato's blast
