### PR TITLE
Update the amout of decimal places we show

### DIFF
--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -4,7 +4,7 @@ import { AUDIO } from '@audius/fixed-decimal'
 
 import { useAudioBalance, useTokenPrice } from '../api'
 import { TOKEN_LISTING_MAP } from '../store'
-import { getCurrencyDecimalPlaces, isNullOrUndefined } from '../utils'
+import { formatAudioBalance, isNullOrUndefined } from '../utils'
 
 // AUDIO token address from Jupiter
 const AUDIO_TOKEN_ID = TOKEN_LISTING_MAP.AUDIO.address
@@ -26,15 +26,9 @@ export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
   const hasFetchedAudioBalance = !isNullOrUndefined(totalBalance)
   const audioBalance = hasFetchedAudioBalance ? totalBalance : null
 
-  const decimalPlaces = useMemo(() => {
-    if (!audioPrice) return 2
-    return getCurrencyDecimalPlaces(parseFloat(audioPrice))
-  }, [audioPrice])
-
+  // Format AUDIO balance with dynamic decimal places (minimum 2)
   const audioBalanceFormatted = hasFetchedAudioBalance
-    ? AUDIO(totalBalance).toLocaleString('en-US', {
-        maximumFractionDigits: decimalPlaces
-      })
+    ? formatAudioBalance(totalBalance)
     : null
 
   // Calculate dollar value of user's AUDIO balance

