### PR TITLE
[API-261] Fire async share action when opening the share modal/drawer for content

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -48,3 +48,4 @@ export * from './useIsArtist'
 
 export * from './useAnalytics'
 export * from './useBuySellAnalytics'
+export * from './useShareAction'

--- a/packages/common/src/hooks/useShareAction.ts
+++ b/packages/common/src/hooks/useShareAction.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react'
+
+import { Id } from '@audius/sdk'
+
+import { useCurrentUserId } from '~/api/tan-query/users/account/useCurrentUserId'
+import { useQueryContext } from '~/api/tan-query/utils/QueryContext'
+
+/** Sends an EntityManager share action. Fire and forget. Will report to sentry if it fails. */
+export const useShareAction = () => {
+  const { audiusSdk, reportToSentry } = useQueryContext()
+  const { data: userId } = useCurrentUserId()
+
+  return useCallback(
+    async (entityId: number, entityType: 'playlist' | 'track') => {
+      if (
+        !userId ||
+        !entityId ||
+        entityId <= 0 ||
+        !['playlist', 'track'].includes(entityType)
+      )
+        return
+
+      try {
+        const sdk = await audiusSdk()
+        if (entityType === 'track') {
+          sdk.tracks.shareTrack({
+            userId: Id.parse(userId),
+            trackId: Id.parse(entityId)
+          })
+        } else if (entityType === 'playlist') {
+          sdk.playlists.sharePlaylist({
+            userId: Id.parse(userId),
+            playlistId: Id.parse(entityId)
+          })
+        }
+      } catch (error) {
+        reportToSentry({
+          error: error as Error,
+          name: 'Failed to send EntityManager share action',
+          additionalInfo: {
+            userId,
+            entityId,
+            entityType
+          }
+        })
+      }
+    },
+    [audiusSdk, userId, reportToSentry]
+  )
+}

--- a/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
+++ b/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 
 import { useCurrentUserId } from '@audius/common/api'
+import { useShareAction } from '@audius/common/hooks'
 import { Name, ShareSource } from '@audius/common/models'
 import {
   collectionsSocialActions,
@@ -70,6 +71,7 @@ export const ShareDrawer = () => {
   const styles = useStyles()
   const viewShotRef = useRef() as React.RefObject<ViewShot>
   const navigation = useNavigation<AppTabScreenParamList>()
+  const sendShareAction = useShareAction()
 
   const { onClose } = useDrawerState('Share')
   const { onClose: onCloseNowPlaying } = useDrawer('NowPlaying')
@@ -236,6 +238,21 @@ export const ShareDrawer = () => {
     handleShareToInstagramStory,
     isShareableTrack
   ])
+
+  // Trigger share action on mount with new content
+  useEffect(() => {
+    if (!content) return
+    switch (content.type) {
+      case 'track':
+        sendShareAction(content.track.track_id, 'track')
+        break
+      case 'album':
+        sendShareAction(content.album.playlist_id, 'playlist')
+        break
+      case 'playlist':
+        sendShareAction(content.playlist.playlist_id, 'playlist')
+    }
+  }, [content, sendShareAction])
 
   return (
     <>

--- a/packages/web/src/components/share-modal/ShareModal.tsx
+++ b/packages/web/src/components/share-modal/ShareModal.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import { useCurrentUserId } from '@audius/common/api'
-import { useIsManagedAccount } from '@audius/common/hooks'
+import { useIsManagedAccount, useShareAction } from '@audius/common/hooks'
 import { Name, PlayableType } from '@audius/common/models'
 import {
   collectionsSocialActions,
@@ -35,6 +35,7 @@ const { setVisibility } = modalsActions
 
 export const ShareModal = () => {
   const { isOpen, onClose, onClosed } = useModalState('Share')
+  const sendShareAction = useShareAction()
 
   const { toast } = useContext(ToastContext)
   const dispatch = useDispatch()
@@ -116,6 +117,21 @@ export const ShareModal = () => {
       onClose()
     }
   }, [content, dispatch, onClose])
+
+  // Trigger share action on mount with new content
+  useEffect(() => {
+    if (!content) return
+    switch (content.type) {
+      case 'track':
+        sendShareAction(content.track.track_id, 'track')
+        break
+      case 'album':
+        sendShareAction(content.album.playlist_id, 'playlist')
+        break
+      case 'playlist':
+        sendShareAction(content.playlist.playlist_id, 'playlist')
+    }
+  }, [content, sendShareAction])
 
   const shareProps = {
     isOpen,


### PR DESCRIPTION
### Description
This uses the new EntityManager action for sending a "share" action. Decided it's easiest to just treat the intention to share as a signal. So using an effect whenever the content id changes to send a new event (i.e. when the user opens the modal/drawer).

### How Has This Been Tested?
Using local client against staging, open the share modal for a track/playlist and watch the console logs for entity manager.
Also looking up the new items in the DB to make sure they get indexed.
