### PR TITLE
Fix mobile profile navving to reposts tab for artists sometimes

### DIFF
--- a/packages/common/src/api/tan-query/users/useUserByParams.ts
+++ b/packages/common/src/api/tan-query/users/useUserByParams.ts
@@ -16,7 +16,7 @@ type UserParams = { id?: ID } | { handle?: string | null }
  * @returns The user data or null if not found
  */
 export const useUserByParams = <
-  TResult extends { user_id: number; handle: string } = UserMetadata
+  TResult extends Partial<UserMetadata> = UserMetadata
 >(
   params: UserParams,
   options?: SelectableQueryOptions<UserMetadata, TResult>

--- a/packages/common/src/hooks/useIsArtist.ts
+++ b/packages/common/src/hooks/useIsArtist.ts
@@ -2,20 +2,22 @@ import { useEffect } from 'react'
 
 import { useDispatch } from 'react-redux'
 
+import { useUserByParams } from '~/api'
 import { useCurrentAccount } from '~/api/tan-query/users/account/useCurrentAccount'
-import { useProfileUser } from '~/api/tan-query/users/useProfileUser'
+import { ID } from '~/models'
 import { accountActions } from '~/store/account'
 
 const { fetchHasTracks } = accountActions
 
-export const useIsArtist = () => {
-  const { user_id, track_count } =
-    useProfileUser({
+export const useIsArtist = (params: { id?: ID; handle?: string }) => {
+  const { data: user } =
+    useUserByParams(params, {
       select: (user) => ({
         user_id: user.user_id,
         track_count: user.track_count
       })
-    }).user ?? {}
+    }) ?? {}
+  const { user_id, track_count } = user ?? {}
 
   const { data: account } = useCurrentAccount()
   const currentUserId = account?.userId

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/ProfileTabNavigator.tsx
@@ -49,7 +49,7 @@ export const ProfileTabNavigator = ({
   const { params } = useRoute<'Profile'>()
 
   const initialParams = { id: user_id, handle: params.handle }
-  const isArtist = useIsArtist()
+  const isArtist = useIsArtist(params)
 
   const showCollectiblesTab = useShouldShowCollectiblesTab()
 

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -1129,7 +1129,7 @@ type HookStateProps = {
 }
 const hookStateToProps = (Component: typeof ProfilePage) => {
   return (props: ProfilePageProps) => {
-    const isArtist = useIsArtist()
+    const isArtist = useIsArtist({ id: props.profile?.profile?.user_id })
     const { data: accountData } = useCurrentAccountUser({
       select: (user) => ({
         accountUserId: user?.user_id

--- a/packages/web/src/pages/transaction-history-page/desktop/TransactionHistoryPage.tsx
+++ b/packages/web/src/pages/transaction-history-page/desktop/TransactionHistoryPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 
 import { useCurrentAccount } from '@audius/common/api'
-import { useFeatureFlag, useIsArtist } from '@audius/common/hooks'
+import { useFeatureFlag } from '@audius/common/hooks'
 import { FeatureFlags } from '@audius/common/services'
 import {
   Button,

--- a/packages/web/src/pages/transaction-history-page/desktop/TransactionHistoryPage.tsx
+++ b/packages/web/src/pages/transaction-history-page/desktop/TransactionHistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 
+import { useCurrentAccount } from '@audius/common/api'
 import { useFeatureFlag, useIsArtist } from '@audius/common/hooks'
 import { FeatureFlags } from '@audius/common/services'
 import {
@@ -41,7 +42,9 @@ type TableMetadata = {
 export const TransactionHistoryPage = ({
   tableView
 }: TransactionHistoryPageProps) => {
-  const isArtist = useIsArtist()
+  const { data: isArtist } = useCurrentAccount({
+    select: (account) => account?.hasTracks
+  })
   const [tableOptions, setTableOptions] = useState<TableType[] | null>(null)
   const [selectedTable, setSelectedTable] = useState<TableType | null>(null)
 

--- a/packages/web/src/pages/transaction-history-page/mobile/TransactionHistoryPage.tsx
+++ b/packages/web/src/pages/transaction-history-page/mobile/TransactionHistoryPage.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useState } from 'react'
 
-import { selectIsGuestAccount, useCurrentAccountUser } from '@audius/common/api'
-import { useFeatureFlag, useIsArtist } from '@audius/common/hooks'
+import {
+  selectIsGuestAccount,
+  useCurrentAccount,
+  useCurrentAccountUser
+} from '@audius/common/api'
+import { useFeatureFlag } from '@audius/common/hooks'
 import { FeatureFlags } from '@audius/common/services'
 import { route } from '@audius/common/utils'
 import {
@@ -47,7 +51,9 @@ export const TransactionHistoryPage = ({
   tableView
 }: TransactionHistoryPageProps) => {
   const dispatch = useDispatch()
-  const isArtist = useIsArtist()
+  const { data: isArtist } = useCurrentAccount({
+    select: (account) => account?.hasTracks
+  })
   const { data: accountData } = useCurrentAccountUser({
     select: (user) => ({
       handle: user?.handle,


### PR DESCRIPTION
### Description

- Dug into it, was tricky to repro but I eventually got it to repro when I set my query client stale time. Digging in I found that the profile user handle selector was showing undefined at first so there was one cycle where the user was undefined. 
- To fix I swapped it to use `useUserByParams`

### How Has This Been Tested?

ios:prod
