### PR TITLE
qa-2243 fix deep links

### DIFF
--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -240,6 +240,14 @@ const NavigationContainer = (props: NavigationContainerProps) => {
       // Add leading slash if it is missing
       if (path[0] !== '/') path = `/${path}`
 
+      // Decode URL-encoded characters in the path
+      try {
+        path = decodeURIComponent(path)
+      } catch (e) {
+        // If decoding fails, continue with the original path
+        console.warn('Failed to decode URL path:', path, e)
+      }
+
       path = path.replace('#embed', '')
 
       const connectPath = /^\/(connect)/

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useMemo } from 'react'
 
-import { useCollection, useCurrentUserId, useUser } from '@audius/common/api'
+import {
+  useCollectionByParams,
+  useCurrentUserId,
+  useUser
+} from '@audius/common/api'
 import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   ShareSource,
@@ -73,9 +77,18 @@ export const CollectionScreen = () => {
   const { params } = useRoute<'Collection'>()
 
   // params is incorrectly typed and can sometimes be undefined
-  const { id = null, searchCollection, collectionType } = params ?? {}
+  const {
+    id = null,
+    searchCollection,
+    collectionType,
+    handle,
+    slug
+  } = params ?? {}
 
-  const { data: cachedCollection } = useCollection(id)
+  // Use useCollectionByParams to handle both ID-based and permalink-based collection fetching
+  const collectionParams = id ? { collectionId: id } : { handle, slug }
+
+  const { data: cachedCollection } = useCollectionByParams(collectionParams)
   const { data: cachedUser } = useUser(cachedCollection?.playlist_owner_id)
 
   const collection = cachedCollection ?? searchCollection


### PR DESCRIPTION
### Description

- Fixes encoded url deep links
- Fixes album/playlist deep links due to not using `useCollectionByParams` in CollectionScreen
