### PR TITLE
Search/explore mobile web pass 

### DIFF
--- a/packages/harmony/src/components/artwork/Artwork.tsx
+++ b/packages/harmony/src/components/artwork/Artwork.tsx
@@ -38,7 +38,6 @@ export const Artwork = (props: ArtworkProps) => {
   const [isLoadingState, setIsLoadingState] = useState(true)
   const isLoading = isLoadingProp ?? isLoadingState
   const { color, motion } = useTheme()
-  console.log('asdf imgRef', imgRef.current)
   useEffect(() => {
     setIsLoadingState(true)
   }, [src])
@@ -90,7 +89,6 @@ export const Artwork = (props: ArtworkProps) => {
               setIsLoadingState(false)
             }}
             onError={(event) => {
-              console.log('asdf error: ', event)
               setIsLoadingState(false)
               onError?.(event)
             }}

--- a/packages/harmony/src/components/artwork/Artwork.tsx
+++ b/packages/harmony/src/components/artwork/Artwork.tsx
@@ -38,7 +38,7 @@ export const Artwork = (props: ArtworkProps) => {
   const [isLoadingState, setIsLoadingState] = useState(true)
   const isLoading = isLoadingProp ?? isLoadingState
   const { color, motion } = useTheme()
-
+  console.log('asdf imgRef', imgRef.current)
   useEffect(() => {
     setIsLoadingState(true)
   }, [src])
@@ -90,6 +90,7 @@ export const Artwork = (props: ArtworkProps) => {
               setIsLoadingState(false)
             }}
             onError={(event) => {
+              console.log('asdf error: ', event)
               setIsLoadingState(false)
               onError?.(event)
             }}

--- a/packages/harmony/src/components/artwork/Artwork.tsx
+++ b/packages/harmony/src/components/artwork/Artwork.tsx
@@ -38,6 +38,7 @@ export const Artwork = (props: ArtworkProps) => {
   const [isLoadingState, setIsLoadingState] = useState(true)
   const isLoading = isLoadingProp ?? isLoadingState
   const { color, motion } = useTheme()
+
   useEffect(() => {
     setIsLoadingState(true)
   }, [src])

--- a/packages/harmony/src/components/radio-group/RadioGroup.tsx
+++ b/packages/harmony/src/components/radio-group/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ReactNode, useCallback } from 'react'
+import { ChangeEvent, ReactNode, useCallback, useRef } from 'react'
 
 import { useControlled } from '../../hooks/useControlled'
 import { Flex, FlexProps } from '../layout'
@@ -27,10 +27,22 @@ export const RadioGroup = (props: RadioGroupProps) => {
     defaultValue,
     componentName: 'RadioButtonGroup'
   })
+
+  const isChanging = useRef(false)
+
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
+      // Prevent concurrent changes
+      if (isChanging.current) return
+
+      isChanging.current = true
       setValueState(e.target.value)
       onChange?.(e)
+
+      // Reset the lock after a short delay
+      requestAnimationFrame(() => {
+        isChanging.current = false
+      })
     },
     [setValueState, onChange]
   )

--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -75,7 +75,8 @@ export const UserLink = (props: UserLinkProps) => {
         columnGap: spacing.xs,
         alignItems: 'center',
         lineHeight: 'normal',
-        display: 'inline-flex'
+        display: 'inline-flex',
+        width: '100%'
       }}
     >
       <TextLink
@@ -83,7 +84,6 @@ export const UserLink = (props: UserLinkProps) => {
         css={{
           lineHeight: 'normal'
         }}
-        ellipses={popover}
         {...other}
       >
         <Text ellipses size={textSize}>
@@ -107,7 +107,8 @@ export const UserLink = (props: UserLinkProps) => {
           columnGap: spacing.xs,
           alignItems: 'center',
           lineHeight: 'normal',
-          display: 'inline-flex'
+          display: 'inline-flex',
+          width: '100%'
         }}
       >
         <ArtistPopover
