### PR TITLE
Add getMostSharedTracks to SDK

### DIFF
--- a/.changeset/sharp-paws-breathe.md
+++ b/.changeset/sharp-paws-breathe.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": minor
+---
+
+Adds the getMostSharedTracks function to tracks API

--- a/packages/sdk/src/sdk/api/generated/default/apis/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/TracksApi.ts
@@ -77,6 +77,13 @@ export interface GetFeelingLuckyTracksRequest {
     minFollowers?: number;
 }
 
+export interface GetMostSharedTracksRequest {
+    userId?: string;
+    limit?: number;
+    offset?: number;
+    timeRange?: GetMostSharedTracksTimeRangeEnum;
+}
+
 export interface GetRecentPremiumTracksRequest {
     offset?: number;
     limit?: number;
@@ -310,6 +317,49 @@ export class TracksApi extends runtime.BaseAPI {
      */
     async getFeelingLuckyTracks(params: GetFeelingLuckyTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<TracksResponse> {
         const response = await this.getFeelingLuckyTracksRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
+     * Gets the most shared tracks for a given time range
+     */
+    async getMostSharedTracksRaw(params: GetMostSharedTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<TracksResponse>> {
+        const queryParameters: any = {};
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.timeRange !== undefined) {
+            queryParameters['time_range'] = params.timeRange;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/tracks/most-shared`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => TracksResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the most shared tracks for a given time range
+     */
+    async getMostSharedTracks(params: GetMostSharedTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<TracksResponse> {
+        const response = await this.getMostSharedTracksRaw(params, initOverrides);
         return await response.value();
     }
 
@@ -954,6 +1004,15 @@ export class TracksApi extends runtime.BaseAPI {
 
 }
 
+/**
+ * @export
+ */
+export const GetMostSharedTracksTimeRangeEnum = {
+    Week: 'week',
+    Month: 'month',
+    AllTime: 'allTime'
+} as const;
+export type GetMostSharedTracksTimeRangeEnum = typeof GetMostSharedTracksTimeRangeEnum[keyof typeof GetMostSharedTracksTimeRangeEnum];
 /**
  * @export
  */

--- a/packages/sdk/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -82,6 +82,13 @@ export interface GetMostLovedTracksRequest {
     withUsers?: boolean;
 }
 
+export interface GetMostSharedTracksRequest {
+    userId?: string;
+    limit?: number;
+    offset?: number;
+    timeRange?: GetMostSharedTracksTimeRangeEnum;
+}
+
 export interface GetNFTGatedTrackSignaturesRequest {
     userId: string;
     trackIds?: Array<number>;
@@ -417,6 +424,49 @@ export class TracksApi extends runtime.BaseAPI {
      */
     async getMostLovedTracks(params: GetMostLovedTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracksResponse> {
         const response = await this.getMostLovedTracksRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
+     * Gets the most shared tracks for a given time range
+     */
+    async getMostSharedTracksRaw(params: GetMostSharedTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTracksResponse>> {
+        const queryParameters: any = {};
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.timeRange !== undefined) {
+            queryParameters['time_range'] = params.timeRange;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/tracks/most-shared`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => FullTracksResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the most shared tracks for a given time range
+     */
+    async getMostSharedTracks(params: GetMostSharedTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracksResponse> {
+        const response = await this.getMostSharedTracksRaw(params, initOverrides);
         return await response.value();
     }
 
@@ -1436,6 +1486,15 @@ export const GetBestNewReleasesWindowEnum = {
     Year: 'year'
 } as const;
 export type GetBestNewReleasesWindowEnum = typeof GetBestNewReleasesWindowEnum[keyof typeof GetBestNewReleasesWindowEnum];
+/**
+ * @export
+ */
+export const GetMostSharedTracksTimeRangeEnum = {
+    Week: 'week',
+    Month: 'month',
+    AllTime: 'allTime'
+} as const;
+export type GetMostSharedTracksTimeRangeEnum = typeof GetMostSharedTracksTimeRangeEnum[keyof typeof GetMostSharedTracksTimeRangeEnum];
 /**
  * @export
  */


### PR DESCRIPTION
### Description
Adding support for getMostSharedTracks to SDK.
In prod, this isn't going to return anything yet, since we haven't shipped the change to send share actions in client yet.

### How Has This Been Tested?
N/A for now, just a code gen for later usage.
