### PR TITLE
[QA-2259] Fix sentry errors and warnings for logged out user

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useConnectedWallets.ts
+++ b/packages/common/src/api/tan-query/wallets/useConnectedWallets.ts
@@ -61,6 +61,7 @@ export const useConnectedWallets = (options?: QueryOptions) => {
         currentUserId
       })
     },
+    enabled: options?.enabled !== false && !!currentUserId,
     ...options
   })
 }
@@ -80,6 +81,9 @@ export const useAddConnectedWallet = () => {
 
   return useMutation({
     mutationFn: async ({ wallet, signature }: AddConnectedWalletParams) => {
+      if (!currentUserId) {
+        throw new Error('Cannot add connected wallet: user not logged in')
+      }
       const sdk = await audiusSdk()
       await sdk.users.addAssociatedWallet({
         userId: Id.parse(currentUserId),
@@ -150,6 +154,9 @@ export const useRemoveConnectedWallet = () => {
 
   return useMutation({
     mutationFn: async ({ wallet }: RemoveConnectedWalletParams) => {
+      if (!currentUserId) {
+        throw new Error('Cannot remove connected wallet: user not logged in')
+      }
       const sdk = await audiusSdk()
       const response = await sdk.users.removeAssociatedWallet({
         userId: Id.parse(currentUserId),

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1,6 +1,6 @@
 import { AUDIO, AudioWei, wAUDIO } from '@audius/fixed-decimal'
 import type { LocalStorage } from '@audius/hedgehog'
-import { AudiusSdk, Id } from '@audius/sdk'
+import { AudiusSdk, Id, HedgehogWalletNotFoundError } from '@audius/sdk'
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   getAccount,
@@ -371,8 +371,11 @@ export const audiusBackend = ({
       })
       return { data, signature }
     } catch (e) {
-      console.error(e)
-      reportError({ error: e as Error })
+      // Don't log an error for HedgehogWalletNotFoundError as it's expected when user is logged out
+      if (!(e instanceof HedgehogWalletNotFoundError)) {
+        console.error(e)
+        reportError({ error: e as Error })
+      }
       return { data, signature: '' }
     }
   }

--- a/packages/sdk/src/sdk/middleware/addRequestSignatureMiddleware.ts
+++ b/packages/sdk/src/sdk/middleware/addRequestSignatureMiddleware.ts
@@ -5,6 +5,7 @@ import {
   type RequestContext,
   type FetchParams
 } from '../api/generated/default'
+import { HedgehogWalletNotFoundError } from '../services/AudiusWalletClient'
 import { ServicesContainer } from '../types'
 
 const SIGNATURE_EXPIRY_MS =
@@ -62,7 +63,10 @@ export const addRequestSignatureMiddleware = ({
           timestamp = currentTimestamp
         }
       } catch (e) {
-        logger.warn(`Unable to add request signature: ${e}`)
+        // Don't log a warning for HedgehogWalletNotFoundError as it's expected when user is logged out
+        if (!(e instanceof HedgehogWalletNotFoundError)) {
+          logger.warn(`Unable to add request signature: ${e}`)
+        }
       }
       return { message, signature }
     })


### PR DESCRIPTION
### Description

- checks signData and addRequestSignatureMiddleware error code and doesn't log sentry/warning for logged out user
- prevents useConnectedWallets from firing for logged out user