### PR TITLE
Fix playback issue clicking tracks

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -755,13 +755,13 @@ export const AudioPlayer = () => {
         queueIndex !== playerIdx &&
         queueIndex < queue.length
       ) {
-        // Safety check: Don't skip if the target track has no URL (corrupted queue)
+        // Only skip if the target track exists and has a valid URL
         const targetTrack = queue[queueIndex]
-        if (!targetTrack?.url || targetTrack.url.trim() === '') {
-          return
+        if (targetTrack?.url && targetTrack.url.trim() !== '') {
+          await TrackPlayer.skip(queueIndex)
         }
-
-        await TrackPlayer.skip(queueIndex)
+        // If the track doesn't have a URL yet, don't skip but also don't return early
+        // This allows the queue change to be processed when the URL becomes available
       }
     } catch (error) {
       console.error('Error in handleQueueIdxChange:', error)

--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -679,6 +679,19 @@ export const AudioPlayer = () => {
       queuableTracks: QueueableTrack[],
       queueIndex = -1
     ) => {
+      // If queueIndex is -1, we're appending tracks - enqueue them all sequentially
+      if (queueIndex === -1) {
+        for (const track of queuableTracks) {
+          if (abortEnqueueControllerRef.current.signal.aborted) {
+            return
+          }
+          if (track) {
+            await TrackPlayer.add(await makeTrackData(track))
+          }
+        }
+        return
+      }
+
       // Safety check: Don't proceed if queueIndex is invalid
       if (queueIndex < 0 || queueIndex >= queuableTracks.length) {
         return


### PR DESCRIPTION
### Description

Fixes issue where clicking on a track, scrolling to fetch new tracks, and then clicking on another one resulted in an issue where the original track kept playing. This issue was introduced in https://github.com/AudiusProject/audius-protocol/pull/12460, fixing another issue, and this follow up maintains that fix while covering this one