@@ -119,7 +120,7 @@ export const UserLink = (props: UserLinkProps) => {
           component='span'
           mount={popoverMount}
         >
-          <TextLink to={url} ellipses={popover} {...other}>
+          <TextLink to={url} {...other}>
             <Text ellipses size={textSize}>
               {name}
             </Text>

--- a/packages/web/src/components/track/Artwork.tsx
+++ b/packages/web/src/components/track/Artwork.tsx
@@ -33,7 +33,7 @@ type TileArtworkProps = {
     user: { name: string; is_verified: boolean; user_id: ID }
   }
   hasStreamAccess?: boolean
-} & BoxProps
+} & Omit<BoxProps, 'id'>
 
 export const ArtworkIcon = ({
   isBuffering,

--- a/packages/web/src/components/track/Artwork.tsx
+++ b/packages/web/src/components/track/Artwork.tsx
@@ -4,7 +4,9 @@ import { SquareSizes, ID } from '@audius/common/models'
 import {
   IconLock,
   IconPlaybackPlay as IconPlay,
-  IconPlaybackPause as IconPause
+  IconPlaybackPause as IconPause,
+  Box,
+  BoxProps
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -31,7 +33,7 @@ type TileArtworkProps = {
     user: { name: string; is_verified: boolean; user_id: ID }
   }
   hasStreamAccess?: boolean
-}
+} & BoxProps
 
 export const ArtworkIcon = ({
   isBuffering,
@@ -86,7 +88,8 @@ const Artwork = memo(
     coSign,
     label,
     hasStreamAccess,
-    isTrack
+    isTrack,
+    ...other
   }: ArtworkProps) => {
     const imageElement = (
       <DynamicImage
@@ -121,6 +124,8 @@ const Artwork = memo(
       >
         {imageElement}
       </TrackFlair>
+    ) : other ? (
+      <Box {...other}>{imageElement}</Box>
     ) : (
       imageElement
     )
@@ -141,6 +146,7 @@ export const CollectionArtwork = memo((props: TileArtworkProps) => {
     collectionId: props.id,
     size: SquareSizes.SIZE_150_BY_150
   })
+  console.log('asdf image', props.id, image)
 
   return <Artwork {...props} image={image} />
 })

--- a/packages/web/src/components/track/Artwork.tsx
+++ b/packages/web/src/components/track/Artwork.tsx
@@ -146,7 +146,6 @@ export const CollectionArtwork = memo((props: TileArtworkProps) => {
     collectionId: props.id,
     size: SquareSizes.SIZE_150_BY_150
   })
-  console.log('asdf image', props.id, image)
 
   return <Artwork {...props} image={image} />
 })

