### PR TITLE
Update sdk gen script to use bridge server

### DIFF
--- a/packages/sdk/src/sdk/api/generator/README.md
+++ b/packages/sdk/src/sdk/api/generator/README.md
@@ -23,9 +23,9 @@ npm run gen:{env}:{flavor?}
 ### Options
 
 - `env` choices=("dev", "stage", "prod"): Which environment to choose the Discovery Provider to generate from
-  - `dev`: http://localhost:5000/
-  - `stage`: https://discoveryprovider.staging.audius.co/
-  - `prod`: https://discoveryprovider.audius.co
+  - `dev`: http://localhost:1323/
+  - `stage`: https://api.staging.audius.co/
+  - `prod`: https://api.audius.co
 - `flavor` [optional] choices=("default", "full"): Which flavor of the API to generate types for
   - undefined for both
   - `default` for /v1

--- a/packages/sdk/src/sdk/api/generator/README.md
+++ b/packages/sdk/src/sdk/api/generator/README.md
@@ -23,7 +23,7 @@ npm run gen:{env}:{flavor?}
 ### Options
 
 - `env` choices=("dev", "stage", "prod"): Which environment to choose the Discovery Provider to generate from
-  - `dev`: http://localhost:1323/
+  - `dev`: http://127.0.0.1:1323/
   - `stage`: https://api.staging.audius.co/
   - `prod`: https://api.audius.co
 - `flavor` [optional] choices=("default", "full"): Which flavor of the API to generate types for

--- a/packages/sdk/src/sdk/api/generator/gen.js
+++ b/packages/sdk/src/sdk/api/generator/gen.js
@@ -22,7 +22,7 @@ const GENERATED_DIR = 'src/sdk/api/generated'
 
 const spawnOpenAPIGenerator = async (openApiGeneratorArgs) => {
   console.info('Running OpenAPI Generator:')
-  const fullCmd = `docker run --add-host=audius-protocol-discovery-provider-1:host-gateway --user $(id -u):$(id -g) --rm -v "${
+  const fullCmd = `docker run --add-host=host.docker.internal:host-gateway --user $(id -u):$(id -g) --rm -v "${
     process.env.PWD
   }:/local" openapitools/openapi-generator-cli:v7.5.0 ${openApiGeneratorArgs.join(
     ' '
@@ -53,13 +53,11 @@ const downloadSpec = async ({ env, apiVersion, apiFlavor }) => {
   // Setup args
   let baseURL = ''
   if (env === 'dev') {
-    baseURL = 'http://audius-protocol-discovery-provider-1'
+    baseURL = 'http://127.0.0.1:1323'
   } else if (env === 'stage') {
-    // Hardcode a stage DN, it doesn't matter
-    baseURL = 'https://discoveryprovider.staging.audius.co'
+    baseURL = 'https://api.staging.audius.co'
   } else if (env === 'prod') {
-    // Hardcode a prod DN, it doesn't matter
-    baseURL = 'https://discoveryprovider.audius.co'
+    baseURL = 'https://api.audius.co'
   }
   const apiPath = apiFlavor === '' ? apiVersion : `${apiVersion}/${apiFlavor}`
 


### PR DESCRIPTION
### Description
Bridge server has an implementation of the swagger docs running now. So this switches SDK generation to use the local/stage/prod URLs for that instead.

### How Has This Been Tested?
`npm run -w @audius/sdk gen:dev` against a local bridge server. Verified that no generated files changed.
