### PR TITLE
Add track tile carousel skeleton and fix width

### DIFF
--- a/packages/mobile/src/screens/explore-screen/components/ActiveDiscussions.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ActiveDiscussions.tsx
@@ -10,15 +10,19 @@ export const ActiveDiscussions = () => {
   const { data: recentlyCommentedTracks, isLoading } =
     useRecentlyCommentedTracks()
 
-  if (!recentlyCommentedTracks || recentlyCommentedTracks.length === 0) {
+  if (
+    !isLoading &&
+    (!recentlyCommentedTracks || recentlyCommentedTracks.length === 0)
+  ) {
     return null
   }
 
   return (
-    <ExploreSection title={messages.activeDiscussions} isLoading={isLoading}>
+    <ExploreSection title={messages.activeDiscussions}>
       <TrackTileCarousel
         tracks={recentlyCommentedTracks}
         uidPrefix='recently-commented-track'
+        isLoading={isLoading}
       />
     </ExploreSection>
   )

--- a/packages/mobile/src/screens/explore-screen/components/RecentPremiumTracks.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/RecentPremiumTracks.tsx
@@ -8,17 +8,18 @@ import { TrackTileCarousel } from './TrackTileCarousel'
 
 export const RecentPremiumTracks = () => {
   const { data: recentPremiumTracks, isLoading } = useRecentPremiumTracks()
-  if (!recentPremiumTracks || recentPremiumTracks.length === 0) {
+  if (
+    !isLoading &&
+    (!recentPremiumTracks || recentPremiumTracks.length === 0)
+  ) {
     return null
   }
   return (
-    <ExploreSection
-      title={messages.recentlyListedForSale}
-      isLoading={isLoading}
-    >
+    <ExploreSection title={messages.recentlyListedForSale}>
       <TrackTileCarousel
         tracks={recentPremiumTracks}
         uidPrefix='recent-premium'
+        isLoading={isLoading}
       />
     </ExploreSection>
   )

--- a/packages/mobile/src/screens/explore-screen/components/RecommendedTracks.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/RecommendedTracks.tsx
@@ -9,15 +9,16 @@ import { TrackTileCarousel } from './TrackTileCarousel'
 export const RecommendedTracks = () => {
   const { data: recommendedTracks, isLoading } = useRecommendedTracks()
 
-  if (!recommendedTracks || recommendedTracks.length === 0) {
+  if (!isLoading && (!recommendedTracks || recommendedTracks.length === 0)) {
     return null
   }
 
   return (
-    <ExploreSection title={messages.forYou} isLoading={isLoading}>
+    <ExploreSection title={messages.forYou}>
       <TrackTileCarousel
         tracks={recommendedTracks}
         uidPrefix='recommended-track'
+        isLoading={isLoading}
       />
     </ExploreSection>
   )

--- a/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
@@ -4,17 +4,44 @@ import { css } from '@emotion/native'
 import { ScrollView } from 'react-native'
 
 import { Flex } from '@audius/harmony-native'
-import { TrackTile } from 'app/components/lineup-tile'
+import { LineupTileSkeleton, TrackTile } from 'app/components/lineup-tile'
 
 interface TrackTileCarouselProps {
-  tracks: number[]
+  tracks?: number[]
   uidPrefix: string
+  isLoading?: boolean
 }
 
 export const TrackTileCarousel = ({
   tracks,
-  uidPrefix
+  uidPrefix,
+  isLoading
 }: TrackTileCarouselProps) => {
+  if (isLoading || !tracks) {
+    return (
+      <Flex direction='row' mh={-16}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ paddingHorizontal: 16 }}
+        >
+          {[0, 1].map((columnIndex) => (
+            <Flex
+              key={columnIndex}
+              direction='column'
+              gap='m'
+              w={343}
+              mr={columnIndex === 0 ? 16 : 0}
+            >
+              <LineupTileSkeleton />
+              <LineupTileSkeleton />
+            </Flex>
+          ))}
+        </ScrollView>
+      </Flex>
+    )
+  }
+
   // Chunk tracks into pairs for 2-track columns
   const trackPairs: number[][] = []
   for (let i = 0; i < tracks.length; i += 2) {
@@ -33,10 +60,8 @@ export const TrackTileCarousel = ({
             key={pairIndex}
             direction='column'
             gap='m'
-            style={css({
-              minWidth: 343,
-              marginRight: pairIndex < trackPairs.length - 1 ? 16 : 0
-            })}
+            w={343}
+            mr={pairIndex < trackPairs.length - 1 ? 16 : 0}
           >
             {pair.map((track, trackIndex) => (
               <TrackTile


### PR DESCRIPTION
### Description
* Make track tile width consistent on mobile. On web, it's trickier because not all the stats can fit. Should follow up with product design about this.
* Also add loading skeletons.

Fixes PE-6549
Fixes PE-6546

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
