### PR TITLE
Add total_track_count to aggregate_user table

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_track.sql
+++ b/packages/discovery-provider/ddl/functions/handle_track.sql
@@ -28,12 +28,13 @@ begin
   insert into aggregate_user (user_id) values (new.owner_id) on conflict do nothing;
 
   update aggregate_user
-  set track_count = (
-    select count(*)
+  set (track_count, total_track_count) = (
+    select
+      count(*) filter (where t.is_unlisted = false),
+      count(*)
     from tracks t
     where t.is_current is true
       and t.is_delete is false
-      and t.is_unlisted is false
       and t.is_available is true
       and t.stem_of is null
       and t.owner_id = new.owner_id

--- a/packages/discovery-provider/ddl/migrations/0143_add_user_total_tracks.sql
+++ b/packages/discovery-provider/ddl/migrations/0143_add_user_total_tracks.sql
@@ -1,0 +1,22 @@
+begin;
+
+alter table aggregate_user add column if not exists total_track_count int default 0;
+
+UPDATE aggregate_user au
+SET total_track_count = track_stats.total_count
+FROM (
+  SELECT
+    t.owner_id AS user_id,
+    COUNT(*) AS total_count
+  FROM tracks t
+  WHERE
+    t.is_current IS TRUE
+    AND t.is_delete IS FALSE
+    AND t.is_available IS TRUE
+    AND t.stem_of IS NULL
+  GROUP BY t.owner_id
+) AS track_stats
+WHERE au.user_id = track_stats.user_id;
+
+commit;
+

--- a/packages/discovery-provider/integration_tests/models/test_aggregate_counters.py
+++ b/packages/discovery-provider/integration_tests/models/test_aggregate_counters.py
@@ -97,6 +97,7 @@ def test_aggregate_counters(app):
             AggregateUser(
                 user_id=1,
                 track_count=1,
+                total_track_count=1,
                 playlist_count=1,
                 album_count=1,
                 follower_count=0,
@@ -116,6 +117,7 @@ def test_aggregate_counters(app):
             AggregateUser(
                 user_id=2,
                 track_count=2,
+                total_track_count=3,
                 playlist_count=0,
                 album_count=0,
                 follower_count=1,
@@ -251,6 +253,7 @@ def test_aggregate_track_count_updates(app):
             AggregateUser(
                 user_id=1,
                 track_count=0,
+                total_track_count=1,
                 playlist_count=0,
                 album_count=0,
                 follower_count=0,
@@ -269,6 +272,7 @@ def test_aggregate_track_count_updates(app):
             AggregateUser(
                 user_id=2,
                 track_count=1,
+                total_track_count=1,
                 playlist_count=0,
                 album_count=0,
                 follower_count=0,

--- a/packages/discovery-provider/src/models/users/aggregate_user.py
+++ b/packages/discovery-provider/src/models/users/aggregate_user.py
@@ -9,6 +9,7 @@ class AggregateUser(Base, RepresentableMixin):
 
     user_id = Column(Integer, primary_key=True)
     track_count = Column(BigInteger, server_default=text("0"))
+    total_track_count = Column(BigInteger, server_default=text("0"))
     playlist_count = Column(BigInteger, server_default=text("0"))
     album_count = Column(BigInteger, server_default=text("0"))
     follower_count = Column(BigInteger, server_default=text("0"))


### PR DESCRIPTION
### Description
This adds an additional column to aggregate_user to track the "total" track account (including unlisted). This will be used to show users the correct track count when fetching their own (or a managed) account.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
