### PR TITLE
Remove foreign key cascade delete for blocks/shares

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0145_create_shares_table.sql
+++ b/packages/discovery-provider/ddl/migrations/0145_create_shares_table.sql
@@ -32,10 +32,6 @@ CREATE TABLE IF NOT EXISTS public.shares (
     PRIMARY KEY (user_id, share_item_id, share_type, txhash)
 );
 
--- Add foreign key constraint to match reposts table pattern
-ALTER TABLE public.shares ADD CONSTRAINT shares_blocknumber_fkey
-    FOREIGN KEY (blocknumber) REFERENCES blocks(number) ON DELETE CASCADE;
-
 -- Create indexes following the same pattern as reposts table
 CREATE INDEX IF NOT EXISTS shares_item_idx ON public.shares USING btree (share_item_id, share_type, user_id);
 CREATE INDEX IF NOT EXISTS shares_new_blocknumber_idx ON public.shares USING btree (blocknumber);

--- a/packages/discovery-provider/src/models/social/share.py
+++ b/packages/discovery-provider/src/models/social/share.py
@@ -37,7 +37,6 @@ class Share(Base, RepresentableMixin):
     blockhash = Column(Text, nullable=True)
     blocknumber = Column(
         Integer,
-        ForeignKey("blocks.number", ondelete="CASCADE"),
         index=True,
         nullable=True,
     )
@@ -58,7 +57,3 @@ class Share(Base, RepresentableMixin):
         server_default=text("''::character varying"),
     )
     slot = Column(Integer, nullable=True)
-
-    block1 = relationship(  # type: ignore
-        "Block", primaryjoin="Share.blocknumber == Block.number"
-    )

--- a/packages/discovery-provider/src/models/social/share.py
+++ b/packages/discovery-provider/src/models/social/share.py
@@ -1,17 +1,6 @@
 import enum
 
-from sqlalchemy import (
-    Column,
-    DateTime,
-    Enum,
-    ForeignKey,
-    Index,
-    Integer,
-    String,
-    Text,
-    text,
-)
-from sqlalchemy.orm import relationship
+from sqlalchemy import Column, DateTime, Enum, Index, Integer, String, Text, text
 
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin


### PR DESCRIPTION
### Description
I added this constraint because it was used in other socials tables. But we don't need blocknumber cascade deletes anymore. And I wrote this in a way that it will fail if applied more than once.

### How Has This Been Tested?
N/A
