### PR TITLE
[PE-6537] Add comment_id to notification action data

### DIFF
--- a/packages/common/src/adapters/notification.ts
+++ b/packages/common/src/adapters/notification.ts
@@ -541,12 +541,14 @@ export const notificationFromSDK = (
     case 'comment': {
       let entityId = 0
       let entityType = Entity.Track
+      let commentId = 0
       const userIds = Array.from(
         new Set(
           notification.actions
             .map((action) => {
               const data = action.data
               entityId = HashId.parse(data.entityId)
+              commentId = HashId.parse(data.commentId)
               // @ts-ignore
               entityType = data.type
               return HashId.parse(data.commentUserId)
@@ -559,6 +561,7 @@ export const notificationFromSDK = (
         userIds,
         entityId,
         entityType,
+        commentId,
         ...formatBaseNotification(notification)
       }
     }
@@ -566,6 +569,7 @@ export const notificationFromSDK = (
       let entityId = 0
       let entityType = Entity.Track
       let entityUserId = 0
+      let commentId = 0
       const userIds = Array.from(
         new Set(
           notification.actions
@@ -573,6 +577,7 @@ export const notificationFromSDK = (
               const data = action.data
               entityId = HashId.parse(data.entityId)
               entityUserId = HashId.parse(data.entityUserId)
+              commentId = HashId.parse(data.commentId)
               // @ts-ignore
               entityType = data.type
               return HashId.parse(data.commentUserId)
@@ -586,6 +591,7 @@ export const notificationFromSDK = (
         entityId,
         entityType,
         entityUserId,
+        commentId,
         ...formatBaseNotification(notification)
       }
     }
@@ -593,11 +599,13 @@ export const notificationFromSDK = (
       let entityId = 0
       let entityType = Entity.Track
       let entityUserId = 0
+      let commentId = 0
       const userIds = notification.actions
         .map((action) => {
           const data = action.data
           entityId = HashId.parse(data.entityId)
           entityUserId = HashId.parse(data.entityUserId)
+          commentId = HashId.parse(data.commentId)
           // @ts-ignore
           entityType = data.type
           return HashId.parse(data.commentUserId)
@@ -609,6 +617,7 @@ export const notificationFromSDK = (
         entityId,
         entityType,
         entityUserId,
+        commentId,
         ...formatBaseNotification(notification)
       }
     }
@@ -616,11 +625,13 @@ export const notificationFromSDK = (
       let entityId = 0
       let entityType = Entity.Track
       let entityUserId = 0
+      let commentId = 0
       const userIds = notification.actions
         .map((action) => {
           const data = action.data
           entityId = HashId.parse(data.entityId)
           entityUserId = HashId.parse(data.entityUserId)
+          commentId = HashId.parse(data.commentId)
           // @ts-ignore
           entityType = data.type
           return HashId.parse(data.reacterUserId)
@@ -632,6 +643,7 @@ export const notificationFromSDK = (
         entityId,
         entityType,
         entityUserId,
+        commentId,
         ...formatBaseNotification(notification)
       }
     }
@@ -718,5 +730,4 @@ export const notificationFromSDK = (
       }
     }
   }
-  return undefined
 }

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -671,6 +671,7 @@ export type CommentNotification = BaseNotification & {
   entityId: ID
   userIds: ID[]
   entityType: Entity.Playlist | Entity.Album | Entity.Track
+  commentId: ID
 }
 
 export type CommentThreadNotification = BaseNotification & {
@@ -679,6 +680,7 @@ export type CommentThreadNotification = BaseNotification & {
   entityUserId: ID
   userIds: ID[]
   entityType: Entity.Playlist | Entity.Album | Entity.Track
+  commentId: ID
 }
 
 export type CommentMentionNotification = BaseNotification & {
@@ -687,6 +689,7 @@ export type CommentMentionNotification = BaseNotification & {
   entityUserId: ID
   userIds: ID[]
   entityType: Entity.Playlist | Entity.Album | Entity.Track
+  commentId: ID
 }
 
 export type CommentReactionNotification = BaseNotification & {
@@ -695,6 +698,7 @@ export type CommentReactionNotification = BaseNotification & {
   entityUserId: ID
   userIds: ID[]
   entityType: Entity.Playlist | Entity.Album | Entity.Track
+  commentId: ID
 }
 
 export type ListenStreakReminderNotification = BaseNotification & {

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/comment.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/comment.test.ts
@@ -56,7 +56,8 @@ describe('Comment Notification', () => {
         data: {
           type: 'Track',
           entity_id: 10,
-          comment_user_id: 2
+          comment_user_id: 2,
+          comment_id: 1
         }
       }
     ])
@@ -82,7 +83,8 @@ describe('Comment Notification', () => {
           type: 'Comment',
           userIds: [2],
           entityType: 'Track',
-          entityId: 10
+          entityId: 10,
+          commentId: 1
         }
       }
     )
@@ -110,7 +112,8 @@ describe('Comment Notification', () => {
         data: {
           type: EntityType.Track,
           comment_user_id: 2,
-          entity_id: 10
+          entity_id: 10,
+          comment_id: 1
         },
         user_ids: [1],
         receiver_user_id: 1
@@ -154,7 +157,8 @@ describe('Comment Notification', () => {
         data: {
           type: EntityType.Track,
           comment_user_id: num + 2,
-          entity_id: 10
+          entity_id: 10,
+          comment_id: num + 1
         },
         user_ids: [1],
         receiver_user_id: 1

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/commentMention.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/commentMention.test.ts
@@ -61,7 +61,8 @@ describe('Comment Mention Notification', () => {
           type: 'Track',
           entity_id: 1,
           entity_user_id: 1,
-          comment_user_id: 1
+          comment_user_id: 1,
+          comment_id: 1
         }
       }
     ])
@@ -87,7 +88,8 @@ describe('Comment Mention Notification', () => {
           type: 'CommentMention',
           userIds: [1],
           entityType: 'Track',
-          entityId: 1
+          entityId: 1,
+          commentId: 1
         }
       }
     )
@@ -121,7 +123,8 @@ describe('Comment Mention Notification', () => {
           type: EntityType.Track,
           entity_id: 1,
           entity_user_id: 1,
-          comment_user_id: 1
+          comment_user_id: 1,
+          comment_id: 1
         },
         user_ids: [2],
         receiver_user_id: 2

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/commentReaction.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/commentReaction.test.ts
@@ -91,7 +91,8 @@ describe('Comment Reaction Notification', () => {
           entityType: 'Track',
           entityId: 1,
           entityUserId: 1,
-          userIds: [2]
+          userIds: [2],
+          commentId: 1
         }
       }
     )
@@ -130,6 +131,8 @@ describe('Comment Reaction Notification', () => {
           type: 'Track',
           entity_id: 1,
           entity_user_id: 3,
+          comment_id: 1,
+          comment_user_id: 1,
           reacter_user_id: 2
         }
       }
@@ -158,7 +161,8 @@ describe('Comment Reaction Notification', () => {
           entityType: 'Track',
           entityId: 1,
           entityUserId: 3,
-          userIds: [2]
+          userIds: [2],
+          commentId: 1
         }
       }
     )

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/commentThread.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/commentThread.test.ts
@@ -70,7 +70,8 @@ describe('Comment Thread Notification', () => {
           type: 'Track',
           entity_id: 1,
           entity_user_id: 1,
-          comment_user_id: 2
+          comment_user_id: 2,
+          comment_id: 2
         }
       }
     ])
@@ -94,7 +95,8 @@ describe('Comment Thread Notification', () => {
           type: 'CommentThread',
           entityType: 'Track',
           entityId: 1,
-          userIds: [2]
+          userIds: [2],
+          commentId: 2
         }
       }
     )
@@ -139,7 +141,8 @@ describe('Comment Thread Notification', () => {
           type: 'Track',
           entity_id: 1,
           entity_user_id: 3,
-          comment_user_id: 2
+          comment_user_id: 2,
+          comment_id: 2
         }
       }
     ])
@@ -166,7 +169,8 @@ describe('Comment Thread Notification', () => {
           type: 'CommentThread',
           entityType: 'Track',
           entityId: 1,
-          userIds: [2]
+          userIds: [2],
+          commentId: 2
         }
       }
     )

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/comment.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/comment.ts
@@ -54,16 +54,13 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
       .from<UserRow>('users')
       .where('is_current', true)
       .whereIn('user_id', [this.receiverUserId, this.commenterUserId])
-    const users = res.reduce(
-      (acc, user) => {
-        acc[user.user_id] = {
-          name: user.name,
-          isDeactivated: user.is_deactivated
-        }
-        return acc
-      },
-      {} as Record<number, { name: string; isDeactivated: boolean }>
-    )
+    const users = res.reduce((acc, user) => {
+      acc[user.user_id] = {
+        name: user.name,
+        isDeactivated: user.is_deactivated
+      }
+      return acc
+    }, {} as Record<number, { name: string; isDeactivated: boolean }>)
 
     if (users?.[this.receiverUserId]?.isDeactivated) {
       return
@@ -79,13 +76,10 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
         .from<TrackRow>('tracks')
         .where('is_current', true)
         .whereIn('track_id', [this.entityId])
-      const tracks = res.reduce(
-        (acc, track) => {
-          acc[track.track_id] = { title: track.title }
-          return acc
-        },
-        {} as Record<number, { title: string }>
-      )
+      const tracks = res.reduce((acc, track) => {
+        acc[track.track_id] = { title: track.title }
+        return acc
+      }, {} as Record<number, { title: string }>)
 
       entityType = 'track'
       entityName = tracks[this.entityId]?.title
@@ -149,7 +143,8 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
                 userIds: [this.commenterUserId],
                 type: 'Comment',
                 entityType: 'Track',
-                entityId: this.entityId
+                entityId: this.entityId,
+                commentId: this.notification.data.comment_id
               }
             }
           )

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/commentMention.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/commentMention.ts
@@ -74,13 +74,10 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
         this.entityUserId
       ])
       .then((rows) =>
-        rows.reduce(
-          (acc, row) => {
-            acc[row.user_id] = row
-            return acc
-          },
-          {} as Record<number, UserRow>
-        )
+        rows.reduce((acc, row) => {
+          acc[row.user_id] = row
+          return acc
+        }, {} as Record<number, UserRow>)
       )
 
     if (users[this.receiverUserId]?.is_deactivated) {
@@ -100,8 +97,8 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
       this.entityUserId === this.receiverUserId
         ? 'your'
         : this.entityUserId === this.commenterUserId
-          ? 'their'
-          : `${users[this.entityUserId]?.name}'s`
+        ? 'their'
+        : `${users[this.entityUserId]?.name}'s`
     } ${entityType?.toLowerCase()} ${entityName}`
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(
@@ -152,7 +149,8 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
                 userIds: [this.commenterUserId],
                 type: 'CommentMention',
                 entityType: 'Track',
-                entityId: this.entityId
+                entityId: this.entityId,
+                commentId: this.notification.data.comment_id
               }
             }
           )

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/commentReaction.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/commentReaction.ts
@@ -74,13 +74,10 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
         this.entityUserId
       ])
       .then((rows) =>
-        rows.reduce(
-          (acc, row) => {
-            acc[row.user_id] = row
-            return acc
-          },
-          {} as Record<number, UserRow>
-        )
+        rows.reduce((acc, row) => {
+          acc[row.user_id] = row
+          return acc
+        }, {} as Record<number, UserRow>)
       )
 
     if (users[this.receiverUserId]?.is_deactivated) {
@@ -98,8 +95,8 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
       this.entityUserId === this.receiverUserId
         ? 'your'
         : this.entityUserId === this.reacterUserId
-          ? 'their'
-          : `${users[this.entityUserId]?.name}'s`
+        ? 'their'
+        : `${users[this.entityUserId]?.name}'s`
     } ${entityType?.toLowerCase()} ${entityName}`
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(
@@ -152,7 +149,8 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
                 type: 'CommentReaction',
                 entityType: 'Track',
                 entityId: this.entityId,
-                entityUserId: this.entityUserId
+                entityUserId: this.entityUserId,
+                commentId: this.notification.data.comment_id
               }
             }
           )

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/commentThread.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/commentThread.ts
@@ -74,13 +74,10 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
         this.entityUserId
       ])
       .then((rows) =>
-        rows.reduce(
-          (acc, row) => {
-            acc[row.user_id] = row
-            return acc
-          },
-          {} as Record<number, UserRow>
-        )
+        rows.reduce((acc, row) => {
+          acc[row.user_id] = row
+          return acc
+        }, {} as Record<number, UserRow>)
       )
 
     if (users[this.receiverUserId]?.is_deactivated) {
@@ -100,8 +97,8 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
       this.entityUserId === this.receiverUserId
         ? 'your'
         : this.entityUserId === this.commenterUserId
-          ? 'their'
-          : `${users[this.entityUserId]?.name}'s`
+        ? 'their'
+        : `${users[this.entityUserId]?.name}'s`
     } ${entityType?.toLowerCase()} ${entityName}`
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(
@@ -153,7 +150,8 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
                 userIds: [this.commenterUserId],
                 type: 'CommentThread',
                 entityType: 'Track',
-                entityId: this.entityId
+                entityId: this.entityId,
+                commentId: this.notification.data.comment_id
               }
             }
           )

--- a/packages/discovery-provider/plugins/notifications/src/types/notifications.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/notifications.ts
@@ -299,6 +299,7 @@ export type CommentNotification = {
   type: EntityType
   entity_id: number
   comment_user_id: number
+  comment_id: number
 }
 
 export type CommentThreadNotification = {
@@ -306,6 +307,7 @@ export type CommentThreadNotification = {
   entity_id: number
   entity_user_id: number
   comment_user_id: number
+  comment_id: number
 }
 
 export type CommentMentionNotification = {
@@ -313,6 +315,7 @@ export type CommentMentionNotification = {
   entity_id: number
   entity_user_id: number
   comment_user_id: number
+  comment_id: number
 }
 
 export type CommentReactionNotification = {

--- a/packages/discovery-provider/src/api/v1/models/notifications.py
+++ b/packages/discovery-provider/src/api/v1/models/notifications.py
@@ -955,6 +955,7 @@ comment_notification_action_data = ns.model(
         "type": fields.String(required=True, enum=["Track", "Playlist", "Album"]),
         "entity_id": fields.String(required=True),
         "comment_user_id": fields.String(required=True),
+        "comment_id": fields.String(required=True),
     },
 )
 comment_notification_action = ns.clone(
@@ -979,6 +980,7 @@ comment_thread_notification_action_data = ns.model(
         "entity_id": fields.String(required=True),
         "entity_user_id": fields.String(required=True),
         "comment_user_id": fields.String(required=True),
+        "comment_id": fields.String(required=True),
     },
 )
 comment_thread_notification_action = ns.clone(
@@ -1004,6 +1006,7 @@ comment_mention_notification_action_data = ns.model(
         "entity_id": fields.String(required=True),
         "entity_user_id": fields.String(required=True),
         "comment_user_id": fields.String(required=True),
+        "comment_id": fields.String(required=True),
     },
 )
 comment_mention_notification_action = ns.clone(
@@ -1029,6 +1032,7 @@ comment_reaction_notification_action_data = ns.model(
         "entity_id": fields.String(required=True),
         "entity_user_id": fields.String(required=True),
         "reacter_user_id": fields.String(required=True),
+        "comment_id": fields.String(required=True),
     },
 )
 comment_reaction_notification_action = ns.clone(

--- a/packages/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/packages/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -749,6 +749,7 @@ def extend_comment_reaction(action: NotificationAction):
             "entity_id": encode_int_id(data["entity_id"]),
             "entity_user_id": encode_int_id(data["entity_user_id"]),
             "reacter_user_id": encode_int_id(data["reacter_user_id"]),
+            "comment_id": encode_int_id(data["comment_id"]),
         },
     }
 

--- a/packages/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/packages/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -689,6 +689,7 @@ def extend_comment(action: NotificationAction):
             "type": data["type"],
             "entity_id": encode_int_id(data["entity_id"]),
             "comment_user_id": encode_int_id(data["comment_user_id"]),
+            "comment_id": encode_int_id(data["comment_id"]),
         },
     }
 
@@ -708,6 +709,7 @@ def extend_comment_thread(action: NotificationAction):
             "entity_id": encode_int_id(data["entity_id"]),
             "entity_user_id": encode_int_id(data["entity_user_id"]),
             "comment_user_id": encode_int_id(data["comment_user_id"]),
+            "comment_id": encode_int_id(data["comment_id"]),
         },
     }
 
@@ -727,6 +729,7 @@ def extend_comment_mention(action: NotificationAction):
             "entity_id": encode_int_id(data["entity_id"]),
             "entity_user_id": encode_int_id(data["entity_user_id"]),
             "comment_user_id": encode_int_id(data["comment_user_id"]),
+            "comment_id": encode_int_id(data["comment_id"]),
         },
     }
 

--- a/packages/discovery-provider/src/queries/get_notifications.py
+++ b/packages/discovery-provider/src/queries/get_notifications.py
@@ -462,6 +462,7 @@ class CommentNotification(TypedDict):
     type: str
     entity_id: int
     comment_user_id: int
+    comment_id: int
 
 
 class CommentThreadNotification(TypedDict):
@@ -469,6 +470,7 @@ class CommentThreadNotification(TypedDict):
     entity_id: int
     entity_user_id: int
     comment_user_id: int
+    comment_id: int
 
 
 class CommentMentionNotification(TypedDict):
@@ -476,6 +478,7 @@ class CommentMentionNotification(TypedDict):
     entity_id: int
     entity_user_id: int
     comment_user_id: int
+    comment_id: int
 
 
 class CommentReactionNotification(TypedDict):
@@ -483,6 +486,7 @@ class CommentReactionNotification(TypedDict):
     entity_id: int
     entity_user_id: int
     reacter_user_id: int
+    comment_id: int
 
 
 class ListenStreakReminderNotification(TypedDict):

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -201,6 +201,7 @@ def create_comment(params: ManageEntityParameters):
                 "type": entity_type,
                 "entity_id": entity_id,
                 "comment_user_id": user_id,
+                "comment_id": comment_id,
             },
         )
 
@@ -252,6 +253,7 @@ def create_comment(params: ManageEntityParameters):
                         "entity_id": entity_id,
                         "entity_user_id": entity_user_id,
                         "comment_user_id": user_id,
+                        "comment_id": comment_id,
                     },
                 )
                 safe_add_notification(params.session, mention_notification)
@@ -315,6 +317,7 @@ def create_comment(params: ManageEntityParameters):
                     "entity_id": entity_id,
                     "entity_user_id": entity_user_id,
                     "comment_user_id": user_id,
+                    "comment_id": comment_id,
                 },
             )
             safe_add_notification(params.session, thread_notification)
@@ -485,6 +488,7 @@ def update_comment(params: ManageEntityParameters):
                             "entity_id": entity_id,
                             "entity_user_id": entity_user_id,
                             "comment_user_id": user_id,
+                            "comment_id": comment_id,
                         },
                     )
                     safe_add_notification(params.session, mention_notification)

--- a/packages/harmony/src/hooks/useHoverDelay.ts
+++ b/packages/harmony/src/hooks/useHoverDelay.ts
@@ -67,8 +67,8 @@ export const useHoverDelay = (
     triggeredBy === 'click'
       ? isClicked
       : triggeredBy === 'both'
-      ? isHovered || isClicked
-      : isHovered
+        ? isHovered || isClicked
+        : isHovered
 
   return {
     isHovered,

--- a/packages/sdk/src/sdk/api/generated/full/models/CommentMentionNotificationActionData.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/CommentMentionNotificationActionData.ts
@@ -44,6 +44,12 @@ export interface CommentMentionNotificationActionData {
      * @memberof CommentMentionNotificationActionData
      */
     commentUserId: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof CommentMentionNotificationActionData
+     */
+    commentId: string;
 }
 
 
@@ -67,6 +73,7 @@ export function instanceOfCommentMentionNotificationActionData(value: object): v
     isInstance = isInstance && "entityId" in value && value["entityId"] !== undefined;
     isInstance = isInstance && "entityUserId" in value && value["entityUserId"] !== undefined;
     isInstance = isInstance && "commentUserId" in value && value["commentUserId"] !== undefined;
+    isInstance = isInstance && "commentId" in value && value["commentId"] !== undefined;
 
     return isInstance;
 }
@@ -85,6 +92,7 @@ export function CommentMentionNotificationActionDataFromJSONTyped(json: any, ign
         'entityId': json['entity_id'],
         'entityUserId': json['entity_user_id'],
         'commentUserId': json['comment_user_id'],
+        'commentId': json['comment_id'],
     };
 }
 
@@ -101,6 +109,7 @@ export function CommentMentionNotificationActionDataToJSON(value?: CommentMentio
         'entity_id': value.entityId,
         'entity_user_id': value.entityUserId,
         'comment_user_id': value.commentUserId,
+        'comment_id': value.commentId,
     };
 }
 

--- a/packages/sdk/src/sdk/api/generated/full/models/CommentNotificationActionData.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/CommentNotificationActionData.ts
@@ -38,6 +38,12 @@ export interface CommentNotificationActionData {
      * @memberof CommentNotificationActionData
      */
     commentUserId: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof CommentNotificationActionData
+     */
+    commentId: string;
 }
 
 
@@ -60,6 +66,7 @@ export function instanceOfCommentNotificationActionData(value: object): value is
     isInstance = isInstance && "type" in value && value["type"] !== undefined;
     isInstance = isInstance && "entityId" in value && value["entityId"] !== undefined;
     isInstance = isInstance && "commentUserId" in value && value["commentUserId"] !== undefined;
+    isInstance = isInstance && "commentId" in value && value["commentId"] !== undefined;
 
     return isInstance;
 }
@@ -77,6 +84,7 @@ export function CommentNotificationActionDataFromJSONTyped(json: any, ignoreDisc
         'type': json['type'],
         'entityId': json['entity_id'],
         'commentUserId': json['comment_user_id'],
+        'commentId': json['comment_id'],
     };
 }
 
@@ -92,6 +100,7 @@ export function CommentNotificationActionDataToJSON(value?: CommentNotificationA
         'type': value.type,
         'entity_id': value.entityId,
         'comment_user_id': value.commentUserId,
+        'comment_id': value.commentId,
     };
 }
 

--- a/packages/sdk/src/sdk/api/generated/full/models/CommentReactionNotificationActionData.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/CommentReactionNotificationActionData.ts
@@ -44,6 +44,12 @@ export interface CommentReactionNotificationActionData {
      * @memberof CommentReactionNotificationActionData
      */
     reacterUserId: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof CommentReactionNotificationActionData
+     */
+    commentId: string;
 }
 
 
@@ -67,6 +73,7 @@ export function instanceOfCommentReactionNotificationActionData(value: object): 
     isInstance = isInstance && "entityId" in value && value["entityId"] !== undefined;
     isInstance = isInstance && "entityUserId" in value && value["entityUserId"] !== undefined;
     isInstance = isInstance && "reacterUserId" in value && value["reacterUserId"] !== undefined;
+    isInstance = isInstance && "commentId" in value && value["commentId"] !== undefined;
 
     return isInstance;
 }
@@ -85,6 +92,7 @@ export function CommentReactionNotificationActionDataFromJSONTyped(json: any, ig
         'entityId': json['entity_id'],
         'entityUserId': json['entity_user_id'],
         'reacterUserId': json['reacter_user_id'],
+        'commentId': json['comment_id'],
     };
 }
 
@@ -101,6 +109,7 @@ export function CommentReactionNotificationActionDataToJSON(value?: CommentReact
         'entity_id': value.entityId,
         'entity_user_id': value.entityUserId,
         'reacter_user_id': value.reacterUserId,
+        'comment_id': value.commentId,
     };
 }
 

--- a/packages/sdk/src/sdk/api/generated/full/models/CommentThreadNotificationActionData.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/CommentThreadNotificationActionData.ts
@@ -44,6 +44,12 @@ export interface CommentThreadNotificationActionData {
      * @memberof CommentThreadNotificationActionData
      */
     commentUserId: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof CommentThreadNotificationActionData
+     */
+    commentId: string;
 }
 
 
@@ -67,6 +73,7 @@ export function instanceOfCommentThreadNotificationActionData(value: object): va
     isInstance = isInstance && "entityId" in value && value["entityId"] !== undefined;
     isInstance = isInstance && "entityUserId" in value && value["entityUserId"] !== undefined;
     isInstance = isInstance && "commentUserId" in value && value["commentUserId"] !== undefined;
+    isInstance = isInstance && "commentId" in value && value["commentId"] !== undefined;
 
     return isInstance;
 }
@@ -85,6 +92,7 @@ export function CommentThreadNotificationActionDataFromJSONTyped(json: any, igno
         'entityId': json['entity_id'],
         'entityUserId': json['entity_user_id'],
         'commentUserId': json['comment_user_id'],
+        'commentId': json['comment_id'],
     };
 }
 
@@ -101,6 +109,7 @@ export function CommentThreadNotificationActionDataToJSON(value?: CommentThreadN
         'entity_id': value.entityId,
         'entity_user_id': value.entityUserId,
         'comment_user_id': value.commentUserId,
+        'comment_id': value.commentId,
     };
 }
 


### PR DESCRIPTION
### Description

Fixes issue where comment-id was missing in comment notifications, which is needed for proper deep links