### PR TITLE
Fix ConnectedWallets typeerror in mobile

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -146,7 +146,7 @@ export const useWalletAudioBalances = (
       queryFn: async () => {
         try {
           const sdk = await audiusSdk()
-          return await fetchWalletAudioBalance(
+          const balance = await fetchWalletAudioBalance(
             { sdk, audiusBackend },
             {
               address,
@@ -154,6 +154,7 @@ export const useWalletAudioBalances = (
               includeStaked: true
             }
           )
+          return { address, chain, balance }
         } catch (error) {
           reportToSentry({
             error: toErrorWithMessage(error),
@@ -166,7 +167,9 @@ export const useWalletAudioBalances = (
       },
       ...options
     })),
-    combine: combineQueryResults<AudioWei[]>
+    combine: combineQueryResults<
+      { balance: AudioWei; address: string; chain: Chain }[]
+    >
   })
 }
 
@@ -204,7 +207,7 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   let accountBalance = AUDIO(0).value
   const isAccountBalanceLoading = accountBalances.isPending
   for (const balanceRes of accountBalances.data ?? []) {
-    accountBalance = AUDIO(accountBalance + balanceRes).value
+    accountBalance = AUDIO(accountBalance + balanceRes.balance).value
   }
 
   // Get linked/connected wallets balances
@@ -226,7 +229,7 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   if (includeConnectedWallets) {
     for (const balanceRes of connectedWalletsBalances.data ?? []) {
       connectedWalletsBalance = AUDIO(
-        connectedWalletsBalance + balanceRes
+        connectedWalletsBalance + balanceRes.balance
       ).value
     }
   }

--- a/packages/mobile/src/components/audio-breakdown-drawer/AudioBreakdownDrawer.tsx
+++ b/packages/mobile/src/components/audio-breakdown-drawer/AudioBreakdownDrawer.tsx
@@ -3,9 +3,8 @@ import {
   useConnectedWallets,
   useWalletAudioBalances
 } from '@audius/common/api'
-import { Chain } from '@audius/common/models'
 import { formatNumberCommas } from '@audius/common/utils'
-import { AUDIO, type AudioWei } from '@audius/fixed-decimal'
+import { AUDIO } from '@audius/fixed-decimal'
 
 import { Divider, Flex, spacing, Text } from '@audius/harmony-native'
 import { GradientText } from 'app/components/core'
@@ -36,22 +35,6 @@ export const AudioBreakdownDrawer = () => {
   const connectedWalletsBalances = useWalletAudioBalances({
     wallets: connectedWallets
   })
-
-  const ethWallets = connectedWallets.filter(
-    (wallet) => wallet.chain === Chain.Eth
-  )
-  const solWallets = connectedWallets.filter(
-    (wallet) => wallet.chain === Chain.Sol
-  )
-
-  const getWalletBalance = (address: string, chain: Chain): AudioWei => {
-    const balanceResult = connectedWalletsBalances.find(
-      (_, index) =>
-        connectedWallets[index]?.address === address &&
-        connectedWallets[index]?.chain === chain
-    )
-    return balanceResult?.data
-  }
 
   return (
     <AppDrawer
@@ -136,20 +119,12 @@ export const AudioBreakdownDrawer = () => {
 
           <Divider orientation='horizontal' />
 
-          {ethWallets.map((wallet) => (
+          {connectedWalletsBalances.data?.map((wallet) => (
             <Wallet
-              chain={Chain.Eth}
+              chain={wallet.chain}
               key={wallet.address}
               address={wallet.address}
-              balance={getWalletBalance(wallet.address, Chain.Eth)}
-            />
-          ))}
-          {solWallets.map((wallet) => (
-            <Wallet
-              chain={Chain.Sol}
-              key={wallet.address}
-              address={wallet.address}
-              balance={getWalletBalance(wallet.address, Chain.Sol)}
+              balance={wallet.balance}
             />
           ))}
 

--- a/packages/web/src/pages/audio-page/components/modals/AudioBreakdownModal.tsx
+++ b/packages/web/src/pages/audio-page/components/modals/AudioBreakdownModal.tsx
@@ -44,7 +44,7 @@ const AudioBreakdownBody = () => {
 
   const linkedWalletsBalance = AUDIO(
     balances.data?.reduce(
-      (acc, result) => AUDIO(acc + result).value,
+      (acc, result) => AUDIO(acc + result.balance).value,
       AUDIO(0).value
     ) ?? 0
   ).value


### PR DESCRIPTION
Return wallet objects with balances instead of raw balances now that we're combining results, as associating the balance ot the wallet became difficult.