### PR TITLE
[QA-2260] Update end_date logic for remix contest

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
@@ -159,8 +159,20 @@ def validate_update_event_tx(params: ManageEntityParameters):
         except ValueError:
             raise IndexingValidationError("end_date is not a valid iso format")
 
-        # Validate end_date is not in the past
+        # Validate that the end_date is after the current end_date of the remix contest
         if (
+            existing_event.event_type == EventType.remix_contest
+            and existing_event.end_date
+        ):
+            if (
+                datetime.fromisoformat(params.metadata["end_date"]).timestamp()
+                < existing_event.end_date.timestamp()
+            ):
+                raise IndexingValidationError(
+                    "end_date cannot be before the current end_date of the remix contest"
+                )
+        # Validate end_date is not in the past for other event types
+        elif (
             datetime.fromisoformat(params.metadata["end_date"]).timestamp()
             < params.block_datetime.timestamp()
         ):

--- a/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
+++ b/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import {
   useCurrentUserId,
@@ -79,6 +79,10 @@ export const HostRemixContestDrawer = () => {
   const isEdit = !!remixContest
   const hasContestEntries = remixesLoading || remixes?.length
   const displayTurnOffButton = !hasContestEntries && isEdit
+  const contestMinDate = useMemo(
+    () => (remixContest ? dayjs(remixContest.endDate) : dayjs()),
+    [remixContest]
+  )
 
   const remixContestData = remixContest?.eventData
 
@@ -95,20 +99,23 @@ export const HostRemixContestDrawer = () => {
   )
   const [endDateError, setEndDateError] = useState<boolean>(false)
 
-  const handleChange = useCallback((date: string, time: string) => {
-    if (!date && !time) {
-      setEndDate(null)
-      return
-    }
+  const handleChange = useCallback(
+    (date: string, time: string) => {
+      if (!date && !time) {
+        setEndDate(null)
+        return
+      }
 
-    const newDate = mergeDateTime(date || time, time || date)
-    if (newDate.isBefore(dayjs())) {
-      setEndDateError(true)
-    } else {
-      setEndDateError(false)
-    }
-    setEndDate(newDate)
-  }, [])
+      const newDate = mergeDateTime(date || time, time || date)
+      if (newDate.isBefore(contestMinDate)) {
+        setEndDateError(true)
+      } else {
+        setEndDateError(false)
+      }
+      setEndDate(newDate)
+    },
+    [contestMinDate]
+  )
 
   const handleDateChange = useCallback(
     (date: string) => {
@@ -266,7 +273,7 @@ export const HostRemixContestDrawer = () => {
                 date={endDate?.toString() ?? ''}
                 onChange={handleDateChange}
                 dateTimeProps={{
-                  minimumDate: new Date(),
+                  minimumDate: contestMinDate.toDate(),
                   maximumDate: dayjs().add(90, 'days').toDate()
                 }}
                 inputProps={{

--- a/packages/web/src/components/edit/fields/DatePickerField.tsx
+++ b/packages/web/src/components/edit/fields/DatePickerField.tsx
@@ -23,6 +23,7 @@ type DatePickerFieldProps = {
   isInitiallyUnlisted?: boolean
   futureDatesOnly?: boolean
   maxDate?: Date
+  minDate?: Date
 }
 
 /**
@@ -71,6 +72,7 @@ export const DatePicker = (props: DatePickerProps) => {
     isInitiallyUnlisted,
     futureDatesOnly,
     maxDate,
+    minDate,
     value,
     touched = false,
     error,
@@ -137,11 +139,20 @@ export const DatePicker = (props: DatePickerProps) => {
                 onChange(date?.startOf('day').toString() ?? moment().toString())
               }}
               isOutsideRange={(day) => {
+                if (maxDate && minDate) {
+                  return (
+                    !isInclusivelyAfterDay(day, moment(minDate)) ||
+                    !isInclusivelyBeforeDay(day, moment(maxDate))
+                  )
+                }
                 if (maxDate) {
                   return (
                     !isInclusivelyAfterDay(day, moment()) ||
                     !isInclusivelyBeforeDay(day, moment(maxDate))
                   )
+                }
+                if (minDate) {
+                  return !isInclusivelyAfterDay(day, moment(minDate))
                 }
                 if (futureDatesOnly) {
                   return !isInclusivelyAfterDay(day, moment())

--- a/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
+++ b/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import {
   useCreateEvent,
@@ -52,6 +52,10 @@ export const HostRemixContestModal = () => {
   const isEdit = !!remixContest
   const hasContestEntries = remixesLoading || remixes?.length
   const displayTurnOffButton = !hasContestEntries && isEdit
+  const contestMinDate = useMemo(
+    () => (remixContest ? dayjs(remixContest.endDate) : dayjs()),
+    [remixContest]
+  )
 
   const remixContestData = remixContest?.eventData
 
@@ -115,7 +119,7 @@ export const HostRemixContestModal = () => {
     const hasDescriptionError = !contestDescription
     const hasDateError =
       !parsedDate ||
-      dayjs(parsedDate.toISOString()).isBefore(dayjs()) ||
+      dayjs(parsedDate.toISOString()).isBefore(contestMinDate) ||
       dayjs(parsedDate.toISOString()).isAfter(dayjs().add(90, 'days'))
     const hasError = hasDateError || hasDescriptionError
 
@@ -170,6 +174,7 @@ export const HostRemixContestModal = () => {
     contestEndDate,
     meridianValue,
     contestDescription,
+    contestMinDate,
     trackId,
     userId,
     contestPrizeInfo,
@@ -263,9 +268,9 @@ export const HostRemixContestModal = () => {
               label={remixMessages.endDateLabel}
               onChange={handleEndDateChange}
               value={contestEndDate?.toISOString()}
-              futureDatesOnly
               error={endDateError ? remixMessages.endDateError : undefined}
               touched={endDateTouched}
+              minDate={contestMinDate.toDate()}
               maxDate={dayjs().add(90, 'days').toDate()}
             />
             <Flex gap='l'>


### PR DESCRIPTION
### Description
Update the modal and entity manager to allow the user to set a date in the past as long as it is after the current end_date of the contest

NOTE: Have to update mobile and test more

### How Has This Been Tested?
Testing the backend now
