### PR TITLE
[QA-2253][QA-2252] Fix swaps and hexagon icon

### DIFF
--- a/packages/common/src/services/tokens/tokenConfigs.ts
+++ b/packages/common/src/services/tokens/tokenConfigs.ts
@@ -7,14 +7,14 @@ const developmentTokens: TokenConfig[] = [
   {
     symbol: 'AUDIO',
     name: 'Audius',
-    network: 'ethereum',
-    address: '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998', // Dev AUDIO token
-    decimals: 18,
+    network: 'solana',
+    address: '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM', // Solana AUDIO mint address
+    decimals: 8,
     enabled: true,
     purchasable: true,
     sellable: true,
-    hasUserbank: false,
-    jupiterEnabled: false,
+    hasUserbank: true,
+    jupiterEnabled: true,
     logoUrl: '/img/tokenLogos/audio.svg',
     coingeckoId: 'audius'
   },
@@ -69,14 +69,14 @@ const stagingTokens: TokenConfig[] = [
   {
     symbol: 'AUDIO',
     name: 'Audius',
-    network: 'ethereum',
-    address: '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998', // Staging AUDIO token
-    decimals: 18,
+    network: 'solana',
+    address: '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM', // Solana AUDIO mint address
+    decimals: 8,
     enabled: true,
     purchasable: true,
     sellable: true,
-    hasUserbank: false,
-    jupiterEnabled: false,
+    hasUserbank: true,
+    jupiterEnabled: true,
     logoUrl: '/img/tokenLogos/audio.svg',
     coingeckoId: 'audius'
   },
@@ -131,14 +131,14 @@ const productionTokens: TokenConfig[] = [
   {
     symbol: 'AUDIO',
     name: 'Audius',
-    network: 'ethereum',
-    address: '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998',
-    decimals: 18,
+    network: 'solana',
+    address: '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM', // Solana AUDIO mint address
+    decimals: 8,
     enabled: true,
     purchasable: true,
     sellable: true,
-    hasUserbank: false,
-    jupiterEnabled: false,
+    hasUserbank: true,
+    jupiterEnabled: true,
     logoUrl: '/img/tokenLogos/audio.svg',
     coingeckoId: 'audius'
   },

--- a/packages/mobile/src/components/buy-sell/CryptoBalanceSection.tsx
+++ b/packages/mobile/src/components/buy-sell/CryptoBalanceSection.tsx
@@ -4,10 +4,9 @@ import type { TokenInfo } from '@audius/common/store'
 
 import {
   Flex,
-  IconTokenUSDC,
   IconTokenAUDIO,
-  Text,
-  useTheme
+  IconTokenUSDC,
+  Text
 } from '@audius/harmony-native'
 
 const messages = {
@@ -27,7 +26,6 @@ export const CryptoBalanceSection = ({
   amount,
   priceLabel
 }: CryptoBalanceSectionProps) => {
-  const { spacing, cornerRadius } = useTheme()
   const { symbol } = tokenInfo
 
   // Get the appropriate token icon for mobile
@@ -42,13 +40,7 @@ export const CryptoBalanceSection = ({
 
       {/* Amount and token info */}
       <Flex direction='row' alignItems='center' gap='s'>
-        <TokenIcon
-          style={{
-            height: spacing.unit16,
-            width: spacing.unit16,
-            borderRadius: cornerRadius.circle
-          }}
-        />
+        <TokenIcon size='l' />
         <Flex direction='column'>
           <Flex direction='row' gap='xs' alignItems='center'>
             <Text variant='heading' size='l'>

--- a/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
+++ b/packages/mobile/src/components/buy-sell/TokenAmountSection.tsx
@@ -7,8 +7,8 @@ import { useTokenAmountFormatting } from '@audius/common/store'
 import {
   Button,
   Flex,
-  IconTokenUSDC,
   IconTokenAUDIO,
+  IconTokenUSDC,
   Text,
   TextInput,
   useTheme
@@ -48,7 +48,6 @@ const DefaultBalanceSection = ({
   tokenInfo
 }: BalanceSectionProps) => {
   const { symbol } = tokenInfo
-  const { cornerRadius } = useTheme()
   const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconTokenUSDC
 
   if (!formattedAvailableBalance || !TokenIcon) {
@@ -63,7 +62,7 @@ const DefaultBalanceSection = ({
       gap='xs'
     >
       <Flex direction='row' alignItems='center' gap='s'>
-        <TokenIcon size='l' style={{ borderRadius: cornerRadius.circle }} />
+        <TokenIcon size='l' />
         <Text variant='title' size='l' color='subdued'>
           {messages.available}
         </Text>
@@ -83,7 +82,6 @@ const StackedBalanceSection = ({
   isStablecoin
 }: BalanceSectionProps) => {
   const { symbol } = tokenInfo
-  const { cornerRadius } = useTheme()
   const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconTokenUSDC
 
   if (!formattedAvailableBalance || !TokenIcon) {
@@ -100,7 +98,7 @@ const StackedBalanceSection = ({
           {messages.stackedBalance(formattedAvailableBalance)}
         </Text>
       </Flex>
-      <TokenIcon size='4xl' style={{ borderRadius: cornerRadius.circle }} />
+      <TokenIcon size='4xl' />
     </Flex>
   )
 }
@@ -116,7 +114,6 @@ const CryptoAmountSection = ({
   isStablecoin: boolean
   priceDisplay?: string
 }) => {
-  const { spacing, cornerRadius } = useTheme()
   const { symbol } = tokenInfo
   const TokenIcon = symbol === 'AUDIO' ? IconTokenAUDIO : IconTokenUSDC
   const tokenTicker = messages.tokenTicker(symbol, !!isStablecoin)
@@ -127,13 +124,7 @@ const CryptoAmountSection = ({
 
   return (
     <Flex direction='row' alignItems='center' gap='s'>
-      <TokenIcon
-        style={{
-          borderRadius: cornerRadius.circle,
-          width: spacing.unit16,
-          height: spacing.unit16
-        }}
-      />
+      <TokenIcon size='l' />
       <Flex direction='column'>
         <Flex direction='row' alignItems='center' gap='xs'>
           <Text variant='heading' size='l'>


### PR DESCRIPTION
### Description
`TokenConfig` change introduced a bug where we were using the ETH contract address for AUDIO instead of the Solana Mint. Updating to use the Solana mint. This config will soon be deprecated in favor of our backend driven approach. 

This PR also updates the hexagonal icons to present correctly in the buy/sell flow for AUDIO 
<img width="336" height="122" alt="image" src="https://github.com/user-attachments/assets/d228d78f-a66c-42e2-8c93-378604fdd507" />


### How Has This Been Tested?

`npm run ios:prod` and test swaps
