### PR TITLE
Border for hex token icons

### DIFF
--- a/packages/harmony/src/utils/createImageIcon.tsx
+++ b/packages/harmony/src/utils/createImageIcon.tsx
@@ -1,7 +1,13 @@
 import type { CSSProperties, FC } from 'react'
 
+import { useTheme } from '@emotion/react'
+
+import { Flex } from '~harmony/components'
+
 import { IconSize, iconSizes } from '../foundations/spacing'
 import { roundedHexClipPath } from '../icons/SVGDefs'
+
+const HEXAGON_BORDER_INSET_SCALE = 0.99
 
 export type IconProps = {
   width?: number | string
@@ -21,22 +27,83 @@ export const createImageIcon = (src: string) => {
     style,
     hex = false
   }) => {
+    const { color } = useTheme()
     const finalWidth =
       width ?? (size ? iconSizes[size as keyof typeof iconSizes] : 20)
     const finalHeight =
       height ?? (size ? iconSizes[size as keyof typeof iconSizes] : 20)
-    return (
+
+    const image = (
       <img
         src={src}
         width={finalWidth}
         height={finalHeight}
-        className={className}
-        style={style}
         css={{
-          clipPath: hex ? `url(#${roundedHexClipPath})` : undefined
+          clipPath: hex ? `url(#${roundedHexClipPath})` : undefined,
+          display: 'block'
         }}
         alt=''
       />
+    )
+
+    // If not hexagonal, return the image as-is
+    if (!hex) {
+      return (
+        <img
+          src={src}
+          width={finalWidth}
+          height={finalHeight}
+          className={className}
+          style={style}
+          css={{
+            clipPath: hex ? `url(#${roundedHexClipPath})` : undefined
+          }}
+          alt=''
+        />
+      )
+    }
+
+    // For hexagonal icons, wrap with border
+    return (
+      <Flex
+        className={className}
+        style={style}
+        css={{
+          position: 'relative',
+          width: finalWidth,
+          height: finalHeight,
+          display: 'inline-block'
+        }}
+      >
+        {image}
+        <svg
+          width={finalWidth}
+          height={finalHeight}
+          viewBox='0 0 1 1'
+          css={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            pointerEvents: 'none'
+          }}
+        >
+          <g
+            transform={`translate(${(1 - HEXAGON_BORDER_INSET_SCALE) / 2}, ${
+              (1 - HEXAGON_BORDER_INSET_SCALE) / 2
+            }) scale(${HEXAGON_BORDER_INSET_SCALE})`}
+          >
+            <path
+              d='M0.966 0.378C0.93 0.301 0.887 0.228 0.839 0.158L0.824 0.136C0.805 0.108 0.779 0.085 0.75 0.068C0.721 0.051 0.688 0.041 0.655 0.039L0.627 0.036C0.543 0.03 0.457 0.03 0.373 0.036L0.346 0.039C0.312 0.041 0.279 0.051 0.25 0.068C0.221 0.085 0.196 0.108 0.177 0.136L0.161 0.158C0.113 0.228 0.07 0.302 0.034 0.378L0.022 0.403C0.008 0.433 0 0.466 0 0.5C0 0.534 0.008 0.567 0.022 0.597L0.034 0.622C0.07 0.698 0.113 0.772 0.161 0.842L0.177 0.864C0.196 0.892 0.221 0.915 0.25 0.932C0.279 0.949 0.312 0.959 0.346 0.961L0.373 0.964C0.457 0.97 0.543 0.97 0.627 0.964L0.655 0.961C0.688 0.959 0.721 0.949 0.75 0.932C0.779 0.915 0.805 0.892 0.824 0.864L0.839 0.842C0.887 0.772 0.93 0.698 0.966 0.622L0.978 0.597C0.992 0.567 1 0.534 1 0.5C1 0.466 0.992 0.433 0.978 0.403L0.966 0.378Z'
+              fill='none'
+              opacity={0.3}
+              stroke={color.neutral.n950}
+              strokeWidth={`${
+                1 / Math.max(finalWidth as number, finalHeight as number)
+              }`}
+            />
+          </g>
+        </svg>
+      </Flex>
     )
   }
   return Icon

--- a/packages/mobile/src/harmony-native/components/HexagonalIcon.tsx
+++ b/packages/mobile/src/harmony-native/components/HexagonalIcon.tsx
@@ -2,8 +2,10 @@ import type { ReactElement } from 'react'
 import { cloneElement } from 'react'
 
 import MaskedView from '@react-native-masked-view/masked-view'
