### PR TITLE
[QA-2205] Fix remix section scrolling to top (properly this time)

### DIFF
--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -267,6 +267,7 @@ const WebPlayer = (props) => {
 
   const context = useContext(SsrContext)
   const ipcRef = useRef(null)
+  const previousRouteRef = useRef(getPathname(history.location))
 
   const [state, setState] = useState({
     mainContent: null,
@@ -289,12 +290,19 @@ const WebPlayer = (props) => {
     const client = getClient()
 
     const removeHistoryEventListener = history.listen((location, action) => {
-      scrollToTop()
-      setState((prev) => ({
-        ...prev,
-        initialPage: false,
-        currentRoute: getPathname(history.location)
-      }))
+      const newRoute = getPathname(location)
+      const previousRoute = previousRouteRef.current
+
+      // Only scroll to top and update state if the pathname actually changed (we dont want to scroll on query params)
+      if (newRoute !== previousRoute) {
+        scrollToTop()
+        previousRouteRef.current = newRoute
+        setState((prev) => ({
+          ...prev,
+          initialPage: false,
+          currentRoute: newRoute
+        }))
+      }
     })
 
     if (client === Client.ELECTRON) {

--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -553,9 +553,7 @@ const GestureSupportingBodyContainer = memo(
         }
         setIndexDelta(newIndexDelta)
         setScrollContainerX(-1 * activeIndex * containerWidth, false)
-        if (isMobile) {
-          window.scrollTo(0, initialScrollOffset)
-        }
+        window.scrollTo(0, initialScrollOffset)
       }
       // Disable exhaustive deps because we only need to run this if the active index has changed:
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Description

- I got false alarmed with my last "fix" (#12503); when I tested RC out it still had the bug. I then realized that the hot reload was making the bug go away
- After digging deeper - the cause is our webplayer scrolling to top on any url change and it should instead ignore query params

### How Has This Been Tested?

web:prod - this time doing a hard refresh
