### PR TITLE
[QA-2197] Update related artists count add follows idx

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0143_follows_ix.sql
+++ b/packages/discovery-provider/ddl/migrations/0143_follows_ix.sql
@@ -1,0 +1,7 @@
+begin;
+
+CREATE INDEX IF NOT EXISTS idx_fanout 
+ON follows (follower_user_id, followee_user_id);
+
+commit;
+

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
@@ -292,7 +292,13 @@ const RelatedArtistsTile = ({ userId }: { userId: number }) => {
       content={
         <UserListWithCount
           users={relatedArtists}
-          count={isLoading ? MAX_CARD_PROFILE_PICTURES : relatedArtists.length}
+          count={
+            isLoading
+              ? MAX_CARD_PROFILE_PICTURES
+              : relatedArtists.length < MAX_CARD_PROFILE_PICTURES
+                ? relatedArtists.length
+                : 100
+          }
           loading={isLoading}
           showCount={false}
         />

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
@@ -48,6 +48,7 @@ import { ProfileTierTile } from './ProfileTierTile'
 
 const MAX_CARD_PROFILE_PICTURES = 4
 const PROFILE_CARD_PICTURE_SIZE = 24
+const DEFAULT_RELATED_ARTISTS_COUNT = 100
 
 const useInfoTileStyles = makeStyles(({ spacing }) => ({
   tile: { flexDirection: 'column', height: 64 },
@@ -297,7 +298,7 @@ const RelatedArtistsTile = ({ userId }: { userId: number }) => {
               ? MAX_CARD_PROFILE_PICTURES
               : relatedArtists.length < MAX_CARD_PROFILE_PICTURES
                 ? relatedArtists.length
-                : 100
+                : DEFAULT_RELATED_ARTISTS_COUNT
           }
           loading={isLoading}
           showCount={false}

--- a/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
@@ -23,6 +23,8 @@ const messages = {
   relatedArtists: 'Related Artists'
 }
 
+const DEFAULT_RELATED_ARTISTS_COUNT = 100
+
 export const RelatedArtists = () => {
   const dispatch = useDispatch()
   const { user: profile } = useProfileUser()
@@ -63,7 +65,7 @@ export const RelatedArtists = () => {
         totalUserCount={
           relatedArtists.length < MAX_PROFILE_RELATED_ARTISTS
             ? relatedArtists.length
-            : 100
+            : DEFAULT_RELATED_ARTISTS_COUNT
         }
         limit={MAX_PROFILE_RELATED_ARTISTS}
         disableProfileClick

--- a/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
@@ -60,7 +60,11 @@ export const RelatedArtists = () => {
       <ProfilePictureListTile
         onClick={handleClick}
         users={relatedArtists as User[]}
-        totalUserCount={relatedArtists.length}
+        totalUserCount={
+          relatedArtists.length < MAX_PROFILE_RELATED_ARTISTS
+            ? relatedArtists.length
+            : 100
+        }
         limit={MAX_PROFILE_RELATED_ARTISTS}
         disableProfileClick
       />


### PR DESCRIPTION
### Description

- Default to 100 related artist b/c the algo will generate top 100 results now. Rather than refactor this endpoint entirely to also return a count (will be slow honestly anyway), it felt better to just do this for simplicity
- Add index for follows fan-out, which helps the new queries added on the bridge side in [QA-2197]

https://github.com/AudiusProject/api/pull/178

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

locally, checking against new bridge API endpoint