### PR TITLE
[QA-2190] Fix download all button text

### DIFF
--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -50,7 +50,8 @@ const messages = {
   followToDownload: 'Must follow artist to download.',
   purchaseableIsOwner: (price: string) =>
     `Fans can unlock & download these files for a one time purchase of ${price}`,
-  downloadAll: 'Download All'
+  downloadAll: 'Download All',
+  download: 'Download'
 }
 
 export const DownloadSection = ({ trackId }: { trackId: ID }) => {
@@ -154,6 +155,17 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
     trackId
   ])
 
+  const hasStems = stemTracks.length > 0
+  const downloadButtonText = hasStems ? messages.downloadAll : messages.download
+
+  const handleDownloadButtonPress = useCallback(() => {
+    if (hasStems) {
+      handleDownloadAll()
+    } else {
+      handleDownload({ trackIds: [trackId] })
+    }
+  }, [hasStems, handleDownloadAll, handleDownload, trackId])
+
   const renderHeader = () => {
     return (
       <Flex gap='l' column pb={isExpanded ? 'l' : undefined}>
@@ -204,10 +216,10 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
           <Button
             variant='secondary'
             size='small'
-            onPress={handleDownloadAll}
+            onPress={handleDownloadButtonPress}
             fullWidth
           >
-            {messages.downloadAll}
+            {downloadButtonText}
           </Button>
         ) : null}
         {shouldDisplayOwnerPremiumDownloads && formattedPrice ? (

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -59,7 +59,8 @@ const messages = {
   followToDownload: 'Must follow artist to download.',
   purchaseableIsOwner: (price: string) =>
     `Fans can unlock & download these files for a one time purchase of ${price}`,
-  downloadAll: 'Download All'
+  downloadAll: 'Download All',
+  download: 'Download'
 }
 
 type DownloadSectionProps = {
@@ -187,6 +188,21 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
     [openDownloadTrackArchiveModal, trackId, stemTracks.length]
   )
 
+  const hasStems = stemTracks.length > 0 || isUploadingStems
+  const downloadButtonText = hasStems ? messages.downloadAll : messages.download
+
+  const handleDownloadButtonClick = useRequiresAccountCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation()
+      if (hasStems) {
+        handleDownloadAll(e)
+      } else {
+        handleDownload({ trackIds: [trackId] })
+      }
+    },
+    [hasStems, handleDownloadAll, handleDownload, trackId]
+  )
+
   const renderDownloadAllButton = () => {
     if (shouldHideDownload || !isDownloadAllTrackFilesEnabled) {
       return null
@@ -204,9 +220,9 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
             disabled={shouldDisplayDownloadFollowGated}
             variant='secondary'
             size='small'
-            onClick={handleDownloadAll}
+            onClick={handleDownloadButtonClick}
           >
-            {messages.downloadAll}
+            {downloadButtonText}
           </Button>
         </Flex>
       </Tooltip>

--- a/packages/web/src/pages/track-page/components/mobile/DownloadSection.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/DownloadSection.tsx
@@ -51,7 +51,8 @@ const messages = {
   followToDownload: 'Must follow artist to download.',
   purchaseableIsOwner: (price: string) =>
     `Fans can unlock & download these files for a one time purchase of ${price}`,
-  downloadAll: 'Download All'
+  downloadAll: 'Download All',
+  download: 'Download Track'
 }
 
 type DownloadSectionProps = {
@@ -177,6 +178,21 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
     ]
   )
 
+  const hasStems = stemTracks.length > 0
+  const downloadButtonText = hasStems ? messages.downloadAll : messages.download
+
+  const handleDownloadButtonClick = useRequiresAccountCallback(
+    (e) => {
+      e.stopPropagation()
+      if (hasStems) {
+        handleDownloadAll(e)
+      } else {
+        handleDownload({ trackIds: [trackId] })
+      }
+    },
+    [hasStems, handleDownloadAll, handleDownload, trackId]
+  )
+
   return (
     <Box css={{ overflow: 'hidden' }}>
       <Flex direction='column'>
@@ -246,10 +262,10 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
               variant='secondary'
               size='small'
               iconLeft={IconReceive}
-              onClick={handleDownloadAll}
+              onClick={handleDownloadButtonClick}
               fullWidth
             >
-              {messages.downloadAll}
+              {downloadButtonText}
             </Button>
           )}
         </Flex>


### PR DESCRIPTION
### Description

Fixes issue where tracks that just have track download weren't working due using the stems-archiver instead of direct download.