### PR TITLE
Switch to port 7001 for identity tests

### DIFF
--- a/dev-tools/compose/docker-compose.identity.prod.yml
+++ b/dev-tools/compose/docker-compose.identity.prod.yml
@@ -27,7 +27,7 @@ services:
         TURBO_TEAM: '${TURBO_TEAM}'
         TURBO_TOKEN: '${TURBO_TOKEN}'
     ports:
-      - '7000:7000'
+      - '7001:7000'
       - '9229:9229'
     environment:
       logLevel: debug


### PR DESCRIPTION
### Description
Was getting a port conflict when trying to run `audius-compose test run "discovery-provider-notifications"`, found that mac control center is using port 7000 now (likely after some mac updates).

```
 ✔ Container audius-protocol-test-discovery-provider-db-1               Healthy                                               0.6s
 ✔ Container audius-protocol-test-db-1                                  Healthy                                               0.3s  ✔ Container audius-protocol-test-discovery-provider-redis-1            Healthy                                               0.3s  ✔ Container audius-protocol-test-solana-test-validator-1               Healthy                                               0.6s
 ✔ Container audius-protocol-test-identity-service-redis-1              Healthy                                               0.4s  ✔ Container audius-protocol-test-eth-ganache-1                         Hea...                                                0.4s  ✔ Container audius-protocol-test-identity-service-db-1                 Healthy                                               0.5s
 ✔ Container audius-protocol-test-discovery-provider-elasticsearch-1    Started                                               0.1s
 ⠦ Container audius-protocol-test-test-identity-service-migrations-1    Starting                                              0.6s
 ✔ Container audius-protocol-test-test-discovery-provider-migrations-1  Started                                               0.1s
Error response from daemon: Ports are not available: exposing port TCP 0.0.0.0:7000 -> 0.0.0.0:0: listen tcp 0.0.0.0:7000: bind: address already in use
```

```
lsof -i :7000
COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ControlCe 639 reed    8u  IPv4  0x70a3f0b92e92c33      0t0  TCP *:afs3-fileserve
r (LISTEN)
ControlCe 639 reed    9u  IPv6 0x1f48cb8bf99c4ded      0t0  TCP *:afs3-fileserve
r (LISTEN)
```

### How Has This Been Tested?

Was able to run `audius-compose test run "discovery-provider-notifications"` locally.