### PR TITLE
[PE-6519] Send artist coin holder blast UI

### DIFF
--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -2,9 +2,11 @@ import { useCallback } from 'react'
 
 import { useCurrentAccountUser } from '@audius/common/api'
 import {
+  useFeatureFlag,
   usePurchasersAudience,
   useRemixersAudience
 } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import { formatNumberCommas } from '@audius/common/utils'
 import { ChatBlastAudience } from '@audius/sdk'
 import { useField } from 'formik'
@@ -41,6 +43,12 @@ const messages = {
     placeholder: 'Tracks with Remixes',
     filterBy: 'Filter by Tracks With Remixes',
     search: 'Search for tracks with remixes'
+  },
+  coinHolders: {
+    label: 'Coin Holders',
+    description:
+      'Send a bulk message to users who have Bonk coins in their wallet.',
+    placeholder: 'Coin Holders'
   }
 }
 
@@ -52,6 +60,7 @@ export const ChatBlastSelectAudienceFields = () => {
       <TipSupportersMessageField />
       <PastPurchasersMessageField />
       <RemixCreatorsMessageField />
+      <CoinHoldersMessageField />
     </ExpandableRadioGroup>
   )
 }
@@ -229,6 +238,34 @@ const RemixCreatorsMessageField = () => {
           </Flex>
         </TouchableOpacity>
       }
+    />
+  )
+}
+
+const CoinHoldersMessageField = () => {
+  const { isEnabled: isArtistCoinEnabled } = useFeatureFlag(
+    FeatureFlags.ARTIST_COINS
+  )
+  const [{ value: targetAudience }] = useField(TARGET_AUDIENCE_FIELD)
+  const isSelected = targetAudience === ChatBlastAudience.COIN_HOLDERS
+  const isDisabled = !isArtistCoinEnabled
+  const coinHoldersCount = 0
+  if (!isArtistCoinEnabled) {
+    return null
+  }
+
+  return (
+    <ExpandableRadio
+      value={ChatBlastAudience.COIN_HOLDERS}
+      disabled={isDisabled}
+      label={
+        <LabelWithCount
+          label={messages.coinHolders.label}
+          count={coinHoldersCount}
+          isSelected={isSelected}
+        />
+      }
+      description={messages.coinHolders.description}
     />
   )
 }

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -5,7 +5,7 @@ import {
   usePurchasersAudience,
   useRemixersAudience
 } from '@audius/common/hooks'
-import { FeatureFlags } from '@audius/common/src/services/remote-config'
+import { FeatureFlags } from '@audius/common/services'
 import {
   useChatBlastModal,
   chatActions,

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -1,9 +1,11 @@
 import { useCurrentAccountUser } from '@audius/common/api'
 import {
+  useFeatureFlag,
   useFirstAvailableBlastAudience,
   usePurchasersAudience,
   useRemixersAudience
 } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/src/services/remote-config'
 import {
   useChatBlastModal,
   chatActions,
@@ -54,6 +56,12 @@ const messages = {
     description:
       'Send a bulk message to creators who have remixed your tracks.',
     placeholder: 'Tracks with Remixes'
+  },
+  coinHolders: {
+    label: 'Coin Holders',
+    description:
+      'Send a bulk message to users who have Bonk coins in their wallet.',
+    placeholder: 'Coin Holders'
   }
 }
 
@@ -164,6 +172,7 @@ const ChatBlastsFields = () => {
         <TipSupportersMessageField />
         <PastPurchasersMessageField />
         <RemixCreatorsMessageField />
+        <CoinHoldersMessageField />
       </Flex>
     </RadioGroup>
   )
@@ -333,6 +342,45 @@ const RemixCreatorsMessageField = () => {
               onChange={setRemixedTrackId}
               clearable
             />
+          </Flex>
+        ) : null}
+      </Flex>
+    </Flex>
+  )
+}
+
+const CoinHoldersMessageField = () => {
+  const [{ value: targetAudience }] = useField(TARGET_AUDIENCE_FIELD)
+
+  const { isEnabled: isArtistCoinEnabled } = useFeatureFlag(
+    FeatureFlags.ARTIST_COINS
+  )
+
+  const isSelected = targetAudience === ChatBlastAudience.COIN_HOLDERS
+  const coinHoldersCount = 0
+  const isDisabled = !isArtistCoinEnabled
+  if (!isArtistCoinEnabled) {
+    return null
+  }
+
+  return (
+    <Flex
+      as='label'
+      gap='l'
+      css={{
+        opacity: isDisabled ? 0.5 : 1
+      }}
+    >
+      <Radio value={ChatBlastAudience.COIN_HOLDERS} disabled={isDisabled} />
+      <Flex direction='column' gap='xs' css={{ cursor: 'pointer' }}>
+        <LabelWithCount
+          label={messages.coinHolders.label}
+          count={coinHoldersCount}
+          isSelected={isSelected}
+        />
+        {isSelected ? (
+          <Flex direction='column' gap='l'>
+            <Text size='s'>{messages.coinHolders.description}</Text>
           </Flex>
         ) : null}
       </Flex>


### PR DESCRIPTION
### Description
Placeholder UI to send message blast to artist coin holders on both mobile and web

### How Has This Been Tested?

<img width="596" height="457" alt="Screenshot 2025-07-16 at 12 13 25 AM" src="https://github.com/user-attachments/assets/8b59c5c6-6607-4af5-9e32-a694dfd24129" />
