### PR TITLE
Fix mobile image fallback logic

### DIFF
--- a/packages/common/src/hooks/useImageSize.ts
+++ b/packages/common/src/hooks/useImageSize.ts
@@ -64,7 +64,7 @@ export const useImageSize = <
       const mirrors = [...(artwork?.mirrors ?? [])]
       let currentUrl = url
 
-      while (mirrors.length > 0) {
+      while (mirrors.length >= 0) {
         try {
           await preloadImageFn?.(currentUrl)
           return currentUrl
@@ -174,9 +174,12 @@ export const useImageSize = <
     getNextMirrorUrl
   ])
 
-  const onError = useCallback((url: string) => {
-    setFailedUrls((prev) => new Set(prev).add(url))
-  }, [])
+  const onError = useCallback(
+    (url: string) => {
+      setFailedUrls((prev) => new Set(prev).add(url))
+    },
+    [setFailedUrls]
+  )
 
   useEffect(() => {
     resolveImageUrl()

--- a/packages/harmony/src/hooks/useHoverDelay.ts
+++ b/packages/harmony/src/hooks/useHoverDelay.ts
@@ -67,8 +67,8 @@ export const useHoverDelay = (
     triggeredBy === 'click'
       ? isClicked
       : triggeredBy === 'both'
-      ? isHovered || isClicked
-      : isHovered
+        ? isHovered || isClicked
+        : isHovered
 
   return {
     isHovered,

--- a/packages/mobile/src/components/audio/GoogleCast.tsx
+++ b/packages/mobile/src/components/audio/GoogleCast.tsx
@@ -43,7 +43,7 @@ export const useChromecast = () => {
   const previousCastState = usePrevious(castState)
 
   const [internalCounter, setInternalCounter] = useState(0)
-  const imageUrl = useImageSize({
+  const { imageUrl } = useImageSize({
     artwork: track?.artwork,
     targetSize: SquareSizes.SIZE_1000_BY_1000
   })

--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -127,7 +127,7 @@ export const CollectionImage = (props: CollectionImageProps) => {
         },
         style
       ]}
-      source={source ?? { uri: '' }}
+      source={source}
       onLoad={onLoad}
       onError={handleError}
     />

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import { useTrack } from '@audius/common/api'
 import { useImageSize } from '@audius/common/hooks'
 import type { SquareSizes, ID } from '@audius/common/models'
@@ -114,7 +116,7 @@ export const TrackImage = (props: TrackImageProps) => {
 
   const source = loadedSource ?? localTrackImageUri
 
-  const handleError = () => {
+  const handleError = useCallback(() => {
     if (
       source &&
       typeof source === 'object' &&
@@ -123,7 +125,7 @@ export const TrackImage = (props: TrackImageProps) => {
     ) {
       onError(source.uri)
     }
-  }
+  }, [source, onError])
 
   return (
     <FastImage
@@ -135,7 +137,7 @@ export const TrackImage = (props: TrackImageProps) => {
         },
         style
       ]}
-      source={source ?? { uri: '' }}
+      source={source}
       onError={handleError}
       onLoad={onLoad}
     />

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -49,7 +49,7 @@ export const useTrackImage = ({
       return track.artwork
     }
   })
-  const image = useImageSize({
+  const { imageUrl, onError } = useImageSize({
     artwork,
     targetSize: size,
     defaultImage: '',
@@ -58,10 +58,11 @@ export const useTrackImage = ({
     }
   })
 
-  if (image === '') {
+  if (imageUrl === '') {
     return {
       source: imageEmpty,
-      isFallbackImage: true
+      isFallbackImage: true,
+      onError
     }
   }
 
@@ -73,13 +74,15 @@ export const useTrackImage = ({
     return {
       // @ts-ignore
       source: primitiveToImageSource(artwork.url),
-      isFallbackImage: false
+      isFallbackImage: false,
+      onError
     }
   }
 
   return {
-    source: primitiveToImageSource(image),
-    isFallbackImage: false
+    source: primitiveToImageSource(imageUrl),
+    isFallbackImage: false,
+    onError
   }
 }
 
@@ -89,6 +92,7 @@ type TrackImageProps = {
   style?: FastImageProps['style']
   borderRadius?: CornerRadiusOptions
   onLoad?: FastImageProps['onLoad']
+  onError?: FastImageProps['onError']
   children?: React.ReactNode
 }
 
@@ -106,9 +110,20 @@ export const TrackImage = (props: TrackImageProps) => {
   const trackImageSource = useTrackImage({ trackId, size })
   const { cornerRadius } = useTheme()
   const { skeleton } = useThemeColors()
-  const { source: loadedSource, isFallbackImage } = trackImageSource
+  const { source: loadedSource, isFallbackImage, onError } = trackImageSource
 
   const source = loadedSource ?? localTrackImageUri
+
+  const handleError = () => {
+    if (
+      source &&
+      typeof source === 'object' &&
+      'uri' in source &&
+      typeof source.uri === 'string'
+    ) {
+      onError(source.uri)
+    }
+  }
 
   return (
     <FastImage
@@ -121,6 +136,7 @@ export const TrackImage = (props: TrackImageProps) => {
         style
       ]}
       source={source ?? { uri: '' }}
+      onError={handleError}
       onLoad={onLoad}
     />
   )

--- a/packages/mobile/src/components/image/UserImage.tsx
+++ b/packages/mobile/src/components/image/UserImage.tsx
@@ -74,11 +74,5 @@ export const UserImage = (props: UserImageProps) => {
     }
   }, [source, onError])
 
-  return (
-    <FastImage
-      {...imageProps}
-      source={source ?? { uri: '' }}
-      onError={handleError}
-    />
-  )
+  return <FastImage {...imageProps} source={source} onError={handleError} />
 }

--- a/packages/mobile/src/components/image/UserImage.tsx
+++ b/packages/mobile/src/components/image/UserImage.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import { useUser } from '@audius/common/api'
 import { useImageSize } from '@audius/common/hooks'
 import type { SquareSizes, ID } from '@audius/common/models'
@@ -28,7 +30,7 @@ export const useProfilePicture = ({
   })
 
   const { profile_picture, updatedProfilePicture } = partialUser ?? {}
-  const image = useImageSize({
+  const { imageUrl, onError } = useImageSize({
     artwork: profile_picture,
     targetSize: size,
     defaultImage: '',
@@ -37,23 +39,26 @@ export const useProfilePicture = ({
     }
   })
 
-  if (image === '') {
+  if (imageUrl === '') {
     return {
       source: profilePicEmpty,
-      isFallbackImage: true
+      isFallbackImage: true,
+      onError
     }
   }
 
   if (updatedProfilePicture) {
     return {
       source: primitiveToImageSource(updatedProfilePicture.url),
-      isFallbackImage: false
+      isFallbackImage: false,
+      onError
     }
   }
 
   return {
-    source: primitiveToImageSource(image),
-    isFallbackImage: false
+    source: primitiveToImageSource(imageUrl),
+    isFallbackImage: false,
+    onError
   }
 }
 
@@ -61,7 +66,19 @@ export type UserImageProps = UseUserImageOptions & Partial<FastImageProps>
 
 export const UserImage = (props: UserImageProps) => {
   const { userId, size, ...imageProps } = props
-  const { source } = useProfilePicture({ userId, size })
+  const { source, onError } = useProfilePicture({ userId, size })
 
-  return <FastImage {...imageProps} source={source ?? { uri: '' }} />
+  const handleError = useCallback(() => {
+    if (source && typeof source === 'object' && 'uri' in source && source.uri) {
+      onError(source.uri)
+    }
+  }, [source, onError])
+
+  return (
+    <FastImage
+      {...imageProps}
+      source={source ?? { uri: '' }}
+      onError={handleError}
+    />
+  )
 }

--- a/packages/mobile/src/harmony-native/components/FastImage/FastImage.tsx
+++ b/packages/mobile/src/harmony-native/components/FastImage/FastImage.tsx
@@ -6,7 +6,7 @@ import type {
 import RNFastImage from 'react-native-fast-image'
 
 export type FastImageProps = Omit<RNFastImageProps, 'source'> & {
-  source: ImageSourcePropType
+  source?: ImageSourcePropType
   priority?: Priority
 }
 

--- a/packages/web/src/components/ai-attribution-modal/SearchBarResult.tsx
+++ b/packages/web/src/components/ai-attribution-modal/SearchBarResult.tsx
@@ -39,7 +39,7 @@ type ImageProps = {
 
 const Image = memo((props: ImageProps) => {
   const { defaultImage, artwork, size, isUser } = props
-  const image = useImageSize({
+  const { imageUrl } = useImageSize({
     artwork,
     targetSize: size,
     defaultImage,
@@ -50,11 +50,11 @@ const Image = memo((props: ImageProps) => {
       skeletonClassName={cn({ [styles.userImageContainerSkeleton]: isUser })}
       wrapperClassName={cn(styles.imageContainer)}
       className={cn({
-        [styles.image]: image,
+        [styles.image]: imageUrl,
         [styles.userImage]: isUser,
-        [styles.emptyUserImage]: isUser && image === defaultImage
+        [styles.emptyUserImage]: isUser && imageUrl === defaultImage
       })}
-      image={image}
+      image={imageUrl}
     />
   )
 })

--- a/packages/web/src/hooks/useCollectionCoverArt.ts
+++ b/packages/web/src/hooks/useCollectionCoverArt.ts
@@ -18,7 +18,7 @@ export const useCollectionCoverArt = ({
   const { data: artwork } = useCollection(collectionId, {
     select: (collection) => collection.artwork
   })
-  const image = useImageSize({
+  const { imageUrl } = useImageSize({
     artwork,
     targetSize: size,
     defaultImage: defaultImage ?? imageEmpty,
@@ -31,5 +31,5 @@ export const useCollectionCoverArt = ({
   // @ts-ignore
   if (artwork?.url) return artwork.url
 
-  return image
+  return imageUrl
 }

--- a/packages/web/src/hooks/useCoverPhoto.ts
+++ b/packages/web/src/hooks/useCoverPhoto.ts
@@ -32,14 +32,14 @@ export const useCoverPhoto = ({
     select: (user) => pick(user, 'cover_photo', 'updatedCoverPhoto')
   })
   const { cover_photo, updatedCoverPhoto } = partialUser ?? {}
-  const image = useImageSize({
+  const { imageUrl } = useImageSize({
     artwork: cover_photo,
     targetSize: size,
     defaultImage: defaultImage ?? imageCoverPhotoBlank,
     preloadImageFn: preload
   })
 
-  const isDefaultCover = image === imageCoverPhotoBlank
+  const isDefaultCover = imageUrl === imageCoverPhotoBlank
   const isDefaultProfile = profilePicture === imageProfilePicEmpty
   const shouldBlur = isDefaultCover && !isDefaultProfile
 
@@ -47,5 +47,5 @@ export const useCoverPhoto = ({
     return { image: updatedCoverPhoto.url, shouldBlur }
   }
 
-  return { image: shouldBlur ? profilePicture : image, shouldBlur }
+  return { image: shouldBlur ? profilePicture : imageUrl, shouldBlur }
 }

--- a/packages/web/src/hooks/useProfilePicture.ts
+++ b/packages/web/src/hooks/useProfilePicture.ts
@@ -20,7 +20,7 @@ export const useProfilePicture = ({
   })
   const { profile_picture, updatedProfilePicture } = partialUser ?? {}
 
-  const image = useImageSize({
+  const { imageUrl } = useImageSize({
     artwork: profile_picture,
     targetSize: size,
     defaultImage: defaultImage ?? profilePicEmpty,
@@ -30,5 +30,5 @@ export const useProfilePicture = ({
   if (updatedProfilePicture) {
     return updatedProfilePicture.url
   }
-  return image
+  return imageUrl
 }

--- a/packages/web/src/hooks/useTrackCoverArt.ts
+++ b/packages/web/src/hooks/useTrackCoverArt.ts
@@ -26,7 +26,7 @@ export const useTrackCoverArt = ({
   const { data: artwork } = useTrack(trackId, {
     select: (track) => track?.artwork
   })
-  const image = useImageSize({
+  const { imageUrl } = useImageSize({
     artwork,
     targetSize: size,
     defaultImage: defaultImage ?? imageEmpty,
@@ -39,7 +39,7 @@ export const useTrackCoverArt = ({
   // @ts-ignore
   if (artwork?.url) return artwork.url
 
-  return image
+  return imageUrl
 }
 
 export const useTrackCoverArtDominantColors = ({


### PR DESCRIPTION
### Description

Very annoyingly react-native-fast-image's preload method can't callback when it fails to preload an image. See https://github.com/DylanVann/react-native-fast-image/pull/995.

Our `useImage` hook depends on the ability for a preload to throw when trying to fetch to roll over to another node in the replica that's not healthy. So instead, we can have the useImage hook return an onError that it can use instead.

Longer term, I'd like to move some form of this logic to the bridge.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran mobile simulator, images load that otherwise didn't