### PR TITLE
[PE-6468] Add BONK token support to solana-relay plugin

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
@@ -44,7 +44,7 @@ type Config = {
   ethRegistryProgramId: string
   usdcMintAddress: string
   waudioMintAddress: string
-  trumpMintAddress: string
+  bonkMintAddress: string
   solanaFeePayerWallets: Keypair[]
   delegatePrivateKey: Buffer
   ipdataApiKey: string | null
@@ -95,8 +95,8 @@ const readConfig = (): Config => {
     audius_solana_usdc_mint: str({
       default: '26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y'
     }),
-    audius_solana_trump_mint: str({
-      default: '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN'
+    audius_solana_bonk_mint: str({
+      default: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263'
     }),
     audius_solana_user_bank_program_address: str({
       default: 'testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9'
@@ -177,7 +177,7 @@ const readConfig = (): Config => {
     trackListenCountProgramId: env.audius_solana_track_listen_count_address,
     usdcMintAddress: env.audius_solana_usdc_mint,
     waudioMintAddress: env.audius_solana_waudio_mint,
-    trumpMintAddress: env.audius_solana_trump_mint,
+    bonkMintAddress: env.audius_solana_bonk_mint,
     solanaFeePayerWallets,
     delegatePrivateKey,
     ipdataApiKey:

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
@@ -43,7 +43,7 @@ const COINFLOW_PROGRAM_ID = 'FD1amxhTsDpwzoVX41dxp2ygAESURV2zdUACzxM1Dfw9'
 
 const waudioMintAddress = config.waudioMintAddress
 const usdcMintAddress = config.usdcMintAddress
-const trumpMintAddress = config.trumpMintAddress
+const bonkMintAddress = config.bonkMintAddress
 
 const REWARD_MANAGER = config.rewardsManagerAccountAddress
 
@@ -56,7 +56,7 @@ const deriveTokenAuthority = (mint: string) =>
 const claimableTokenAuthorities = {
   usdc: deriveTokenAuthority(usdcMintAddress),
   waudio: deriveTokenAuthority(waudioMintAddress),
-  trump: deriveTokenAuthority(trumpMintAddress)
+  bonk: deriveTokenAuthority(bonkMintAddress)
 }
 
 const deriveUserBank = async (
@@ -106,7 +106,7 @@ const assertAllowedAssociatedTokenAccountProgramInstruction = async (
       NATIVE_MINT.toBase58(),
       usdcMintAddress,
       waudioMintAddress,
-      trumpMintAddress
+      bonkMintAddress
     ]
     const mintAddress = decodedInstruction.keys.mint.pubkey.toBase58()
     if (!allowedMints.includes(mintAddress)) {
@@ -199,15 +199,15 @@ const assertAllowedTokenProgramInstruction = async (
       wallet,
       claimableTokenAuthorities.usdc
     )
-    const trumpUserbank = await deriveUserBank(
+    const bonkUserbank = await deriveUserBank(
       wallet,
-      claimableTokenAuthorities.trump
+      claimableTokenAuthorities.bonk
     )
 
     // Check that destination is either a userbank or a payment router token account
     if (
       !destination.equals(usdcUserbank) &&
-      !destination.equals(trumpUserbank) &&
+      !destination.equals(bonkUserbank) &&
       !destination.equals(PAYMENT_ROUTER_USDC_TOKEN_ACCOUNT)
     ) {
       throw new InvalidRelayInstructionError(
@@ -259,7 +259,7 @@ const assertAllowedClaimableTokenProgramInstruction = async (
   if (
     !authority.equals(claimableTokenAuthorities.usdc) &&
     !authority.equals(claimableTokenAuthorities.waudio) &&
-    !authority.equals(claimableTokenAuthorities.trump)
+    !authority.equals(claimableTokenAuthorities.bonk)
   ) {
     throw new InvalidRelayInstructionError(
       instructionIndex,
@@ -290,15 +290,15 @@ const allowedSourceMints = [
   NATIVE_MINT.toBase58(),
   usdcMintAddress,
   waudioMintAddress,
-  trumpMintAddress
+  bonkMintAddress
 ]
 const allowedDestinationMints = [
   NATIVE_MINT.toBase58(),
   usdcMintAddress,
   waudioMintAddress,
-  trumpMintAddress
+  bonkMintAddress
 ]
-// Only allow swaps to SOL (for withdrawals) or USDC, AUDIO, or TRUMP (for userbank purchases)
+// Only allow swaps to SOL (for withdrawals) or USDC, AUDIO, or BONK (for userbank purchases)
 const assertAllowedJupiterProgramInstruction = async (
   instructionIndex: number,
   instruction: TransactionInstruction,


### PR DESCRIPTION
## Summary

This PR adds BONK token support to the solana-relay plugin, going to use for testing of other mints with buy/sell flow. Will remove once everything is tested. Going to test with UI flow setup [here](https://github.com/AudiusProject/audius-protocol/pull/12454)

## Changes

### Configuration
- Add `bonkMintAddress` to Config type and environment variable validation
- Add BONK mint address `DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263` with default configuration

