### PR TITLE
Clicking on token badges shows hover card too

### DIFF
--- a/packages/harmony/src/components/hover-card/HoverCard.tsx
+++ b/packages/harmony/src/components/hover-card/HoverCard.tsx
@@ -45,42 +45,47 @@ const HoverCardComponent = ({
   onClick,
   anchorOrigin = DEFAULT_ANCHOR_ORIGIN,
   transformOrigin = DEFAULT_TRANSFORM_ORIGIN,
-  mouseEnterDelay = 0.5
+  mouseEnterDelay = 0.5,
+  triggeredBy = 'hover'
 }: HoverCardProps) => {
   const anchorRef = useRef<HTMLDivElement | null>(null)
   const {
-    isHovered,
+    isVisible,
     handleMouseEnter,
     handleMouseLeave,
+    handleClick,
     clearTimer,
-    setIsHovered
-  } = useHoverDelay(mouseEnterDelay)
+    setIsHovered,
+    setIsClicked
+  } = useHoverDelay(mouseEnterDelay, triggeredBy)
 
   const handleClose = useCallback(() => {
     clearTimer()
-    onClose?.()
-  }, [clearTimer, onClose])
-
-  const handleClick = useCallback(() => {
-    onClick?.()
-    clearTimer()
     setIsHovered(false)
-  }, [onClick, clearTimer, setIsHovered])
+    setIsClicked(false)
+    onClose?.()
+  }, [clearTimer, setIsHovered, setIsClicked, onClose])
+
+  const handleClickInternal = useCallback(() => {
+    handleClick()
+    onClick?.()
+  }, [handleClick, onClick])
 
   return (
     <Flex
       ref={anchorRef}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      onClick={triggeredBy !== 'hover' ? handleClickInternal : undefined}
     >
       {children}
 
       <Popup
         shadow='near'
         anchorRef={anchorRef}
-        isVisible={isHovered}
+        isVisible={isVisible}
         onClose={handleClose}
-        dismissOnMouseLeave
+        dismissOnMouseLeave={triggeredBy !== 'click'}
         hideCloseButton
         zIndex={30000}
         anchorOrigin={anchorOrigin}
@@ -91,7 +96,7 @@ const HoverCardComponent = ({
           borderRadius='m'
           backgroundColor='white'
           direction='column'
-          onClick={handleClick}
+          onClick={onClick}
         >
           {content}
         </Paper>

--- a/packages/harmony/src/components/hover-card/types.ts
+++ b/packages/harmony/src/components/hover-card/types.ts
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { TriggerType } from '../../hooks/useHoverDelay'
 import { IconComponent } from '../icon'
 import { Origin } from '../popup/types'
 
@@ -46,6 +47,12 @@ export type HoverCardProps = {
    * @default 0.5
    */
   mouseEnterDelay?: number
+
+  /**
+   * Whether to trigger the hover card on hover, click, or both
+   * @default 'hover'
+   */
+  triggeredBy?: TriggerType
 }
 
 export type HoverCardHeaderProps = {

--- a/packages/web/src/components/hover-card/ArtistCoinHoverCard.tsx
+++ b/packages/web/src/components/hover-card/ArtistCoinHoverCard.tsx
@@ -14,7 +14,12 @@ import { HoverCardBody } from './HoverCardBody'
 
 type ArtistCoinHoverCardProps = Pick<
   HoverCardProps,
-  'children' | 'onClose' | 'onClick' | 'anchorOrigin' | 'transformOrigin'
+  | 'children'
+  | 'onClose'
+  | 'onClick'
+  | 'anchorOrigin'
+  | 'transformOrigin'
+  | 'triggeredBy'
 > & {
   /**
    * The mint address of the artist coin
@@ -37,7 +42,8 @@ export const ArtistCoinHoverCard = ({
   onClose,
   anchorOrigin,
   transformOrigin,
-  onClick
+  onClick,
+  triggeredBy
 }: ArtistCoinHoverCardProps) => {
   const { cornerRadius } = useTheme()
 
@@ -78,6 +84,7 @@ export const ArtistCoinHoverCard = ({
       anchorOrigin={anchorOrigin}
       transformOrigin={transformOrigin}
       onClick={onClick}
+      triggeredBy={triggeredBy}
     >
       {children}
     </HoverCard>

--- a/packages/web/src/components/hover-card/AudioHoverCard.tsx
+++ b/packages/web/src/components/hover-card/AudioHoverCard.tsx
@@ -20,7 +20,12 @@ import { HoverCardBody } from './HoverCardBody'
 
 type AudioHoverCardProps = Pick<
   HoverCardProps,
-  'children' | 'onClose' | 'onClick' | 'anchorOrigin' | 'transformOrigin'
+  | 'children'
+  | 'onClose'
+  | 'onClick'
+  | 'anchorOrigin'
+  | 'transformOrigin'
+  | 'triggeredBy'
 > & {
   /**
    * The $AUDIO tier to display
@@ -61,7 +66,8 @@ export const AudioHoverCard = ({
   onClose,
   anchorOrigin,
   transformOrigin,
-  onClick
+  onClick,
+  triggeredBy
 }: AudioHoverCardProps) => {
   const { cornerRadius } = useTheme()
 
@@ -101,6 +107,7 @@ export const AudioHoverCard = ({
       anchorOrigin={anchorOrigin}
       transformOrigin={transformOrigin}
       onClick={onClick}
+      triggeredBy={triggeredBy}
     >
       {children}
     </HoverCard>

--- a/packages/web/src/components/user-badges/UserBadges.tsx
+++ b/packages/web/src/components/user-badges/UserBadges.tsx
@@ -11,7 +11,7 @@ import { useFeatureFlag } from '@audius/common/hooks'
 import { BadgeTier, ID } from '@audius/common/models'
 import { FeatureFlags, getTokenBySymbol } from '@audius/common/services'
 import { useTierAndVerifiedForUser } from '@audius/common/store'
-import { Nullable, route } from '@audius/common/utils'
+import { Nullable } from '@audius/common/utils'
 import {
   Box,
   Flex,
@@ -32,12 +32,9 @@ import cn from 'classnames'
 
 import { ArtistCoinHoverCard } from 'components/hover-card/ArtistCoinHoverCard'
 import { AudioHoverCard } from 'components/hover-card/AudioHoverCard'
-import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { env } from 'services/env'
 
 import styles from './UserBadges.module.css'
-
-const { AUDIO_PAGE } = route
 
 export const audioTierMap: {
   [tier in BadgeTier]: Nullable<ReactElement>
@@ -98,13 +95,6 @@ const UserBadges = ({
   const isUserVerified = isVerifiedOverride ?? isVerified
   const hasContent = isUserVerified || tier !== 'none' || !!coinBalance
 
-  const navigate = useNavigateToPage()
-
-  // Create a click handler that stops propagation and navigates to AUDIO page
-  const handleClick = useCallback(() => {
-    navigate(AUDIO_PAGE)
-  }, [navigate])
-
   // Create a handler to stop event propagation
   const handleStopPropagation = useCallback((e: MouseEvent) => {
     e.stopPropagation()
@@ -150,7 +140,7 @@ const UserBadges = ({
         userId={userId}
         anchorOrigin={anchorOrigin}
         transformOrigin={transformOrigin}
-        onClick={handleClick}
+        triggeredBy='both'
       >
         <Box
           css={{
@@ -165,7 +155,7 @@ const UserBadges = ({
         </Box>
       </AudioHoverCard>
     )
-  }, [tier, userId, anchorOrigin, transformOrigin, handleClick, size])
+  }, [tier, userId, anchorOrigin, transformOrigin, size])
 
   const artistCoinBadge = useMemo(() => {
     if (!coinBalance || !bonkMint || !isArtistCoinEnabled) return null
@@ -175,6 +165,7 @@ const UserBadges = ({
         userId={userId}
         anchorOrigin={anchorOrigin}
         transformOrigin={transformOrigin}
+        triggeredBy='both'
       >
         <Box
           css={{

--- a/packages/web/src/components/user-badges/UserBadges.tsx
+++ b/packages/web/src/components/user-badges/UserBadges.tsx
@@ -106,6 +106,7 @@ const UserBadges = ({
 
     return (
       <HoverCard
+        triggeredBy='both'
         content={
           <Flex alignItems='center' justifyContent='center' gap='s' p='s'>
             <IconVerified size='l' />


### PR DESCRIPTION
### Description
Previously, the hover cards would only display when the user hovered over them for a moment. Now if the user clicks on them, it toggles the show/hide of the hover cards as well.

Tried to get it so that the track tile click animation wouldn't trigger as well but that proved to be pretty involved..

### How Has This Been Tested?


https://github.com/user-attachments/assets/90ec8a39-6118-4620-a220-37e2b6dd74cc

