### PR TITLE
Make our eth rpc conform to updated viem

### DIFF
--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -5,7 +5,7 @@ import {
   SolanaRelay,
   ArchiverService
 } from '@audius/sdk'
-import { createWalletClient, custom } from 'viem'
+import { createWalletClient, custom, RpcRequestError } from 'viem'
 import { mainnet } from 'viem/chains'
 import { getHttpRpcClient } from 'viem/utils'
 
@@ -71,20 +71,27 @@ export const initSdk = async () => {
     chain: mainnet,
     transport: custom({
       request: async (request) => {
+        const url = `${env.IDENTITY_SERVICE}/ethereum/rpc`
         const message = `signature:${new Date().getTime()}`
         const signature = await audiusWalletClient.signMessage({ message })
-        const rpcClient = getHttpRpcClient(
-          `${env.IDENTITY_SERVICE}/ethereum/rpc`,
-          {
-            fetchOptions: {
-              headers: {
-                'Encoded-Data-Message': message,
-                'Encoded-Data-Signature': signature
-              }
+        const rpcClient = getHttpRpcClient(url, {
+          fetchOptions: {
+            headers: {
+              'Encoded-Data-Message': message,
+              'Encoded-Data-Signature': signature
             }
           }
-        )
-        return await rpcClient.request(request)
+        })
+        const res = await rpcClient.request({ body: request })
+        if ('result' in res) {
+          return res.result
+        }
+        throw new RpcRequestError({
+          body: request,
+          error:
+            'error' in res ? res.error : { code: 0, message: 'Unknown error' },
+          url
+        })
       }
     })
   })


### PR DESCRIPTION
### Description

https://github.com/wevm/viem/blame/f9ddb33438eef8d14296d56b0150ec6d058e19d0/src/clients/transports/http.ts
See usage here - it unpacks result, error and also sends with `body`. Neither of these things we were doing correctly before. Unclear when that changed?

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Wormhole transfer on prod with `npm run web:prod`