### PR TITLE
[API-228] Update SDK generation to use new OAPI 3.0 files from bridge

### DIFF
--- a/packages/sdk/src/sdk/api/generator/gen.js
+++ b/packages/sdk/src/sdk/api/generator/gen.js
@@ -11,11 +11,7 @@ const program = new commander.Command()
 
 const OUT_DIR = 'src/sdk/api/generator/out'
 
-const SWAGGER_JSON_PATH = path.join(OUT_DIR, 'swagger.json')
-
-const OPEN_API_JSON_PATH = path.join(OUT_DIR, 'openapi.json')
-
-const PROCESSED_JSON_PATH = path.join(OUT_DIR, 'processed.json')
+const SWAGGER_SPEC_PATH = path.join(OUT_DIR, 'swagger.yaml')
 
 const TEMPLATES_DIR = 'src/sdk/api/generator/templates'
 const GENERATED_DIR = 'src/sdk/api/generated'
@@ -61,43 +57,9 @@ const downloadSpec = async ({ env, apiVersion, apiFlavor }) => {
   }
   const apiPath = apiFlavor === '' ? apiVersion : `${apiVersion}/${apiFlavor}`
 
-  const res = await fetch(`${baseURL}/${apiPath}/swagger.json`)
-  const json = await res.text()
-  fs.writeFileSync(path.join(process.env.PWD, SWAGGER_JSON_PATH), json)
-}
-
-const upgradeSpec = async () => {
-  const openApiGeneratorArgs = [
-    'generate',
-    '-g',
-    'openapi',
-    '-i',
-    `/local/${SWAGGER_JSON_PATH}`,
-    '-o',
-    `/local/${OUT_DIR}`,
-    '--skip-validate-spec'
-  ]
-  await spawnOpenAPIGenerator(openApiGeneratorArgs)
-}
-
-const processSpec = () => {
-  const swagger = JSON.parse(
-    fs.readFileSync(path.join(process.env.PWD, SWAGGER_JSON_PATH), 'utf-8')
-  )
-  const openApi = JSON.parse(
-    fs.readFileSync(path.join(process.env.PWD, OPEN_API_JSON_PATH), 'utf-8')
-  )
-
-  for (const [key, value] of Object.entries(swagger.definitions)) {
-    if (value.oneOf) {
-      openApi.components.schemas[key] = value
-    }
-  }
-
-  fs.writeFileSync(
-    path.join(process.env.PWD, PROCESSED_JSON_PATH),
-    JSON.stringify(openApi)
-  )
+  const res = await fetch(`${baseURL}/${apiPath}/swagger.yaml`)
+  const spec = await res.text()
+  fs.writeFileSync(path.join(process.env.PWD, SWAGGER_SPEC_PATH), spec)
 }
 
 const generate = async ({ apiFlavor, generator }) => {
@@ -107,10 +69,9 @@ const generate = async ({ apiFlavor, generator }) => {
     '-g',
     generator,
     '-i',
-    `/local/${PROCESSED_JSON_PATH}`,
+    `/local/${SWAGGER_SPEC_PATH}`,
     '-o',
     `/local/${GENERATED_DIR}/${outputFolderName}`,
-    '--skip-validate-spec',
     '--additional-properties=modelPropertyNaming=camelCase,useSingleRequestParameter=true,withSeparateModelsAndApi=true,apiPackage=api,modelPackage=model',
     '-t',
     `/local/${TEMPLATES_DIR}/${generator}`
@@ -128,8 +89,6 @@ program
   .action(async (options) => {
     clearOutput(options)
     await downloadSpec(options)
-    await upgradeSpec(options)
-    processSpec(options)
     await generate(options)
   })
 


### PR DESCRIPTION
### Description
https://github.com/AudiusProject/api/pull/179 for reference (merge this after that is deployed)

API server is going to server OAPI 3.0 YAML files now. We no longer need the intermediate conversion, and we can re-enable validation on the spec since it should be fully valid now.

### How Has This Been Tested?
`npm run -w @audius/sdk gen:dev` produces identical output to before.