### PR TITLE
[PE-6557] Adds most shared section to Search/Explore

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -105,6 +105,7 @@ export * from './tan-query/tracks/useSuggestedPlaylistTracks'
 export * from './tan-query/tracks/useFeelingLuckyTrack'
 export * from './tan-query/tracks/useRecentlyPlayedTracks'
 export * from './tan-query/tracks/useRecentlyCommentedTracks'
+export * from './tan-query/tracks/useMostSharedTracks'
 
 // Users
 export * from './tan-query/users/useUpdateProfile'

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -73,6 +73,7 @@ export const QUERY_KEYS = {
   purchasersCount: 'purchasersCount',
   remixedTracks: 'remixedTracks',
   recommendedTracks: 'recommendedTracks',
+  mostSharedTracks: 'mostSharedTracks',
   recentPremiumTracks: 'recentPremiumTracks',
   mutedUsers: 'mutedUsers',
   salesAggregate: 'salesAggregate',

--- a/packages/common/src/api/tan-query/tracks/useMostSharedTracks.ts
+++ b/packages/common/src/api/tan-query/tracks/useMostSharedTracks.ts
@@ -1,0 +1,52 @@
+import { HashId, OptionalId } from '@audius/sdk'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { userTrackMetadataFromSDK } from '~/adapters/track'
+import { transformAndCleanList } from '~/adapters/utils'
+import { primeTrackData, useQueryContext } from '~/api/tan-query/utils'
+import { ID } from '~/models'
+
+import { QUERY_KEYS } from '../queryKeys'
+import { QueryKey, SelectableQueryOptions } from '../types'
+import { useCurrentUserId } from '../users/account/useCurrentUserId'
+
+export type UseMostSharedTracksArgs = {
+  userId: ID | null | undefined
+}
+
+export const getMostSharedTracksQueryKey = ({
+  userId
+}: UseMostSharedTracksArgs) => {
+  return [QUERY_KEYS.mostSharedTracks, userId] as unknown as QueryKey<ID[]>
+}
+
+export const useMostSharedTracks = <TResult = ID[]>(
+  options?: SelectableQueryOptions<ID[], TResult>
+) => {
+  const { audiusSdk } = useQueryContext()
+  const { data: currentUserId } = useCurrentUserId()
+  const queryClient = useQueryClient()
+
+  return useQuery({
+    queryKey: getMostSharedTracksQueryKey({ userId: currentUserId }),
+    queryFn: async () => {
+      if (!currentUserId) return []
+      const sdk = await audiusSdk()
+      const { data = [] } = await sdk.full.tracks.getMostSharedTracks({
+        userId: OptionalId.parse(currentUserId),
+        limit: 10,
+        timeRange: 'week'
+      })
+      const tracks = transformAndCleanList(data, userTrackMetadataFromSDK)
+
+      primeTrackData({
+        tracks,
+        queryClient
+      })
+
+      return data.map((item) => HashId.parse(item.id))
+    },
+    ...options,
+    enabled: options?.enabled !== false
+  })
+}

--- a/packages/common/src/api/tan-query/tracks/useMostSharedTracks.ts
+++ b/packages/common/src/api/tan-query/tracks/useMostSharedTracks.ts
@@ -1,4 +1,4 @@
-import { HashId, OptionalId } from '@audius/sdk'
+import { OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
@@ -37,14 +37,12 @@ export const useMostSharedTracks = <TResult = ID[]>(
         limit: 10,
         timeRange: 'week'
       })
-      const tracks = transformAndCleanList(data, userTrackMetadataFromSDK)
-
-      primeTrackData({
-        tracks,
+      const tracks = primeTrackData({
+        tracks: transformAndCleanList(data, userTrackMetadataFromSDK),
         queryClient
       })
 
-      return data.map((item) => HashId.parse(item.id))
+      return tracks.map(({ track_id }) => track_id)
     },
     ...options,
     enabled: options?.enabled !== false

--- a/packages/common/src/api/tan-query/tracks/useRecentlyCommentedTracks.ts
+++ b/packages/common/src/api/tan-query/tracks/useRecentlyCommentedTracks.ts
@@ -1,4 +1,4 @@
-import { HashId, Id } from '@audius/sdk'
+import { Id } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
@@ -38,13 +38,12 @@ export const useRecentlyCommentedTracks = <TResult = ID[]>(
         limit: 30
       })
 
-      const tracks = transformAndCleanList(data, userTrackMetadataFromSDK)
-
-      primeTrackData({
-        tracks,
+      const tracks = primeTrackData({
+        tracks: transformAndCleanList(data, userTrackMetadataFromSDK),
         queryClient
       })
-      return data.map((item) => HashId.parse(item.id))
+
+      return tracks.map(({ track_id }) => track_id)
     },
     ...options,
     enabled: options?.enabled !== false

--- a/packages/common/src/api/tan-query/tracks/useRecommendedTracks.ts
+++ b/packages/common/src/api/tan-query/tracks/useRecommendedTracks.ts
@@ -1,4 +1,4 @@
-import { HashId, Id } from '@audius/sdk'
+import { Id } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
@@ -36,14 +36,12 @@ export const useRecommendedTracks = <TResult = ID[]>(
         id: Id.parse(currentUserId),
         userId: Id.parse(currentUserId)
       })
-      const tracks = transformAndCleanList(data, userTrackMetadataFromSDK)
-
-      primeTrackData({
-        tracks,
+      const tracks = primeTrackData({
+        tracks: transformAndCleanList(data, userTrackMetadataFromSDK),
         queryClient
       })
 
-      return data.map((item) => HashId.parse(item.id))
+      return tracks.map(({ track_id }) => track_id)
     },
     ...options,
     enabled: options?.enabled !== false && !!currentUserId

--- a/packages/common/src/messages/explore.ts
+++ b/packages/common/src/messages/explore.ts
@@ -16,5 +16,6 @@ export const exploreMessages = {
   feelingLucky: 'Feeling Lucky?',
   imFeelingLucky: "I'm Feeling Lucky",
   recentlyPlayed: 'Recently Played',
-  activeDiscussions: 'Active Discussions'
+  activeDiscussions: 'Active Discussions',
+  mostShared: 'Most Shared Tracks This Week'
 }

--- a/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
@@ -39,13 +39,12 @@ const MemoizedExploreContent = () => {
       <MoodsGrid />
       {isSearchExploreGoodiesEnabled ? (
         <>
+          <MostSharedTracks />
           <BestSelling />
           <FeelingLucky />
           <RecentPremiumTracks />
         </>
       ) : null}
-
-      <MostSharedTracks />
 
       <BestOfAudiusTiles />
     </ProgressiveScrollView>

--- a/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
@@ -12,6 +12,7 @@ import { FeaturedRemixContests } from './FeaturedRemixContests'
 import { FeelingLucky } from './FeelingLucky'
 import { LabelSpotlight } from './LabelSpotlight'
 import { MoodsGrid } from './MoodsGrid'
+import { MostSharedTracks } from './MostSharedTracks'
 import { ProgressiveScrollView } from './ProgressiveScrollView'
 import { RecentPremiumTracks } from './RecentPremiumTracks'
 import { RecentlyPlayedTracks } from './RecentlyPlayed'
@@ -43,6 +44,8 @@ const MemoizedExploreContent = () => {
           <RecentPremiumTracks />
         </>
       ) : null}
+
+      <MostSharedTracks />
 
       <BestOfAudiusTiles />
     </ProgressiveScrollView>

--- a/packages/mobile/src/screens/explore-screen/components/MostSharedTracks.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/MostSharedTracks.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { useMostSharedTracks } from '@audius/common/api'
+import { exploreMessages as messages } from '@audius/common/messages'
+
+import { ExploreSection } from './ExploreSection'
+import { TrackTileCarousel } from './TrackTileCarousel'
+
+export const MostSharedTracks = () => {
+  const { data: mostSharedTracks, isLoading } = useMostSharedTracks()
+
+  if (!isLoading && (!mostSharedTracks || mostSharedTracks.length === 0)) {
+    return null
+  }
+
+  return (
+    <ExploreSection title={messages.mostShared}>
+      <TrackTileCarousel
+        tracks={mostSharedTracks}
+        uidPrefix='most-shared-track'
+        isLoading={isLoading}
+      />
+    </ExploreSection>
+  )
+}

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -6,7 +6,8 @@ import {
   useRecentPremiumTracks,
   useBestSelling,
   useFeelingLuckyTracks,
-  useRecentlyPlayedTracks
+  useRecentlyPlayedTracks,
+  useMostSharedTracks
 } from '@audius/common/api'
 import { useFeatureFlag, useToggleTrack } from '@audius/common/hooks'
 import { exploreMessages as messages } from '@audius/common/messages'
@@ -145,6 +146,7 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
 
   const { data: exploreContent } = useExploreContent()
   const { data: recommendedTracks } = useRecommendedTracks()
+  const { data: mostSharedTracks } = useMostSharedTracks()
   const { data: recentlyPlayed } = useRecentlyPlayedTracks()
   const { data: recentlyCommentedTracks } = useRecentlyPlayedTracks()
   const { data: recentPremiumTracks } = useRecentPremiumTracks()
@@ -454,6 +456,11 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
             <Flex direction='column'>
               {isSearchExploreGoodiesEnabled ? (
                 <>
+                  <ExploreSection
+                    title={messages.mostShared}
+                    data={mostSharedTracks}
+                    Card={TrackCard}
+                  />
                   <BestSellingSection
                     title={messages.bestSelling}
                     data={bestSelling}

--- a/packages/web/src/pages/explore-page/components/mobile/MostSharedSection.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/MostSharedSection.tsx
@@ -1,0 +1,17 @@
+import { useMostSharedTracks } from '@audius/common/api'
+import { exploreMessages as messages } from '@audius/common/messages'
+
+import { TrackCard } from 'components/track/TrackCard'
+
+import { ExploreSection } from '../desktop/ExploreSection'
+
+export const MostSharedSection = () => {
+  const { data: mostSharedTracks } = useMostSharedTracks()
+  return (
+    <ExploreSection
+      title={messages.mostShared}
+      data={mostSharedTracks}
+      Card={TrackCard}
+    />
+  )
+}

--- a/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
@@ -8,7 +8,9 @@ import {
 } from 'react'
 
 import { useExploreContent } from '@audius/common/api'
+import { useFeatureFlag } from '@audius/common/hooks'
 import { exploreMessages as messages } from '@audius/common/messages'
+import { FeatureFlags } from '@audius/common/services'
 import {
   Paper,
   Text,
@@ -60,6 +62,8 @@ import { BASE_URL, stripBaseUrl } from 'utils/route'
 
 import { ExploreSection } from '../desktop/ExploreSection'
 
+import { MostSharedSection } from './MostSharedSection'
+
 export type ExplorePageProps = {
   title: string
   pageTitle: string
@@ -94,6 +98,10 @@ const ExplorePage = () => {
   const searchBarRef = useRef<HTMLInputElement>(null)
   const { color, spacing } = useTheme()
   const { isLarge } = useMedia()
+
+  const { isEnabled: isSearchExploreGoodiesEnabled } = useFeatureFlag(
+    FeatureFlags.SEARCH_EXPLORE_GOODIES
+  )
 
   const { data: exploreContent } = useExploreContent()
 
@@ -272,6 +280,7 @@ const ExplorePage = () => {
               data={exploreContent?.featuredLabels}
               Card={UserCard}
             />
+
             <Flex direction='column' ph='l' gap='2xl'>
               <Flex direction='column' gap='l' alignItems='center'>
                 <Text variant='title' size='l'>
@@ -312,6 +321,7 @@ const ExplorePage = () => {
                     ))}
                 </Flex>
               </Flex>
+              {isSearchExploreGoodiesEnabled && <MostSharedSection />}
               <Flex direction='column' gap='l'>
                 <Text variant='title' size='l'>
                   {messages.bestOfAudius}


### PR DESCRIPTION
### Description
This consumes the new endpoint for most shared tracks and adds sections to the explore pages for web/mobile to show the results. It's building off existing components and patterns, so not a big change.

### How Has This Been Tested?
Local clients against staging. Browse to explore page and verify the Most Shared Tracks This Week section looks correct.
