### PR TITLE
Fix search result scroll cutoff

### DIFF
--- a/packages/mobile/src/screens/search-screen/search-results/AlbumResults.tsx
+++ b/packages/mobile/src/screens/search-screen/search-results/AlbumResults.tsx
@@ -44,6 +44,7 @@ export const AlbumResults = () => {
             height: '100%',
             paddingVertical: spacing.m
           }}
+          ListFooterComponent={<Flex h={200} />}
           keyboardShouldPersistTaps='handled'
           isLoading={isLoading}
           collection={albums}

--- a/packages/mobile/src/screens/search-screen/search-results/PlaylistResults.tsx
+++ b/packages/mobile/src/screens/search-screen/search-results/PlaylistResults.tsx
@@ -72,6 +72,7 @@ export const PlaylistResults = () => {
             height: '100%',
             paddingVertical: spacing.m
           }}
+          ListFooterComponent={<Flex h={200} />}
           keyboardShouldPersistTaps='handled'
           isLoading={isLoading}
           collection={playlists}

--- a/packages/mobile/src/screens/search-screen/search-results/ProfileResults.tsx
+++ b/packages/mobile/src/screens/search-screen/search-results/ProfileResults.tsx
@@ -73,6 +73,7 @@ export const ProfileResults = () => {
             height: '100%',
             paddingVertical: spacing.m
           }}
+          ListFooterComponent={<Flex h={200} />}
           profiles={profiles}
           isLoading={isLoading}
           onCardPress={handlePress}


### PR DESCRIPTION
### Description
Adding an empty footer that matches the bottom bar seems to be the easiest way to fix this. 

Fixes QA-2204

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested in stage iOS