-import Svg, { Path } from 'react-native-svg'
+import { View } from 'react-native'
+import Svg, { Path, G } from 'react-native-svg'
 
+import { useTheme } from '../foundations'
 import type { IconProps } from '../icons'
 
 type HexagonalIconProps = {
@@ -12,10 +14,12 @@ type HexagonalIconProps = {
 }
 
 /**
- * Component that applies a hexagonal mask to icons
+ * Component that applies a hexagonal mask to icons with a 1px inset border
  * Used for user tier badges to match the web design
  */
 export const HexagonalIcon = ({ children, size }: HexagonalIconProps) => {
+  const { color } = useTheme()
+
   const HexagonalMask = () => (
     <Svg width={size} height={size} viewBox='0 0 1 1'>
       <Path
@@ -25,7 +29,34 @@ export const HexagonalIcon = ({ children, size }: HexagonalIconProps) => {
     </Svg>
   )
 
-  return (
+  const HexagonalBorder = () => {
+    // Create a smaller hexagon for the inset border effect
+    const insetScale = 0.99
+    const centerOffset = (1 - insetScale) / 2
+
+    return (
+      <Svg
+        width={size}
+        height={size}
+        viewBox='0 0 1 1'
+        style={{ position: 'absolute', top: 0, left: 0 }}
+      >
+        <G
+          transform={`translate(${centerOffset}, ${centerOffset}) scale(${insetScale})`}
+        >
+          <Path
+            d='M0.966 0.378C0.93 0.301 0.887 0.228 0.839 0.158L0.824 0.136C0.805 0.108 0.779 0.085 0.75 0.068C0.721 0.051 0.688 0.041 0.655 0.039L0.627 0.036C0.543 0.03 0.457 0.03 0.373 0.036L0.346 0.039C0.312 0.041 0.279 0.051 0.25 0.068C0.221 0.085 0.196 0.108 0.177 0.136L0.161 0.158C0.113 0.228 0.07 0.302 0.034 0.378L0.022 0.403C0.008 0.433 0 0.466 0 0.5C0 0.534 0.008 0.567 0.022 0.597L0.034 0.622C0.07 0.698 0.113 0.772 0.161 0.842L0.177 0.864C0.196 0.892 0.221 0.915 0.25 0.932C0.279 0.949 0.312 0.959 0.346 0.961L0.373 0.964C0.457 0.97 0.543 0.97 0.627 0.964L0.655 0.961C0.688 0.959 0.721 0.949 0.75 0.932C0.779 0.915 0.805 0.892 0.824 0.864L0.839 0.842C0.887 0.772 0.93 0.698 0.966 0.622L0.978 0.597C0.992 0.567 1 0.534 1 0.5C1 0.466 0.992 0.433 0.978 0.403L0.966 0.378Z'
+            fill='none'
+            stroke={color.neutral.n950}
+            opacity={0.3}
+            strokeWidth={1 / size} // 1px stroke relative to actual size
+          />
+        </G>
+      </Svg>
+    )
+  }
+
+  const maskedContent = (
     <MaskedView maskElement={<HexagonalMask />}>
       {cloneElement(children, {
         ...children.props,
@@ -33,5 +64,12 @@ export const HexagonalIcon = ({ children, size }: HexagonalIconProps) => {
         width: size
       })}
     </MaskedView>
+  )
+
+  return (
+    <View style={{ position: 'relative', width: size, height: size }}>
+      {maskedContent}
+      <HexagonalBorder />
+    </View>
   )
 }


### PR DESCRIPTION
### Description
1px inset border for hex icons

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
<img width="1728" height="1117" alt="Screenshot 2025-07-14 at 6 28 43 PM" src="https://github.com/user-attachments/assets/1affe15d-b6fb-4e69-9cc2-97cb440eef99" />
<img width="1728" height="1117" alt="Screenshot 2025-07-14 at 6 30 40 PM" src="https://github.com/user-attachments/assets/1deb0244-5c4e-4555-b930-21cf3e6d7cc8" />
<img width="1728" height="1117" alt="Screenshot 2025-07-14 at 6 30 50 PM" src="https://github.com/user-attachments/assets/4f9b79e0-64d6-434b-8207-3959c046d7d1" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-14 at 18 31 04" src="https://github.com/user-attachments/assets/96b50821-0598-4aac-8c18-e60cd685aacf" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-14 at 18 31 16" src="https://github.com/user-attachments/assets/8ae790a3-7312-4655-b395-bf9e4e01e822" />
