### PR TITLE
Don't use call with queryClient in sagas

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -402,6 +402,6 @@ export function* revertOptimisticUserSolBalance() {
 
   for (const queryParams of solWalletQueries) {
     const queryKey = getWalletAudioBalanceQueryKey(queryParams)
-    yield* call([queryClient, queryClient.invalidateQueries], { queryKey })
+    queryClient.invalidateQueries({ queryKey })
   }
 }

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -363,8 +363,7 @@ function* claimSingleChallengeRewardAsync(
   const claimed = results.filter((r) => !('error' in r))
 
   const queryClient = yield* getContext('queryClient')
-
-  yield* call(queryClient.invalidateQueries, {
+  queryClient.invalidateQueries({
     queryKey: [QUERY_KEYS.audioBalance]
   })
   yield* put(setUserChallengesDisbursed({ challengeId, specifiers: claimed }))
@@ -611,7 +610,7 @@ function* checkForNewDisbursements(
   }
   if (newDisbursement) {
     // Trigger a refetch for all audio balances
-    yield* call(queryClient.invalidateQueries, {
+    queryClient.invalidateQueries({
       queryKey: [QUERY_KEYS.audioBalance]
     })
 

--- a/packages/web/src/common/store/pages/token-dashboard/addWalletToUser.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/addWalletToUser.ts
@@ -53,7 +53,7 @@ export function* addWalletToUser(
   function* onSuccess() {
     const queryClient = yield* getContext<QueryClient>('queryClient')
     // Trigger a refetch for all audio balances
-    yield* call(queryClient.invalidateQueries, {
+    queryClient.invalidateQueries({
       queryKey: [QUERY_KEYS.audioBalance]
     })
 

--- a/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
@@ -61,7 +61,7 @@ function* removeWallet(action: ConfirmRemoveWalletAction) {
   function* onSuccess() {
     const queryClient = yield* getContext<QueryClient>('queryClient')
     // Trigger a refetch for all audio balances
-    yield* call(queryClient.invalidateQueries, {
+    queryClient.invalidateQueries({
       queryKey: [QUERY_KEYS.audioBalance]
     })
     yield* put(removeWalletAction({ wallet: removeWallet, chain: removeChain }))

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -216,7 +216,7 @@ function* sendTipAsync() {
       yield* call(confirmTipIndexed, { signature })
 
       // Trigger a refetch for all audio balances
-      yield* call(queryClient.invalidateQueries, {
+      queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.audioBalance]
       })
 

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -95,6 +95,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const { toast } = useContext(ToastContext)
   const dispatch = useDispatch()
   const claimStatus = useSelector(getClaimStatus)
+  console.log('REED claimStatus', claimStatus)
   const aaoErrorCode = useSelector(getAAOErrorCode)
   const modalType = useSelector(getChallengeRewardsModalType) as ChallengeName
   const { data: currentAccount } = useCurrentAccount()

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -95,7 +95,6 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const { toast } = useContext(ToastContext)
   const dispatch = useDispatch()
   const claimStatus = useSelector(getClaimStatus)
-  console.log('REED claimStatus', claimStatus)
   const aaoErrorCode = useSelector(getAAOErrorCode)
   const modalType = useSelector(getChallengeRewardsModalType) as ChallengeName
   const { data: currentAccount } = useCurrentAccount()

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -890,7 +890,7 @@ function* transferStep({
 
   // Refetch wallet balance
   const queryClient = yield* getContext('queryClient')
-  yield* call(queryClient.invalidateQueries, {
+  queryClient.invalidateQueries({
     queryKey: [QUERY_KEYS.audioBalance]
   })
   yield* put(transferCompleted())


### PR DESCRIPTION
### Description
Bug was: UI was reporting challenge claim failure even though it succeeded on the backend. This was due to missing square brackets in the `call`:
right:
```
yield* call([queryClient, queryClient.invalidateQueries], { queryKey })
```
wrong:
```
yield* call(queryClient.invalidateQueries, {
        queryKey: [QUERY_KEYS.audioBalance]
      })
```
But then we realized that tan-query functions are synchronous, so don't need to use `call` anymore.

### How Has This Been Tested?

Claimed challenge successfully on stage.