### PR TITLE
Adhere to ios rich push naming standards

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/sns.ts
+++ b/packages/discovery-provider/plugins/notifications/src/sns.ts
@@ -60,18 +60,7 @@ export const sendIOSMessage = async ({
   if (targetARN.includes('APNS_SANDBOX')) arn = 'APNS_SANDBOX'
   else if (targetARN.includes('APNS')) arn = 'APNS'
 
-  const apnsConfig: {
-    aps: {
-      alert: {
-        title: string
-        body: string
-      }
-      sound: string | false
-      badge: number
-      'mutable-content'?: number
-    }
-    data?: object
-  } = {
+  const apnsConfig = {
     aps: {
       alert: {
         title,
@@ -86,10 +75,7 @@ export const sendIOSMessage = async ({
   // Enable rich notifications when image is provided
   if (imageUrl) {
     apnsConfig.aps['mutable-content'] = 1
-    apnsConfig.data = {
-      ...data,
-      imageUrl
-    }
+    apnsConfig['media-url'] = imageUrl
   }
 
   const message = JSON.stringify({


### PR DESCRIPTION
### Description

Update ios push notifications to use media-url and moves it outside body to follow guidelines. Also updates notification-service to receive it correctly