### PR TITLE
Fix scroll in chat user list

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
@@ -298,7 +298,6 @@ export const ChatUserListScreen = () => {
           ) : (
             <KeyboardAwareFlatList
               onEndReached={handleLoadMore}
-              maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
               data={users}
               renderItem={({ item }) => (
                 <ChatUserListItem


### PR DESCRIPTION
### Description

Previously, when a user typed into the "New Message" search bar on mobile, the results list would incorrectly scroll to the bottom, displaying seemingly random low-match users. To see relevant results, users had to manually scroll up. This was caused by the `maintainVisibleContentPosition` prop on the `KeyboardAwareFlatList` in `ChatUserListScreen.tsx`. This prop is intended for chat-like interfaces where new items are added to the top and the scroll position needs to be maintained, but it's not suitable for search results.

### Changes

Removed the `maintainVisibleContentPosition` prop from the `KeyboardAwareFlatList` in `packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx`.

### Rationale

- For search results, the expected behavior is for the list to start from the top when new results are loaded, displaying the most relevant matches first.
- The `maintainVisibleContentPosition` prop is specifically designed for scenarios where content is added to the top of a list (e.g., new messages in a chat) and the user's current scroll position should be preserved. This behavior is counterproductive for a search results list.
- This change aligns the search results behavior with user expectations and the pattern observed in other search screens within the codebase.


### How Has This Been Tested?

`npm run ios:prod` 

- go to messages
- click compose button in top right
- search for user
- ensure items load properly 
