### PR TITLE
Update rate limit mechanism in solana relay

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
@@ -133,7 +133,7 @@ export const rateLimitTokenAccountCreation = async (
   const [systemCount] = await redis
     .multi()
     .incr(key)
-    .expire(userKey, TWO_DAYS_IN_SECONDS)
+    .expire(key, TWO_DAYS_IN_SECONDS)
     .exec()
 
   if (

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
@@ -6,6 +6,8 @@ import { logger } from './logger'
 let redisClient: RedisClientType
 let isReady: boolean
 
+const TWO_DAYS_IN_SECONDS = 60 * 60 * 24 * 2
+
 export const getRedisConnection = async () => {
   if (!isReady) {
     redisClient = createClient({ url: config.redisUrl })
@@ -113,7 +115,7 @@ export const rateLimitTokenAccountCreation = async (
   const [userCount] = await redis
     .multi()
     .incr(userKey)
-    .expire(userKey, 60 * 60 * 48) // Expire old keys after 48 hrs
+    .expire(userKey, TWO_DAYS_IN_SECONDS)
     .exec()
   if (typeof userCount !== 'number' || userCount > limit) {
     logger.error(
@@ -131,7 +133,7 @@ export const rateLimitTokenAccountCreation = async (
   const [systemCount] = await redis
     .multi()
     .incr(key)
-    .expire(userKey, 60 * 60 * 48) // Expire old keys after 48 hrs
+    .expire(userKey, TWO_DAYS_IN_SECONDS)
     .exec()
 
   if (

--- a/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
+++ b/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import { useCurrentAccountUser } from '@audius/common/api'
 import { SolanaWalletAddress } from '@audius/common/models'
+import { MEMO_PROGRAM_ID } from '@audius/common/services'
 import { isValidSolAddress, profilePageActions } from '@audius/common/store'
 import {
   Button,
@@ -26,7 +27,11 @@ import {
   getAssociatedTokenAddressSync,
   unpackAccount
 } from '@solana/spl-token'
-import { PublicKey, SystemProgram } from '@solana/web3.js'
+import {
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction
+} from '@solana/web3.js'
 import { Formik, useField } from 'formik'
 import { useDispatch } from 'react-redux'
 import { useAsync } from 'react-use'
@@ -167,6 +172,8 @@ const PayoutWalletModalForm = ({
   )
 }
 
+const SET_PAYOUT_WALLET_MEMO_STRING = 'Payout Wallet'
+
 export const PayoutWalletModal = () => {
   const [isOpen, setIsOpen] = useModalState('PayoutWallet')
   const { data: user } = useCurrentAccountUser()
@@ -249,7 +256,18 @@ export const PayoutWalletModal = () => {
                         ataPubkey,
                         addressPubkey,
                         usdcMint
-                      )
+                      ),
+                      new TransactionInstruction({
+                        keys: [
+                          {
+                            pubkey: payer,
+                            isSigner: true,
+                            isWritable: true
+                          }
+                        ],
+                        programId: MEMO_PROGRAM_ID,
+                        data: Buffer.from(SET_PAYOUT_WALLET_MEMO_STRING)
+                      })
                     ]
                   })
 

--- a/packages/web/src/components/withdraw-usdc-modal/components/CoinflowWithdrawPage.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/CoinflowWithdrawPage.tsx
@@ -2,7 +2,7 @@ import { Flex, LoadingSpinner } from '@audius/harmony'
 
 export const CoinflowWithdrawPage = () => {
   return (
-    <Flex direction={'column'}>
+    <Flex direction={'column'} alignItems='center' justifyContent='center'>
       <LoadingSpinner size='xl' />
     </Flex>
   )


### PR DESCRIPTION
### Description

User smart rate limits
- Unique rate limit per memo method (add memo to set payout wallet tx for this purpose). I kind of like having this a memo because we can re-audit TX's from the past.
- Set rate limit _per day_ rather than rolling window

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ensure memo works:
```
npm run web:prod
> set payout wallet
```
with memo: https://explorer.solana.com/tx/T9RdJsn5rsDfqzPmCnahx1ZaQ9V64ut6bEjRQUf9ebg8UowrgPbfGRkhdRHSeVDvvUGrpVhPG1je4tK2HwD6RT2


Test new rate limit keys:
```
audius-compose up
audius-cmd user create bank
audius-cmd mint 10000000000 -m USDC -f bank
audius-cmd withdraw-tokens BDeWw2tJ9Si1443MG8kYZacLPHjBAz2wQf5Txo3eojhF 1

docker exec -it audius-protocol-discovery-provider-redis-1 redis-cli

keys ata:*
> 1) "ata-creation-count:global:2025-07-23"
> 2) "ata-creation-count:user:0x0fac83d12a163292568b8826c68a5fa70ec48bc1:2025-07-23"
```