### PR TITLE
Fix relay empty metadata bug

### DIFF
--- a/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
@@ -208,7 +208,8 @@ export class EntityManagerClient implements EntityManagerService {
       !entityType ||
       !entityId ||
       !action ||
-      !metadata ||
+      // Empty string is valid metadata for some actions
+      (!metadata && metadata !== '') ||
       !nonce ||
       !subjectSig
     ) {


### PR DESCRIPTION
### Description

Naive assumption that metadata had to be truthy

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
>> in browser:
audiusSdk.services.entityManager.decodeManageEntity('0xd622c72d000000000000000000000000000000000000000000000000000000000000156400000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000073a5a02200000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000160a9788440bef01a0544bcd7590d0c4c9d5d090fdbb1917277e8584adbf193bdbf00000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000005547261636b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000065265706f737400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004132eb0b7db84a56689c8ee6781751f94f90ce89c8689046e4adebe8b825de1f4b39dede7d2188f63e96d9cf6c42626e527bd8910e39bb44759b199d04a06b748a1b00000000000000000000000000000000000000000000000000000000000000')```