--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -35,7 +35,6 @@ export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
   const audioDollarValue = useMemo(() => {
     if (!audioPrice || !audioBalance) return '$0.00'
 
-    // Use FixedDecimal for proper decimal handling instead of parseFloat
     const priceNumber = Number(new FixedDecimal(audioPrice).toString())
     const balanceValue = Number(AUDIO(audioBalance).toString())
     const totalValue = priceNumber * balanceValue

--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { AUDIO } from '@audius/fixed-decimal'
+import { AUDIO, FixedDecimal } from '@audius/fixed-decimal'
 
 import { useAudioBalance, useTokenPrice } from '../api'
 import { TOKEN_LISTING_MAP } from '../store'
@@ -35,11 +35,12 @@ export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
   const audioDollarValue = useMemo(() => {
     if (!audioPrice || !audioBalance) return '$0.00'
 
-    const priceNumber = parseFloat(audioPrice)
-    const balanceValue = parseFloat(AUDIO(audioBalance).toString())
+    // Use FixedDecimal for proper decimal handling instead of parseFloat
+    const priceNumber = Number(new FixedDecimal(audioPrice).toString())
+    const balanceValue = Number(AUDIO(audioBalance).toString())
     const totalValue = priceNumber * balanceValue
 
-    return `$${totalValue.toFixed(2)} ($${parseFloat(audioPrice).toFixed(4)})`
+    return `$${totalValue.toFixed(2)} ($${Number(new FixedDecimal(audioPrice).toString()).toFixed(4)})`
   }, [audioBalance, audioPrice])
 
   return {

--- a/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
@@ -33,7 +33,6 @@ const getSafeNumericValue = (value: string | number): number => {
 export const useTokenAmountFormatting = ({
   amount,
   availableBalance,
-  exchangeRate,
   isStablecoin,
   placeholder = '0.00'
 }: UseTokenAmountFormattingProps) => {
@@ -61,8 +60,7 @@ export const useTokenAmountFormatting = ({
     const decimals = getAudioBalanceDecimalPlaces(availableBalance)
 
     return audioAmount.toLocaleString('en-US', {
-      maximumFractionDigits: decimals,
-      roundingMode: 'trunc'
+      maximumFractionDigits: decimals
     })
   }, [availableBalance, placeholder, isStablecoin])
 
@@ -81,8 +79,7 @@ export const useTokenAmountFormatting = ({
     const decimals = getAudioBalanceDecimalPlaces(safeNumericAmount)
 
     return audioAmount.toLocaleString('en-US', {
-      maximumFractionDigits: decimals,
-      roundingMode: 'trunc'
+      maximumFractionDigits: decimals
     })
   }, [amount, placeholder, isStablecoin])
 

--- a/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
@@ -55,8 +55,8 @@ export const useTokenAmountFormatting = ({
       return formatUSDCValue(availableBalance)
     }
 
-    // Use the same logic as formatAudioBalance for non-stablecoins
-    // Convert to AUDIO fixed decimal for proper truncation formatting
+    // Use AUDIO for non-stablecoins for now, when we expand to other tokens
+    // we will need to use FixedDecimal itself
     const audioAmount = AUDIO(availableBalance)
     const decimals = getAudioBalanceDecimalPlaces(availableBalance)
 
@@ -77,8 +77,6 @@ export const useTokenAmountFormatting = ({
       return formatUSDCValue(safeNumericAmount)
     }
 
-    // Use the same logic as formatAudioBalance for non-stablecoins
-    // Convert to AUDIO fixed decimal for proper truncation formatting
     const audioAmount = AUDIO(safeNumericAmount)
     const decimals = getAudioBalanceDecimalPlaces(safeNumericAmount)
 

--- a/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
@@ -1,7 +1,12 @@
 import { useCallback, useMemo } from 'react'
 
+import { AUDIO } from '@audius/fixed-decimal'
+
 import { formatUSDCValue } from '../../../api'
-import { getCurrencyDecimalPlaces } from '../../../utils'
+import {
+  getAudioBalanceDecimalPlaces,
+  getCurrencyDecimalPlaces
+} from '../../../utils'
 
 export type UseTokenAmountFormattingProps = {
   amount?: string | number
@@ -50,19 +55,16 @@ export const useTokenAmountFormatting = ({
       return formatUSDCValue(availableBalance)
     }
 
-    const decimals = getDisplayDecimalPlaces(exchangeRate)
+    // Use the same logic as formatAudioBalance for non-stablecoins
+    // Convert to AUDIO fixed decimal for proper truncation formatting
+    const audioAmount = AUDIO(availableBalance)
+    const decimals = getAudioBalanceDecimalPlaces(availableBalance)
 
-    return availableBalance.toLocaleString('en-US', {
-      minimumFractionDigits: defaultDecimalPlaces,
-      maximumFractionDigits: decimals
+    return audioAmount.toLocaleString('en-US', {
+      maximumFractionDigits: decimals,
+      roundingMode: 'trunc'
     })
-  }, [
-    availableBalance,
-    exchangeRate,
-    getDisplayDecimalPlaces,
-    placeholder,
-    isStablecoin
-  ])
+  }, [availableBalance, placeholder, isStablecoin])
 
   const formattedAmount = useMemo(() => {
     if (!amount && amount !== 0) return placeholder
@@ -75,13 +77,16 @@ export const useTokenAmountFormatting = ({
       return formatUSDCValue(safeNumericAmount)
     }
 
-    const decimals = getDisplayDecimalPlaces(exchangeRate)
+    // Use the same logic as formatAudioBalance for non-stablecoins
+    // Convert to AUDIO fixed decimal for proper truncation formatting
+    const audioAmount = AUDIO(safeNumericAmount)
+    const decimals = getAudioBalanceDecimalPlaces(safeNumericAmount)
 
-    return safeNumericAmount.toLocaleString('en-US', {
-      minimumFractionDigits: defaultDecimalPlaces,
-      maximumFractionDigits: decimals
+    return audioAmount.toLocaleString('en-US', {
+      maximumFractionDigits: decimals,
+      roundingMode: 'trunc'
     })
-  }, [amount, exchangeRate, getDisplayDecimalPlaces, placeholder, isStablecoin])
+  }, [amount, placeholder, isStablecoin])
 
   return {
     formattedAvailableBalance,

--- a/packages/common/src/utils/decimal.ts
+++ b/packages/common/src/utils/decimal.ts
@@ -69,3 +69,76 @@ export const getCurrencyDecimalPlaces = (priceUSD: number) => {
   if (priceUSD >= 0.0001) return 6
   return 8
 }
+
+/**
+ * Returns the number of decimal places to show for AUDIO balance formatting
+ * based on the balance magnitude. Smaller balances show more decimals to remain meaningful.
+ * Always shows a minimum of 2 decimal places.
+ *
+ * @param balance - The balance value to determine decimal places for
+ * @returns Number of decimal places to show (minimum 2)
+ *
+ * @example
+ * getAudioBalanceDecimalPlaces(1234.56)   // 2 → "1,234.56"
+ * getAudioBalanceDecimalPlaces(92.0253)   // 2 → "92.02"
+ * getAudioBalanceDecimalPlaces(1.2345)    // 2 → "1.23"
+ * getAudioBalanceDecimalPlaces(0.1234)    // 3 → "0.123"
+ * getAudioBalanceDecimalPlaces(0.00123)   // 5 → "0.00123"
+ */
+export const getAudioBalanceDecimalPlaces = (balance: number) => {
+  const absBalance = Math.abs(balance)
+
+  // Dynamic precision based on balance magnitude with minimum 2 decimals
+  if (absBalance >= 1000) {
+    return 2 // 1,234.56 (minimum 2 decimals even for large amounts)
+  }
+  if (absBalance >= 100) {
+    return 2 // 123.45
+  }
+  if (absBalance >= 10) {
+    return 2 // 12.34
+  }
+  if (absBalance >= 1) {
+    return 2 // 1.23
+  }
+  if (absBalance >= 0.1) {
+    return 3 // 0.123
+  }
+  if (absBalance >= 0.01) {
+    return 4 // 0.0123
+  }
+  if (absBalance >= 0.001) {
+    return 5 // 0.00123
+  }
+
+  // For very small amounts, show enough decimals to see meaningful value
+  return 6
+}
+
+/**
+ * Formats an AUDIO balance with dynamic decimal places based on magnitude and truncation.
+ * Uses smart decimal precision that adapts to the balance size, with a minimum of 2 decimals.
+ * Never rounds up.
+ *
+ * @param balance - The AUDIO balance as AudioWei (bigint)
+ * @param locale - Locale for formatting (defaults to 'en-US')
+ * @returns Formatted balance string
+ */
+export const formatAudioBalance = (
+  balance: bigint,
+  locale: string = 'en-US'
+): string => {
+  // Import AUDIO here to avoid circular dependencies
+  const { AUDIO } = require('@audius/fixed-decimal')
+
+  // Convert balance to number for decimal place calculation
+  const balanceNumber = parseFloat(AUDIO(balance).toString())
+  const decimalPlaces = getAudioBalanceDecimalPlaces(balanceNumber)
+
+  return AUDIO(balance).toLocaleString(locale, {
+    maximumFractionDigits: decimalPlaces,
+    // Ensure we use truncation (never round up) - this is already the default
+    // but being explicit about it per user requirements
+    roundingMode: 'trunc'
+  })
+}

--- a/packages/common/src/utils/decimal.ts
+++ b/packages/common/src/utils/decimal.ts
@@ -1,4 +1,4 @@
-import { AUDIO, FixedDecimal } from '@audius/fixed-decimal'
+import { AUDIO } from '@audius/fixed-decimal'
 
 const PRECISION = 2
 
@@ -62,7 +62,7 @@ export const decimalIntegerFromHumanReadable = (
   value: string,
   { precision = PRECISION }: DecimalUtilOptions = {}
 ) => {
-  return Number(new FixedDecimal(value).toString()) * 10 ** precision
+  return parseFloat(value) * 10 ** precision
 }
 
 export const getCurrencyDecimalPlaces = (priceUSD: number) => {

--- a/packages/common/src/utils/decimal.ts
+++ b/packages/common/src/utils/decimal.ts
@@ -1,3 +1,5 @@
+import { AUDIO, FixedDecimal } from '@audius/fixed-decimal'
+
 const PRECISION = 2
 
 export type DecimalUtilOptions = {
@@ -60,7 +62,7 @@ export const decimalIntegerFromHumanReadable = (
   value: string,
   { precision = PRECISION }: DecimalUtilOptions = {}
 ) => {
-  return parseFloat(value) * 10 ** precision
+  return Number(new FixedDecimal(value).toString()) * 10 ** precision
 }
 
 export const getCurrencyDecimalPlaces = (priceUSD: number) => {
@@ -88,7 +90,6 @@ export const getCurrencyDecimalPlaces = (priceUSD: number) => {
 export const getAudioBalanceDecimalPlaces = (balance: number) => {
   const absBalance = Math.abs(balance)
 
-  // Dynamic precision based on balance magnitude with minimum 2 decimals
   if (absBalance >= 1000) {
     return 2 // 1,234.56 (minimum 2 decimals even for large amounts)
   }
@@ -115,30 +116,15 @@ export const getAudioBalanceDecimalPlaces = (balance: number) => {
   return 6
 }
 
-/**
- * Formats an AUDIO balance with dynamic decimal places based on magnitude and truncation.
- * Uses smart decimal precision that adapts to the balance size, with a minimum of 2 decimals.
- * Never rounds up.
- *
- * @param balance - The AUDIO balance as AudioWei (bigint)
- * @param locale - Locale for formatting (defaults to 'en-US')
- * @returns Formatted balance string
- */
 export const formatAudioBalance = (
   balance: bigint,
   locale: string = 'en-US'
 ): string => {
-  // Import AUDIO here to avoid circular dependencies
-  const { AUDIO } = require('@audius/fixed-decimal')
-
-  // Convert balance to number for decimal place calculation
-  const balanceNumber = parseFloat(AUDIO(balance).toString())
+  const balanceNumber = Number(AUDIO(balance).toString())
   const decimalPlaces = getAudioBalanceDecimalPlaces(balanceNumber)
 
   return AUDIO(balance).toLocaleString(locale, {
     maximumFractionDigits: decimalPlaces,
-    // Ensure we use truncation (never round up) - this is already the default
-    // but being explicit about it per user requirements
     roundingMode: 'trunc'
   })
 }


### PR DESCRIPTION
### Description

This pull request introduces refined formatting for AUDIO token balances 

**Key Changes:**

- **Improved AUDIO Balance Formatting:**

  - A new utility function, `getAudioBalanceDecimalPlaces`, has been added to `packages/common/src/utils/decimal.ts`. This function dynamically determines the number of decimal places to display for an AUDIO balance, ensuring more precision for smaller amounts while maintaining readability for larger ones, with a minimum of two decimal places.
  - Another new utility, `formatAudioBalance`, has been introduced in `packages/common/src/utils/decimal.ts` to consistently format AUDIO balances. This function leverages `getAudioBalanceDecimalPlaces` and applies truncation, ensuring that balances are never rounded up.
  - The `useFormattedAudioBalance` hook in `packages/common/src/hooks/useFormattedAudioBalance.ts` has been updated to utilize the new `formatAudioBalance` utility for consistent and dynamic display of AUDIO balances.
  - The `useTokenAmountFormatting` hook in `packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts` has been modified to align its AUDIO formatting logic with the new `formatAudioBalance` and `getAudioBalanceDecimalPlaces` utilities, specifically for the `formattedAvailableBalance` and `formattedAmount` calculations, ensuring truncation is applied.


### How Has This Been Tested?

`npm run ios:prod` and play around with inputting amounts in the buy/sell input fields and ensure the decimal places look ight 
