### PR TITLE
[PE-6420] Improve useCurrentAccount local-storage perf

### DIFF
--- a/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
@@ -1,5 +1,3 @@
-import { useMemo } from 'react'
-
 import { AudiusSdk } from '@audius/sdk'
 import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -116,12 +114,6 @@ export const useCurrentAccount = <TResult = AccountState | null | undefined>(
   const currentUserWallet = walletAddresses?.currentUser
   const { localStorage } = useAppContext()
   const queryClient = useQueryClient()
-  // We intentionally cache account data in local storage to quickly render the account details
-  // This initialData primes our query slice up front and will cause the hook to return synchronously (if the data exists)
-  const initialData = useMemo(
-    () => getLocalAccount(localStorage, queryClient),
-    [localStorage, queryClient]
-  )
 
   return useQuery({
     queryKey: getCurrentAccountQueryKey(),
@@ -135,7 +127,6 @@ export const useCurrentAccount = <TResult = AccountState | null | undefined>(
     staleTime: Infinity,
     gcTime: Infinity,
     enabled: options?.enabled !== false && !!currentUserWallet,
-    initialData: initialData ?? undefined,
     ...options
   })
 }


### PR DESCRIPTION
### Description

Fixes issue where we get "excessive pending callbacks" due to `useCurrentUser` continuously checking local storage. I went ahead and dropped the initialData which seemed to work okay for mobile and web. but @DejayJD lmk if this breaks an assumption