### PR TITLE
[QA-2212] Improve bottom bar haptics

### DIFF
--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
@@ -9,7 +9,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Flex } from '@audius/harmony-native'
 import { FULL_DRAWER_HEIGHT } from 'app/components/drawer'
 import { PLAY_BAR_HEIGHT } from 'app/components/now-playing-drawer'
-import * as haptics from 'app/haptics'
 
 import { ExploreButton } from './bottom-tab-bar-buttons/ExploreButton'
 import { FeedButton } from './bottom-tab-bar-buttons/FeedButton'
@@ -71,12 +70,6 @@ export const BottomTabBar = (props: BottomTabBarProps) => {
 
   const handlePress = useCallback(
     (isFocused: boolean, routeName: string, routeKey: string) => {
-      if (isFocused) {
-        haptics.light()
-      } else {
-        haptics.medium()
-      }
-
       const event = navigation.emit({
         type: 'tabPress',
         target: routeKey,
@@ -96,7 +89,6 @@ export const BottomTabBar = (props: BottomTabBarProps) => {
   )
 
   const handleLongPress = useCallback(() => {
-    haptics.medium()
     navigation.emit({
       type: 'scrollToTop'
     })

--- a/packages/mobile/src/components/bottom-tab-bar/bottom-tab-bar-buttons/BottomTabBarButton.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/bottom-tab-bar-buttons/BottomTabBarButton.tsx
@@ -8,6 +8,8 @@ import { Pressable, StyleSheet } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import { usePrevious } from 'react-use'
 
+import * as haptics from 'app/haptics'
+
 import { BOTTOM_BAR_BUTTON_HEIGHT } from '../constants'
 
 export type BaseBottomTabBarButtonProps = {
@@ -59,6 +61,15 @@ export const BottomTabBarButton = (props: BottomTabBarButtonProps) => {
   )
   const [isPressing, setIsPressing] = useState(false)
 
+  const handlePressIn = useCallback(() => {
+    // Trigger haptics on press down
+    if (isActive) {
+      haptics.light()
+    } else {
+      haptics.medium()
+    }
+  }, [isActive])
+
   const handlePress = useCallback(() => {
     if (!isActive) {
       animationRef.current?.play()
@@ -74,7 +85,14 @@ export const BottomTabBarButton = (props: BottomTabBarButtonProps) => {
     }
   }, [isActive, previousActive])
 
-  const handleLongPress = isActive ? onLongPress : handlePress
+  const handleLongPress = useCallback(() => {
+    haptics.medium()
+    if (isActive) {
+      onLongPress()
+    } else {
+      handlePress()
+    }
+  }, [onLongPress, handlePress, isActive])
 
   const { primary } = color.primary
   const { neutral } = color.neutral
@@ -91,6 +109,7 @@ export const BottomTabBarButton = (props: BottomTabBarButtonProps) => {
   return (
     <Pressable
       onPress={handlePress}
+      onPressIn={handlePressIn}
       onLongPress={handleLongPress}
       pointerEvents='box-only'
       style={styles.root}


### PR DESCRIPTION
### Description

Improves bottom-bar haptics by giving feedaback on pressIn, which makes the transition between the pages feel less laggy, whereas before you would press, the page would start transitioning, then you'd get vibration, which felt clunky