### PR TITLE
Fix crash on AudioBreakdownModal

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -226,7 +226,7 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   if (includeConnectedWallets) {
     for (const balanceRes of connectedWalletsBalances.data ?? []) {
       connectedWalletsBalance = AUDIO(
-        connectedWalletsBalance + (balanceRes ?? AUDIO(0).value)
+        connectedWalletsBalance + balanceRes
       ).value
     }
   }

--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -1,6 +1,6 @@
 import { AUDIO, AudioWei, wAUDIO } from '@audius/fixed-decimal'
 import type { AudiusSdk } from '@audius/sdk'
-import { QueryClient, useQueries, useQuery } from '@tanstack/react-query'
+import { QueryClient, useQuery } from '@tanstack/react-query'
 import { call, getContext } from 'typed-redux-saga'
 import { getAddress } from 'viem'
 
@@ -19,6 +19,7 @@ import { queryCurrentUserId, queryUser } from '../saga-utils'
 import { QueryOptions, type QueryKey } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { useUser } from '../users/useUser'
+import { combineQueryResults, useQueries } from '../utils'
 
 import {
   ConnectedWallet,
@@ -164,7 +165,8 @@ export const useWalletAudioBalances = (
         }
       },
       ...options
-    }))
+    })),
+    combine: combineQueryResults<AudioWei[]>
   })
 }
 
@@ -200,11 +202,9 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
     { enabled: isUserFetched }
   )
   let accountBalance = AUDIO(0).value
-  const isAccountBalanceLoading = accountBalances.some(
-    (balanceRes) => balanceRes.isPending
-  )
-  for (const balanceRes of accountBalances) {
-    accountBalance += balanceRes?.data ?? AUDIO(0).value
+  const isAccountBalanceLoading = accountBalances.isPending
+  for (const balanceRes of accountBalances.data ?? []) {
+    accountBalance = AUDIO(accountBalance + balanceRes).value
   }
 
   // Get linked/connected wallets balances
@@ -221,11 +221,13 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   )
   let connectedWalletsBalance = AUDIO(0).value
   const isConnectedWalletsBalanceLoading = includeConnectedWallets
-    ? connectedWalletsBalances.some((balanceRes) => balanceRes.isPending)
+    ? connectedWalletsBalances.isPending
     : false
   if (includeConnectedWallets) {
-    for (const balanceRes of connectedWalletsBalances) {
-      connectedWalletsBalance += balanceRes?.data ?? AUDIO(0).value
+    for (const balanceRes of connectedWalletsBalances.data ?? []) {
+      connectedWalletsBalance = AUDIO(
+        connectedWalletsBalance + (balanceRes ?? AUDIO(0).value)
+      ).value
     }
   }
 
@@ -234,8 +236,8 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   const isLoading = isAccountBalanceLoading || isConnectedWalletsBalanceLoading
   const isError =
     isConnectedWalletsError ||
-    accountBalances.some((balanceRes) => balanceRes.isError) ||
-    connectedWalletsBalances.some((balanceRes) => balanceRes.isError)
+    accountBalances.isError ||
+    connectedWalletsBalances.isError
   return {
     accountBalance,
     connectedWalletsBalance,

--- a/packages/web/src/pages/audio-page/components/WalletsTable.tsx
+++ b/packages/web/src/pages/audio-page/components/WalletsTable.tsx
@@ -160,7 +160,7 @@ type WalletsTableProps = {
 }
 
 const WalletsTable = ({
-  renderWallet = (props) => <WalletTableRow {...props} />,
+  renderWallet = (props) => <WalletTableRow key={props.address} {...props} />,
   showWalletActionMenus = false,
   className
 }: WalletsTableProps) => {

--- a/packages/web/src/pages/audio-page/components/modals/AudioBreakdownModal.tsx
+++ b/packages/web/src/pages/audio-page/components/modals/AudioBreakdownModal.tsx
@@ -43,7 +43,10 @@ const AudioBreakdownBody = () => {
   )
 
   const linkedWalletsBalance = AUDIO(
-    balances.reduce((acc, result) => acc + (result.data ?? 0), 0)
+    balances.data?.reduce(
+      (acc, result) => AUDIO(acc + result).value,
+      AUDIO(0).value
+    ) ?? 0
   ).value
 
   const totalBalance = AUDIO(


### PR DESCRIPTION
My account was experiencing a crash on the `AudioBreakdownModal` because we were mixing numbers and bigints in a reduce call. This brought my attention to how `useWalletAudioBalances` wasn't returning the proper types. After investigating other `useQueries` calls, I saw we're using a wrapper and combiner, so I adopted that pattern as well.

Also fixes a warning about not having keys in WalletsTable