### PR TITLE
[PE-6553] Add underground trending to explore page

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -40,6 +40,7 @@ export * from './tan-query/lineups/useLibraryTracks'
 export * from './tan-query/lineups/useProfileReposts'
 export * from './tan-query/lineups/useProfileTracks'
 export * from './tan-query/lineups/useTrending'
+export * from './tan-query/lineups/useTrendingUnderground'
 export * from './tan-query/lineups/useTrackPageLineup'
 
 // Notifications

--- a/packages/common/src/messages/explore.ts
+++ b/packages/common/src/messages/explore.ts
@@ -17,5 +17,6 @@ export const exploreMessages = {
   imFeelingLucky: "I'm Feeling Lucky",
   recentlyPlayed: 'Recently Played',
   activeDiscussions: 'Active Discussions',
-  mostShared: 'Most Shared Tracks This Week'
+  mostShared: 'Most Shared Tracks This Week',
+  undergroundTrending: 'Underground Trending'
 }

--- a/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
@@ -17,6 +17,7 @@ import { ProgressiveScrollView } from './ProgressiveScrollView'
 import { RecentPremiumTracks } from './RecentPremiumTracks'
 import { RecentlyPlayedTracks } from './RecentlyPlayed'
 import { RecommendedTracks } from './RecommendedTracks'
