### PR TITLE
[QA-2209] Fix track replace crashing app

### DIFF
--- a/packages/harmony/src/components/progress-bar/ProgressBar.tsx
+++ b/packages/harmony/src/components/progress-bar/ProgressBar.tsx
@@ -7,7 +7,7 @@ import { ProgressBarProps, ProgressValue } from './types'
 
 const getBigInt = (num: ProgressValue): bigint => {
   if (typeof num === 'bigint') return num
-  return BigInt(num)
+  return BigInt(Math.round(num))
 }
 
 function clampBigInt(value: bigint, min: bigint, max: bigint): bigint {


### PR DESCRIPTION
### Description

Track replace is crashing due to a float passed into the ProgressBar component (which cant be converted to BigInt)

### How Has This Been Tested?

web:stage