### PR TITLE
Add hook to prevent changes to discovery-provider api

### DIFF
--- a/packages/discovery-provider/.hooks/pre-commit.json
+++ b/packages/discovery-provider/.hooks/pre-commit.json
@@ -1,6 +1,11 @@
 {
   "steps": [
     {
+      "name": "Don't touch API",
+      "command": "echo 'API endpoints all go through Bridge now, not discovery. Talk to the bridge team if you really need to make changes here.' && false",
+      "onlyOn": "src/api/**"
+    },
+    {
       "name": "Sort imports",
       "command": "isort --diff --check . --skip ./src/tasks/core/gen --skip ./plugins --skip ./src/tasks/core/audiusd_gen"
     },


### PR DESCRIPTION
### Description

It is highly unlikely you should be touching anything in discovery-provider API going forward. Please don't add new endpoints there or modify endpoints there without talking to Bridge. It probably won't have any effect since most endpoints are now implemented in and served from Bridge.

### How Has This Been Tested?

Modify a file under `packages/discovery-provider/src/api/` and attempt to commit.
