### PR TITLE
Fix local entity writes

### DIFF
--- a/.changeset/unlucky-rice-flow.md
+++ b/.changeset/unlucky-rice-flow.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": patch
+---
+
+fix early consumption of request body in EM when request has an error

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/index.ts
@@ -30,10 +30,11 @@ export let wallets: WalletManager
 export let audiusSdk: AudiusSdk
 
 const main = async () => {
+  console.log('config', config)
   audiusSdk = sdk({
     appName: 'relay',
     environment:
-      config.environment === ' '
+      config.environment === 'dev'
         ? 'development'
         : config.environment === 'stage'
           ? 'staging'

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/index.ts
@@ -30,7 +30,6 @@ export let wallets: WalletManager
 export let audiusSdk: AudiusSdk
 
 const main = async () => {
-  console.log('config', config)
   audiusSdk = sdk({
     appName: 'relay',
     environment:

--- a/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
@@ -115,8 +115,8 @@ export class EntityManagerClient implements EntityManagerService {
         senderAddress
       })
     })
-    const jsonResponse = await response.json()
     if (response.ok) {
+      const jsonResponse = await response.json()
       if (!skipConfirmation) {
         await this.confirmWrite({
           blockHash: jsonResponse.receipt.blockHash,


### PR DESCRIPTION
### Description
Two small issues:
1. We weren't correctly detecting dev environment for the relay plugin. This was causing EM writes to fail because signer recovery was using the wrong contract address.
2. The EM code in SDK was consuming the body of responses before checking for errors. This makes the response body unusable in the case that we throw a RequestError up the stack (since you can only consume it once). The fetch logic in the generated `runtime` does it in the opposite order to allow for calling code to do what it wants with the response body in the error case.

NOTE: This will also fix e2e tests since they were failing on the track upload test portion

### How Has This Been Tested?
`audius-cmd user create user1 && audius-cmd track upload --from user1`
