### PR TITLE
Fix misc mobile tile layout issues

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -36,7 +36,6 @@ import { CollectionTileTrackList } from './CollectionTileTrackList'
 import { LineupTileActionButtons } from './LineupTileActionButtons'
 import { LineupTileMetadata } from './LineupTileMetadata'
 import { LineupTileRoot } from './LineupTileRoot'
-import { LineupTileTopRight } from './LineupTileTopRight'
 import { LineupTileSource, type CollectionTileProps } from './types'
 import { useEnhancedCollectionTracks } from './useEnhancedCollectionTracks'
 

--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -234,12 +234,6 @@ export const CollectionTile = (props: CollectionTileProps) => {
       scaleTo={scale}
     >
       <CollectionDogEar collectionId={collection.playlist_id} hideUnlocked />
-      <LineupTileTopRight
-        duration={duration}
-        trackId={collection.playlist_id}
-        isLongFormContent={false}
-        isCollection={true}
-      />
       <LineupTileMetadata
         renderImage={renderImage}
         onPressTitle={handlePressTitle}
@@ -248,6 +242,8 @@ export const CollectionTile = (props: CollectionTileProps) => {
         isPlayingUid={isPlayingUid}
         type={contentType}
         trackId={collection.playlist_id}
+        duration={duration}
+        isLongFormContent={false}
       />
       <CollectionTileStats
         collectionId={collection.playlist_id}

--- a/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
@@ -11,6 +11,7 @@ import type { GestureResponderHandler } from 'app/types/gesture'
 import { useThemeColors } from 'app/utils/theme'
 
 import { LineupTileArt } from './LineupTileArt'
+import { LineupTileTopRight } from './LineupTileTopRight'
 import { useStyles as useTileStyles } from './styles'
 import type { RenderImage } from './types'
 
@@ -18,7 +19,9 @@ const { getPlaying } = playerSelectors
 
 const useStyles = makeStyles(({ palette }) => ({
   metadata: {
-    flexDirection: 'row'
+    flexDirection: 'row',
+    gap: 8,
+    width: '100%'
   },
   playingIndicator: {
     marginLeft: 8
@@ -43,6 +46,8 @@ type Props = {
   isPlayingUid: boolean
   type: 'track' | 'playlist' | 'album'
   trackId: ID
+  duration: number
+  isLongFormContent: boolean
 }
 
 export const LineupTileMetadata = ({
@@ -52,7 +57,9 @@ export const LineupTileMetadata = ({
   userId,
   isPlayingUid,
   type,
-  trackId
+  trackId,
+  duration,
+  isLongFormContent
 }: Props) => {
   const styles = useStyles()
   const tileStyles = useTileStyles()
@@ -117,6 +124,12 @@ export const LineupTileMetadata = ({
           userId={userId}
         />
       </FadeInView>
+      <LineupTileTopRight
+        duration={duration}
+        trackId={trackId}
+        isLongFormContent={isLongFormContent}
+        isCollection={false}
+      />
     </View>
   )
 }

--- a/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
@@ -1,16 +1,12 @@
 import { useCurrentUserId } from '@audius/common/api'
 import { playbackPositionSelectors } from '@audius/common/store'
 import { formatLineupTileDuration } from '@audius/common/utils'
-import type { ViewStyle } from 'react-native'
 import { StyleSheet, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import { IconCheck } from '@audius/harmony-native'
 import Text from 'app/components/text'
-import { flexRowCentered } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
-
-import { ProgressBar } from '../progress-bar'
 
 import { useStyles as useTrackTileStyles } from './styles'
 
@@ -21,18 +17,10 @@ const messages = {
   played: 'Played'
 }
 
-const flexRowEnd = (): ViewStyle => ({
-  ...flexRowCentered(),
-  justifyContent: 'flex-end'
-})
-
 const styles = StyleSheet.create({
   topRight: {
-    ...flexRowEnd(),
-    position: 'absolute',
     top: 8,
-    right: 8,
-    left: 0
+    marginRight: 8
   }
 })
 
@@ -95,13 +83,6 @@ export const LineupTileTopRight = ({
             <IconCheck height={12} width={14} fill={secondary} />
           ) : null}
         </Text>
-        {duration && isInProgress ? (
-          <ProgressBar
-            progress={(playbackPositionInfo.playbackPosition / duration) * 100}
-            max={100}
-            style={{ root: trackTileStyles.statTextProgressBar }}
-          />
-        ) : null}
       </View>
     </View>
   )

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -41,7 +41,6 @@ import { TrackDogEar } from '../track/TrackDogEar'
 import { LineupTileActionButtons } from './LineupTileActionButtons'
 import { LineupTileMetadata } from './LineupTileMetadata'
 import { LineupTileRoot } from './LineupTileRoot'
-import { LineupTileTopRight } from './LineupTileTopRight'
 import { TrackTileStats } from './TrackTileStats'
 
 const { getUid } = playerSelectors
@@ -238,14 +237,6 @@ export const TrackTile = (props: TrackTileProps) => {
       scaleTo={scale}
     >
       <TrackDogEar trackId={track.track_id} hideUnlocked />
-      <LineupTileTopRight
-        duration={track.duration}
-        trackId={track.track_id}
-        isLongFormContent={
-          track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
-        }
-        isCollection={false}
-      />
       <LineupTileMetadata
         renderImage={renderImage}
         onPressTitle={handlePressTitle}
@@ -254,6 +245,10 @@ export const TrackTile = (props: TrackTileProps) => {
         isPlayingUid={isPlayingUid}
         type='track'
         trackId={track.track_id}
+        duration={track.duration}
+        isLongFormContent={
+          track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
+        }
       />
       <TrackTileStats
         trackId={track.track_id}

--- a/packages/mobile/src/components/lineup-tile/TrackTileMetrics.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTileMetrics.tsx
@@ -94,10 +94,11 @@ type CommentMetricProps = {
   trackId: ID
   actions?: LineupBaseActions
   uid?: string
+  showLeaveCommentText?: boolean
 }
 
 export const CommentMetric = (props: CommentMetricProps) => {
-  const { trackId, actions, uid } = props
+  const { trackId, actions, uid, showLeaveCommentText } = props
   const { open } = useCommentDrawer()
   const navigation = useNavigation()
   const { isEnabled } = useFeatureFlag(FeatureFlags.COMMENTS_ENABLED)
@@ -129,11 +130,13 @@ export const CommentMetric = (props: CommentMetricProps) => {
     )
   }, [open, trackId, navigation, uid, actions])
 
-  if (!commentCount || !isEnabled || commentsDisabled) return null
+  if (commentCount === undefined || !isEnabled || commentsDisabled) return null
 
   return (
     <VanityMetric icon={IconMessage} onPress={handlePress}>
-      {commentCount > 0 ? formatCount(commentCount) : 'Leave a comment'}
+      {commentCount === 0 && showLeaveCommentText
+        ? 'Leave a comment'
+        : formatCount(commentCount)}
     </VanityMetric>
   )
 }

--- a/packages/mobile/src/components/lineup-tile/TrackTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTileStats.tsx
@@ -30,11 +30,16 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
 
   const isUnlockable = useIsTrackUnlockable(trackId)
 
-  const { data: isUnlisted } = useTrack(trackId, {
+  const { data: partialTrack } = useTrack(trackId, {
     select: (track) => {
-      return track.is_unlisted
+      return {
+        isUnlisted: track.is_unlisted,
+        noMetrics:
+          !track.repost_count && !track.save_count && !track.comment_count
+      }
     }
   })
+  const { isUnlisted, noMetrics } = partialTrack ?? {}
 
   return (
     <Flex row justifyContent='space-between' alignItems='center' p='s' h={32}>
@@ -47,7 +52,12 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
           <>
             <RepostsMetric trackId={trackId} />
             <SavesMetric trackId={trackId} />
-            <CommentMetric trackId={trackId} uid={uid} actions={actions} />
+            <CommentMetric
+              trackId={trackId}
+              uid={uid}
+              actions={actions}
+              showLeaveCommentText={noMetrics}
+            />
             <TrackDownloadStatusIndicator size='s' trackId={trackId} />
           </>
         )}

--- a/packages/mobile/src/components/lineup-tile/styles.ts
+++ b/packages/mobile/src/components/lineup-tile/styles.ts
@@ -32,21 +32,18 @@ export const useStyles = makeStyles(({ palette }) => ({
   },
   imageContainer: {
     marginTop: spacing(2),
-    marginRight: spacing(2),
     marginLeft: spacing(2)
   },
   titles: {
     paddingVertical: spacing(1),
     alignItems: 'flex-start',
-    flexBasis: '65%',
-    marginRight: spacing(3),
     marginTop: spacing(2),
+    flex: 1,
     gap: spacing(1)
   },
   collectionTitles: {
     alignItems: 'flex-start',
-    flexBasis: '65%',
-    marginRight: spacing(3),
+    flex: 1,
     marginTop: spacing(2),
     gap: spacing(1)
   },


### PR DESCRIPTION
### Description

- Fixes this issue by removing the progress bar & rearranging the layout to a grid system to match the way designs have it
<img width="1170" height="520" alt="image" src="https://github.com/user-attachments/assets/ce63405c-1d52-44d2-856a-7deeacafb5f2" />
- Also fixed issue where tracks should be showing "leave a comment" but are showing nothing there


### How Has This Been Tested?

ios