+import { UndergroundTrendingTracks } from './UndergroundTrendingTracks'
 
 const MemoizedExploreContent = () => {
   const { isEnabled: isSearchExploreGoodiesEnabled } = useFeatureFlag(
@@ -33,6 +34,7 @@ const MemoizedExploreContent = () => {
       ) : null}
       <FeaturedPlaylists />
       <FeaturedRemixContests />
+      {isSearchExploreGoodiesEnabled ? <UndergroundTrendingTracks /> : null}
       <ArtistSpotlight />
       <LabelSpotlight />
       {isSearchExploreGoodiesEnabled ? <ActiveDiscussions /> : null}

--- a/packages/mobile/src/screens/explore-screen/components/UndergroundTrendingTracks.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/UndergroundTrendingTracks.tsx
@@ -1,0 +1,30 @@
+import React, { useMemo } from 'react'
+
+import { useTrendingUnderground } from '@audius/common/api'
+import { exploreMessages as messages } from '@audius/common/messages'
+
+import { ExploreSection } from './ExploreSection'
+import { TrackTileCarousel } from './TrackTileCarousel'
+
+export const UndergroundTrendingTracks = () => {
+  const { data: undergroundTrendingTracks, isLoading } =
+    useTrendingUnderground()
+
+  const trackIds = useMemo(() => {
+    return undergroundTrendingTracks?.map(({ id }) => id) ?? []
+  }, [undergroundTrendingTracks])
+
+  if (!isLoading && undergroundTrendingTracks.length === 0) {
+    return null
+  }
+
+  return (
+    <ExploreSection title={messages.undergroundTrending}>
+      <TrackTileCarousel
+        tracks={trackIds}
+        uidPrefix='underground-trending-track'
+        isLoading={isLoading}
+      />
+    </ExploreSection>
+  )
+}

--- a/packages/web/src/components/track/mobile/TrackTile.module.css
+++ b/packages/web/src/components/track/mobile/TrackTile.module.css
@@ -2,7 +2,7 @@
   --border-width: 1px;
   position: relative;
   min-height: 152px;
-  flex: 1 1 352px;
+  flex: 1 1 152px;
   border: var(--border-width) solid var(--harmony-n-100);
   background-color: var(--harmony-white);
   box-shadow:

--- a/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
@@ -16,6 +16,9 @@ import {
 import { TrackTileSize } from 'components/track/types'
 import { useIsMobile } from 'hooks/useIsMobile'
 
+const TILE_WIDTH = 532
+const MOBILE_TILE_WIDTH = 343
+
 // Wrapper component to make tiles playable
 const PlayableTile: React.FC<{
   id: ID
@@ -105,6 +108,7 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
   })
 
   const renderTilePairs = (data: number[], Tile: React.ComponentType<any>) => {
+    const tileWidth = isMobile ? MOBILE_TILE_WIDTH : TILE_WIDTH
     const pairs = []
     for (let i = 0; i < data.length; i += 2) {
       pairs.push(data.slice(i, i + 2))
@@ -114,7 +118,7 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
         key={pairIndex}
         direction='column'
         gap='m'
-        css={{ minWidth: '532px', width: '532px' }}
+        css={{ minWidth: tileWidth, width: tileWidth }}
       >
         {pair.map((id, idIndex) => (
           <PlayableTile
@@ -131,12 +135,13 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
   }
 
   const renderTileSkeletons = (Tile: React.ComponentType<any>) => {
+    const tileWidth = isMobile ? MOBILE_TILE_WIDTH : TILE_WIDTH
     return Array.from({ length: 2 }).map((_, i) => (
       <Flex
         key={i}
         direction='column'
         gap='m'
-        css={{ minWidth: '532px', width: '532px' }}
+        css={{ minWidth: tileWidth, width: tileWidth }}
       >
         <Tile key={`${i}-0`} id={0} size='m' />
         <Tile key={`${i}-1`} id={0} size='m' />

--- a/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
@@ -63,12 +63,14 @@ const PlayableTile: React.FC<{
 type ExploreSectionProps = {
   title: string
   data?: number[]
+  isLoading?: boolean
   Card?: React.ComponentType<any>
   Tile?: React.ComponentType<any>
 }
 export const ExploreSection: React.FC<ExploreSectionProps> = ({
   title,
   data,
+  isLoading,
   Card,
   Tile
 }) => {
@@ -233,17 +235,17 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
             pv='2xs'
           >
             {Tile && !Card
-              ? data
-                ? renderTilePairs(data, Tile)
-                : renderTileSkeletons(Tile)
+              ? isLoading || !data
+                ? renderTileSkeletons(Tile)
+                : renderTilePairs(data, Tile)
               : null}
             {Card
-              ? data
-                ? data?.map((id) => <Card key={id} id={id} size='s' />)
-                : Array.from({ length: 6 }).map((_, i) => (
+              ? !data || isLoading
+                ? Array.from({ length: 6 }).map((_, i) => (
                     // loading skeletons
                     <Card key={i} id={0} size={isMobile ? 'xs' : 's'} />
                   ))
+                : data?.map((id) => <Card key={id} id={id} size='s' />)
               : null}
           </Flex>
         </Flex>

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -75,6 +75,7 @@ import { BASE_URL, stripBaseUrl } from 'utils/route'
 
 import { BestSellingSection } from './BestSellingSection'
 import { ExploreSection } from './ExploreSection'
+import { UndergroundTrendingTracks } from './UndergroundTrendingTracks'
 
 export type ExplorePageProps = {
   title: string
@@ -395,6 +396,10 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
                 data={exploreContent?.featuredRemixContests}
                 Card={RemixContestCard}
               />
+
+              {isSearchExploreGoodiesEnabled ? (
+                <UndergroundTrendingTracks />
+              ) : null}
 
               <ExploreSection
                 title={messages.artistSpotlight}

--- a/packages/web/src/pages/explore-page/components/desktop/UndergroundTrendingTracks.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/UndergroundTrendingTracks.tsx
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+
+import { useTrendingUnderground } from '@audius/common/api'
+import { exploreMessages as messages } from '@audius/common/messages'
+
+import { TrackCard } from 'components/track/TrackCard'
+
+import { ExploreSection } from './ExploreSection'
+
+export const UndergroundTrendingTracks = () => {
+  const { data: undergroundTrendingTracks, isLoading } =
+    useTrendingUnderground()
+
+  const trackIds = useMemo(() => {
+    return undergroundTrendingTracks.map(({ id }) => id)
+  }, [undergroundTrendingTracks])
+
+  if (!isLoading && undergroundTrendingTracks.length === 0) {
+    return null
+  }
+
+  return (
+    <ExploreSection
+      isLoading={isLoading}
+      title={messages.undergroundTrending}
+      data={trackIds}
+      Card={TrackCard}
+    />
+  )
+}

--- a/packages/web/src/pages/explore-page/components/mobile/MostSharedSection.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/MostSharedSection.tsx
@@ -6,11 +6,17 @@ import { TrackCard } from 'components/track/TrackCard'
 import { ExploreSection } from '../desktop/ExploreSection'
 
 export const MostSharedSection = () => {
-  const { data: mostSharedTracks } = useMostSharedTracks()
+  const { data: mostSharedTracks, isLoading } = useMostSharedTracks()
+
+  if (!isLoading && (!mostSharedTracks || mostSharedTracks.length === 0)) {
+    return null
+  }
+
   return (
     <ExploreSection
       title={messages.mostShared}
       data={mostSharedTracks}
+      isLoading={isLoading}
       Card={TrackCard}
     />
   )

--- a/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
@@ -63,6 +63,7 @@ import { BASE_URL, stripBaseUrl } from 'utils/route'
 import { ExploreSection } from '../desktop/ExploreSection'
 
 import { MostSharedSection } from './MostSharedSection'
+import { UndergroundTrendingSection } from './UndergroundTrendingSection'
 
 export type ExplorePageProps = {
   title: string
@@ -269,6 +270,10 @@ const ExplorePage = () => {
               Card={RemixContestCard}
             />
 
+            {isSearchExploreGoodiesEnabled ? (
+              <UndergroundTrendingSection />
+            ) : null}
+
             <ExploreSection
               title={messages.artistSpotlight}
               data={exploreContent?.featuredProfiles}
@@ -321,57 +326,57 @@ const ExplorePage = () => {
                     ))}
                 </Flex>
               </Flex>
-              {isSearchExploreGoodiesEnabled && <MostSharedSection />}
-              <Flex direction='column' gap='l'>
-                <Text variant='title' size='l'>
-                  {messages.bestOfAudius}
-                </Text>
-                <Flex
-                  wrap='wrap'
-                  gap='l'
-                  direction={isLarge ? 'column' : 'row'}
-                  justifyContent='space-between'
-                  css={
-                    !isLarge
-                      ? {
-                          display: 'grid',
-                          gridTemplateColumns: '1fr 1fr',
-                          gridTemplateRows: '1fr 1fr',
-                          gap: spacing.l, // or just gap: 'l' if supported
-                          width: '100%'
-                        }
-                      : undefined
-                  }
-                >
-                  {justForYouTiles.map((tile) => {
-                    const Icon = tile.icon
-                    return (
-                      <PerspectiveCard
-                        key={tile.title}
-                        backgroundGradient={tile.gradient}
-                        shadowColor={tile.shadow}
-                        useOverlayBlendMode={
-                          tile.title !== PREMIUM_TRACKS.title
-                        }
-                        backgroundIcon={
-                          Icon ? (
-                            <Icon height={180} width={180} color='inverse' />
-                          ) : undefined
-                        }
-                        onClick={() => onClickCard(tile.link)}
-                        isIncentivized={!!tile.incentivized}
-                        sensitivity={tile.cardSensitivity}
-                      >
-                        <Flex w={'100%'} h={200}>
-                          <TextInterior
-                            title={tile.title}
-                            subtitle={tile.subtitle}
-                          />
-                        </Flex>
-                      </PerspectiveCard>
-                    )
-                  })}
-                </Flex>
+            </Flex>
+            <Flex direction='column' mt='2xl' gap='l'>
+              {isSearchExploreGoodiesEnabled ? <MostSharedSection /> : null}
+            </Flex>
+            <Flex direction='column' ph='l' gap='l'>
+              <Text variant='title' size='l'>
+                {messages.bestOfAudius}
+              </Text>
+              <Flex
+                wrap='wrap'
+                gap='l'
+                direction={isLarge ? 'column' : 'row'}
+                justifyContent='space-between'
+                css={
+                  !isLarge
+                    ? {
+                        display: 'grid',
+                        gridTemplateColumns: '1fr 1fr',
+                        gridTemplateRows: '1fr 1fr',
+                        gap: spacing.l, // or just gap: 'l' if supported
+                        width: '100%'
+                      }
+                    : undefined
+                }
+              >
+                {justForYouTiles.map((tile) => {
+                  const Icon = tile.icon
+                  return (
+                    <PerspectiveCard
+                      key={tile.title}
+                      backgroundGradient={tile.gradient}
+                      shadowColor={tile.shadow}
+                      useOverlayBlendMode={tile.title !== PREMIUM_TRACKS.title}
+                      backgroundIcon={
+                        Icon ? (
+                          <Icon height={180} width={180} color='inverse' />
+                        ) : undefined
+                      }
+                      onClick={() => onClickCard(tile.link)}
+                      isIncentivized={!!tile.incentivized}
+                      sensitivity={tile.cardSensitivity}
+                    >
+                      <Flex w={'100%'} h={200}>
+                        <TextInterior
+                          title={tile.title}
+                          subtitle={tile.subtitle}
+                        />
+                      </Flex>
+                    </PerspectiveCard>
+                  )
+                })}
               </Flex>
             </Flex>
           </Flex>

--- a/packages/web/src/pages/explore-page/components/mobile/UndergroundTrendingSection.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/UndergroundTrendingSection.tsx
@@ -3,11 +3,11 @@ import { useMemo } from 'react'
 import { useTrendingUnderground } from '@audius/common/api'
 import { exploreMessages as messages } from '@audius/common/messages'
 
-import { TrackTile as DesktopTrackTile } from 'components/track/desktop/TrackTile'
+import { TrackTile as MobileTrackTile } from 'components/track/mobile/TrackTile'
 
-import { ExploreSection } from './ExploreSection'
+import { ExploreSection } from '../desktop/ExploreSection'
 
-export const UndergroundTrendingTracks = () => {
+export const UndergroundTrendingSection = () => {
   const { data: undergroundTrendingTracks, isLoading } =
     useTrendingUnderground()
 
@@ -24,7 +24,7 @@ export const UndergroundTrendingTracks = () => {
       isLoading={isLoading}
       title={messages.undergroundTrending}
       data={trackIds}
-      Tile={DesktopTrackTile}
+      Tile={MobileTrackTile}
     />
   )
 }


### PR DESCRIPTION
### Description
Adds underground trending to all platforms. Had to do a little style fixing as part of this.
Also our existing hook for underground trending is a _little_ weird. But I opted to leave it as-is because it will make navigating to the full underground trending page seamless if the user decides to click through on "View All" (coming soon in another PR)

### How Has This Been Tested?
Local clients against staging, visit explore page and make sure the underground trending section renders two rows of track tiles.
