### PR TITLE
Fix collection image regression

### DIFF
--- a/packages/web/src/components/track/Artwork.tsx
+++ b/packages/web/src/components/track/Artwork.tsx
@@ -4,9 +4,7 @@ import { SquareSizes, ID } from '@audius/common/models'
 import {
   IconLock,
   IconPlaybackPlay as IconPlay,
-  IconPlaybackPause as IconPause,
-  Box,
-  BoxProps
+  IconPlaybackPause as IconPause
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -33,7 +31,7 @@ type TileArtworkProps = {
     user: { name: string; is_verified: boolean; user_id: ID }
   }
   hasStreamAccess?: boolean
-} & Omit<BoxProps, 'id'>
+}
 
 export const ArtworkIcon = ({
   isBuffering,
@@ -88,8 +86,7 @@ const Artwork = memo(
     coSign,
     label,
     hasStreamAccess,
-    isTrack,
-    ...other
+    isTrack
   }: ArtworkProps) => {
     const imageElement = (
       <DynamicImage
@@ -124,8 +121,6 @@ const Artwork = memo(
       >
         {imageElement}
       </TrackFlair>
-    ) : other ? (
-      <Box {...other}>{imageElement}</Box>
     ) : (
       imageElement
     )


### PR DESCRIPTION
### Description

Fixes regression introduced by unecessarily adding other option prop spreading on artwork from https://github.com/AudiusProject/audius-protocol/pull/12562