### PR TITLE
Fix staging ios build by avoiding harmony build

### DIFF
--- a/packages/mobile/turbo.json
+++ b/packages/mobile/turbo.json
@@ -1,22 +1,31 @@
 {
   "extends": ["//"],
   "tasks": {
+    "build": {
+      "dependsOn": [
+        "@audius/common#build",
+        "@audius/sdk#build",
+        "@audius/fixed-decimal#build"
+      ],
+      "outputs": ["dist/**", "build/**"],
+      "outputLogs": "new-only"
+    },
     "android": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "cache": false,
       "persistent": true,
       "outputLogs": "new-only"
     },
     "ios": {
       "env": ["ENVFILE"],
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "cache": false,
       "persistent": true,
       "outputLogs": "new-only"
     },
     "bundle:ios": {
       "outputs": ["./ios/main.jsbundle"],
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputLogs": "new-only"
     }
   }


### PR DESCRIPTION
### Description

There is a bug where we try to build harmony on an mac box and it complains because it tries to build with darwin rollup, which we dont have. The fix is to avoid building harmony for mobile, because we technically dont need it. This requires going a bit manual on the turbo.json side for mobile, which is a bit hacky. Lets use this to unblock for now.