### PR TITLE
[QA-2191] Fix trending lineup scroll issues

### DIFF
--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -772,7 +772,10 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
                 useWindow={isMobile}
                 initialLoad={false}
                 getScrollParent={() => {
-                  if (scrollParent?.id === 'mainContent') {
+                  if (
+                    scrollParent?.id === 'mainContent' ||
+                    scrollParent === null
+                  ) {
                     return document.getElementById('mainContent')
                   }
                   return scrollParent


### PR DESCRIPTION
### Description

- #12378 broke the scroll ref somehow. Rather than dig extra deep to figure out the issue I'm just going to default to mainContentRef for our lineups. Could go deeper but this lineup component is short lived anyways

### How Has This Been Tested?

web:stage - desktop & web - trending & feed infinite scrolling
