### PR TITLE
Add dummy sw

### DIFF
--- a/packages/protocol-dashboard/public/earthfast-sw.js
+++ b/packages/protocol-dashboard/public/earthfast-sw.js
@@ -1,0 +1,12 @@
+// kill earthfast sw
+self.addEventListener('install', () => self.skipWaiting())
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    self.registration.unregister().then(() => {
+      return self.clients.matchAll().then((clients) => {
+        clients.forEach((client) => client.navigate(client.url))
+      })
+    })
+  )
+})


### PR DESCRIPTION
### Description

Existing earthfast-sw.js can prevent site from loading. Fix it by installing a dummy sw.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Deployed to prod via local to unbrick a broken user