--- a/packages/web/src/components/user-card/UserCard.tsx
+++ b/packages/web/src/components/user-card/UserCard.tsx
@@ -82,6 +82,7 @@ export const UserCard = (props: UserCardProps) => {
           center
           onClick={onUserLinkClick}
           popover={true}
+          css={{ width: '100%' }}
         />
         <ArtistPopover handle={handle} css={{ width: '100%' }}>
           <TextLink

--- a/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
@@ -151,7 +151,12 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
         justifyContent='space-between'
         ph={isMobile ? 'l' : undefined}
       >
-        <Text variant='heading'>{title}</Text>
+        <Text
+          variant={isMobile ? 'title' : 'heading'}
+          size={isMobile ? 'l' : 'm'}
+        >
+          {title}
+        </Text>
         {!isMobile && (canScrollLeft || canScrollRight) ? (
           <Flex gap='l'>
             <IconButton

--- a/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
@@ -212,6 +212,7 @@ const ExplorePage = () => {
             aria-label={'Select search category'}
             name='searchcategory'
             value={categoryKey}
+            onChange={handleCategoryChange}
             css={{
               overflow: 'scroll',
               // Hide scrollbar for IE, Edge, and Firefox
@@ -230,11 +231,9 @@ const ExplorePage = () => {
                 key={key}
                 label={capitalize(key)}
                 name='searchCategory'
-                onChange={handleCategoryChange}
                 size='large'
                 type='radio'
                 value={key}
-                checked={key === categoryKey}
               />
             ))}
           </RadioGroup>

--- a/packages/web/src/pages/search-page/RecentSearches.tsx
+++ b/packages/web/src/pages/search-page/RecentSearches.tsx
@@ -149,12 +149,22 @@ const RecentSearchTrack = (props: { searchItem: SearchItem }) => {
           {title}
         </Text>
         <Flex alignItems='baseline'>
-          <Text variant='body' size='xs' color='subdued'>
+          <Text
+            variant='body'
+            size='xs'
+            color='subdued'
+            style={{ width: '100%' }}
+          >
             {messages.track}
             {' |'}
             &nbsp;
-            <UserLink userId={user.user_id} variant='subdued' badgeSize='2xs' />
           </Text>
+          <UserLink
+            textSize='xs'
+            userId={user.user_id}
+            variant='subdued'
+            badgeSize='2xs'
+          />
         </Flex>
       </Flex>
     </RecentSearch>
@@ -213,16 +223,22 @@ const RecentSearchCollection = (props: { searchItem: SearchItem }) => {
           {playlist_name}
         </Text>
         <Flex alignItems='baseline'>
-          <Text variant='body' size='xs' color='subdued'>
+          <Text
+            variant='body'
+            size='xs'
+            color='subdued'
+            style={{ width: '100%' }}
+          >
             {is_album ? messages.album : messages.playlist}
             {' |'}
             &nbsp;
-            <UserLink
-              userId={playlist_owner_id}
-              variant='subdued'
-              badgeSize='2xs'
-            />
           </Text>
+          <UserLink
+            textSize='xs'
+            userId={playlist_owner_id}
+            variant='subdued'
+            badgeSize='2xs'
+          />
         </Flex>
       </Flex>
     </RecentSearch>

--- a/packages/web/src/pages/search-page/search-results/AllResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/AllResults.tsx
@@ -17,6 +17,7 @@ import { useDispatch } from 'react-redux'
 import { Link, useNavigate } from 'react-router-dom-v5-compat'
 
 import { make } from 'common/store/analytics/actions'
+import { CollectionImage } from 'components/collection/CollectionImage'
 import { TrackArtwork } from 'components/track/TrackArtwork'
 import { useIsMobile } from 'hooks/useIsMobile'
 
@@ -68,8 +69,8 @@ const SearchResultItem = ({
     }}
   >
     {imageComponent}
-    <Flex direction='column' flex={1}>
-      <Text size='s' ellipses style={{ maxWidth: '90%' }}>
+    <Flex direction='column' css={{ minWidth: 0, flex: 1 }}>
+      <Text size='s' ellipses>
         {name}
       </Text>
       <Text size='xs' color='subdued'>
@@ -253,12 +254,15 @@ export const AllResults = ({ handleSearchTab }: AllResultsProps) => {
               kind={Kind.COLLECTIONS}
               onClick={handleClickSearchResult}
               imageComponent={
-                <Artwork
-                  src={playlist.artwork?.['150x150']}
-                  isLoading={isLoading}
-                  w={40}
-                  h={40}
-                />
+                <Flex>
+                  <CollectionImage
+                    collectionId={playlist.playlist_id}
+                    size={SquareSizes.SIZE_150_BY_150}
+                    data-testid={`cover-art-${playlist.playlist_id}`}
+                    h={40}
+                    w={40}
+                  />
+                </Flex>
               }
               name={playlist.playlist_name}
               entityType={messages.playlist}

--- a/packages/web/src/pages/trending-page/components/RewardsBanner.tsx
+++ b/packages/web/src/pages/trending-page/components/RewardsBanner.tsx
@@ -78,30 +78,29 @@ const RewardsBanner = ({ bannerType }: RewardsBannerProps) => {
         w='100%'
         alignItems={isMobile ? 'flex-start' : 'center'}
         gap={isMobile ? undefined : 'l'}
-        mr='m'
         css={{
           '@media (max-width: 1300px)': {
             flexDirection: 'column',
-            alignItems: 'flex-start',
+            alignItems: isMobile ? 'center' : 'flex-start',
             gap: 'unset'
           }
         }}
       >
-        <Flex alignItems='center' mb={isMobile ? 'xs' : undefined} gap='s'>
-          <IconCrown size='l' color='staticWhite' />
-          <Text variant='title' size='l' color='staticWhite'>
+        <Flex mb={isMobile ? 'xs' : undefined} gap={isMobile ? 'xs' : 's'}>
+          <IconCrown size={isMobile ? 's' : 'm'} color='staticWhite' />
+          <Text variant='title' size={isMobile ? 's' : 'l'} color='staticWhite'>
             {messageMap[bannerType].title}
           </Text>
         </Flex>
         <Text
           variant='body'
-          size='l'
+          size={isMobile ? 's' : 'l'}
           strength='strong'
           color='staticWhite'
           css={{
             opacity: 0.8,
             marginTop: isMobile ? spacing.xs : 0,
-            whiteSpace: isMobile ? 'normal' : 'nowrap'
+            whiteSpace: 'nowrap'
           }}
         >
           {messageMap[bannerType].description}


### PR DESCRIPTION
### Description
Fixes a bunch of small mobile-web issues uncovered during Search/Explore QA.

Profile card overflow issues with long usernames (A)
Overflow of text names in “All” search results (B)
incorrect Title Sizes
Empty playlist artwork doesn’t render default image (B)
Able to click two Pills at once
Underground trending banner not centered (maybe not related to project) (C)
Quick searches text overflows (D)
No Results Card Misaligned
Incorrect font on recent searches (E)
Add Search Icon to “All” Pill

Images in https://www.notion.so/audiusproject/Meeting-Notes-Search-Explore-Merge-1ebc00e6b2038063a59de3e3f249c43d?source=copy_link#231c00e6b20380ed89a5dcfad7e48056

Resolves PE-6531.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on mobile web against stage
