### PR TITLE
Speed up mobile app warm start by another ~75%

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -4,7 +4,6 @@ import { PortalProvider, PortalHost } from '@gorhom/portal'
 import * as Sentry from '@sentry/react-native'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { Platform, UIManager } from 'react-native'
-import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import {
   SafeAreaProvider,
   initialWindowMetrics
@@ -20,19 +19,16 @@ import { NotificationReminder } from 'app/components/notification-reminder/Notif
 import OAuthWebView from 'app/components/oauth/OAuthWebView'
 import { RateCtaReminder } from 'app/components/rate-cta-drawer/RateCtaReminder'
 import { Toasts } from 'app/components/toasts'
-import { useEnterForeground } from 'app/hooks/useAppState'
 import { incrementSessionCount } from 'app/hooks/useSessionCount'
 import { RootScreen } from 'app/screens/root-screen'
 import { localStorage } from 'app/services/local-storage'
 import { queryClient } from 'app/services/query-client'
 import { persistor, store } from 'app/store'
-import {
-  forceRefreshConnectivity,
-  subscribeToNetworkStatusUpdates
-} from 'app/utils/reachability'
+import { subscribeToNetworkStatusUpdates } from 'app/utils/reachability'
 
 import { AppContextProvider } from './AppContextProvider'
 import { AudiusQueryProvider } from './AudiusQueryProvider'
+import { ConnectivityManager } from './ConnectivityManager'
 import { Drawers } from './Drawers'
 import ErrorBoundary from './ErrorBoundary'
 import { ThemeProvider } from './ThemeProvider'
@@ -61,10 +57,6 @@ const App = () => {
     TrackPlayer.setupPlayer({ autoHandleInterruptions: true })
   })
 
-  useEnterForeground(() => {
-    forceRefreshConnectivity()
-  })
-
   return (
     <AppContextProvider>
       <SafeAreaProvider initialMetrics={initialWindowMetrics}>
@@ -74,29 +66,28 @@ const App = () => {
               <SyncLocalStorageUserProvider localStorage={localStorage}>
                 <PersistGate loading={null} persistor={persistor}>
                   <ThemeProvider>
-                    <GestureHandlerRootView style={{ flex: 1 }}>
-                      <PortalProvider>
-                        <ErrorBoundary>
-                          <NavigationContainer
-                            navigationIntegration={navigationIntegration}
-                          >
-                            <BottomSheetModalProvider>
-                              <CommentDrawerProvider>
-                                <Toasts />
-                                <Airplay />
-                                <RootScreen />
-                                <Drawers />
-                                <OAuthWebView />
-                                <NotificationReminder />
-                                <RateCtaReminder />
-                                <PortalHost name='ChatReactionsPortal' />
-                              </CommentDrawerProvider>
-                            </BottomSheetModalProvider>
-                            <PortalHost name='DrawerPortal' />
-                          </NavigationContainer>
-                        </ErrorBoundary>
-                      </PortalProvider>
-                    </GestureHandlerRootView>
+                    <PortalProvider>
+                      <ErrorBoundary>
+                        <ConnectivityManager />
+                        <NavigationContainer
+                          navigationIntegration={navigationIntegration}
+                        >
+                          <BottomSheetModalProvider>
+                            <CommentDrawerProvider>
+                              <Toasts />
+                              <Airplay />
+                              <RootScreen />
+                              <Drawers />
+                              <OAuthWebView />
+                              <NotificationReminder />
+                              <RateCtaReminder />
+                              <PortalHost name='ChatReactionsPortal' />
+                            </CommentDrawerProvider>
+                          </BottomSheetModalProvider>
+                          <PortalHost name='DrawerPortal' />
+                        </NavigationContainer>
+                      </ErrorBoundary>
+                    </PortalProvider>
                   </ThemeProvider>
                 </PersistGate>
               </SyncLocalStorageUserProvider>

--- a/packages/mobile/src/app/ConnectivityManager.tsx
+++ b/packages/mobile/src/app/ConnectivityManager.tsx
@@ -1,0 +1,14 @@
+import { useEnterForeground } from 'app/hooks/useAppState'
+import { forceRefreshConnectivity } from 'app/utils/reachability'
+
+/**
+ * Component that handles connectivity refresh when app enters foreground.
+ * Separated from main App component to prevent unnecessary rerenders.
+ */
+export const ConnectivityManager = () => {
+  useEnterForeground(() => {
+    forceRefreshConnectivity()
+  })
+
+  return null
+}

--- a/performance-log.md
+++ b/performance-log.md
@@ -1,3 +1,3 @@
-- Improved app warm start by another 75% (down 2 renders / down ~150ms)
-- Improved app warm start by 83% (removed 21 rerenders from App.tsx / down ~1785ms)
-- Improved profile screen render time by 50% (down 2 renders / down ~250ms)
+- Improved app warm start by another 75% (trimmed 2 renders / ~150ms)
+- Improved app warm start by 83% (trimmed 21 rerenders / ~1785ms)
+- Improved profile screen render time by 50% (trimmed 2 renders / ~250ms)

--- a/performance-log.md
+++ b/performance-log.md
@@ -1,0 +1,3 @@
+- Improved app warm start by another 75% (down 2 renders / down ~150ms)
+- Improved app warm start by 83% (removed 21 rerenders from App.tsx / down ~1785ms)
+- Improved profile screen render time by 50% (down 2 renders / down ~250ms)


### PR DESCRIPTION
### Description

- This hook was the only thing triggering rerenders on `App.tsx` on warm start (lock/unlock screen). 
- I realized that this foreground hook doesnt even change anything in the render so there's no reason for it to be causing any renders at all.
- Moving the hook out to its own component which means `App.tsx` doesnt ever rerender now.

Now the app warm start looks sooooo nice 
<img width="410" height="256" alt="image" src="https://github.com/user-attachments/assets/7e30ae77-50e3-46d4-bdf5-619548711389" />

(most expensive commit being 10ms is well within the 16.6ms range to stay at 60fps ❤️ )

- Also added a markdown file to keep a log of performance improvements as we go

### How Has This Been Tested?

ios:prod
