### PR TITLE
[PE-6596] Add carousels to all results page

### DIFF
--- a/packages/web/src/pages/explore-page/components/desktop/Carousel.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/Carousel.tsx
@@ -6,17 +6,21 @@ import {
   IconCaretLeft,
   IconCaretRight,
   Text,
+  PlainButton,
   useMedia
 } from '@audius/harmony'
+import { Link } from 'react-router-dom-v5-compat'
 
 import { useIsMobile } from 'hooks/useIsMobile'
 
 export const Carousel = ({
   title,
-  children
+  children,
+  viewAllLink
 }: {
   title: React.ReactNode
   children: React.ReactNode
+  viewAllLink?: string
 }) => {
   const [canScrollLeft, setCanScrollLeft] = useState(false)
   const [canScrollRight, setCanScrollRight] = useState(true)
@@ -62,32 +66,39 @@ export const Carousel = ({
         >
           {title}
         </Text>
-        {!isMobile && (canScrollLeft || canScrollRight) ? (
-          <Flex gap='l'>
-            <IconButton
-              ripple
-              icon={IconCaretLeft}
-              color={canScrollLeft ? 'default' : 'disabled'}
-              aria-label={`${title} scroll left`}
-              onClick={() => {
-                scrollContainerRef.current?.scrollBy({
-                  left: -648,
-                  behavior: 'smooth'
-                })
-              }}
-            />
-            <IconButton
-              ripple
-              icon={IconCaretRight}
-              color={canScrollRight ? 'default' : 'disabled'}
-              aria-label={`${title} scroll right`}
-              onClick={() => {
-                scrollContainerRef.current?.scrollBy({
-                  left: 648,
-                  behavior: 'smooth'
-                })
-              }}
-            />
+        {!isMobile && (canScrollLeft || canScrollRight || viewAllLink) ? (
+          <Flex gap='l' alignItems='center'>
+            {viewAllLink && (
+              <PlainButton size='large' asChild>
+                <Link to={viewAllLink}>View All</Link>
+              </PlainButton>
+            )}
+            <Flex gap='l'>
+              <IconButton
+                ripple
+                icon={IconCaretLeft}
+                color={canScrollLeft ? 'default' : 'disabled'}
+                aria-label={`${title} scroll left`}
+                onClick={() => {
+                  scrollContainerRef.current?.scrollBy({
+                    left: -648,
+                    behavior: 'smooth'
+                  })
+                }}
+              />
+              <IconButton
+                ripple
+                icon={IconCaretRight}
+                color={canScrollRight ? 'default' : 'disabled'}
+                aria-label={`${title} scroll right`}
+                onClick={() => {
+                  scrollContainerRef.current?.scrollBy({
+                    left: 648,
+                    behavior: 'smooth'
+                  })
+                }}
+              />
+            </Flex>
           </Flex>
         ) : null}
       </Flex>

--- a/packages/web/src/pages/search-page/search-results/AllResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/AllResults.tsx
@@ -17,16 +17,16 @@ import { useDispatch } from 'react-redux'
 import { Link, useNavigate } from 'react-router-dom-v5-compat'
 
 import { make } from 'common/store/analytics/actions'
+import { CollectionCard } from 'components/collection'
 import { CollectionImage } from 'components/collection/CollectionImage'
 import { TrackArtwork } from 'components/track/TrackArtwork'
+import { UserCard } from 'components/user-card'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { Carousel } from 'pages/explore-page/components/desktop/Carousel'
 
 import { NoResultsTile } from '../NoResultsTile'
 import { useSearchParams } from '../hooks'
 
-import { AlbumResults } from './AlbumResults'
-import { PlaylistResults } from './PlaylistResults'
-import { ProfileResultsTiles } from './ProfileResults'
 import { TrackResults } from './TrackResults'
 
 const messages = {
@@ -38,7 +38,7 @@ const messages = {
   album: 'Album',
   playlists: 'Playlists',
   playlist: 'Playlist',
-  showAll: 'Show All'
+  viewAll: 'View All'
 }
 const { addItem: addRecentSearch } = searchActions
 const { profilePage } = route
@@ -298,28 +298,23 @@ export const AllResults = ({ handleSearchTab }: AllResultsProps) => {
 
   return (
     <Flex direction='column' gap='unit10' ref={containerRef}>
+      {/* Profiles with Carousel */}
       {isLoading || data?.users?.length ? (
-        <Flex gap='xl' direction='column'>
-          <Flex justifyContent='space-between' alignItems='center'>
-            <Text variant='heading' textAlign='left'>
-              {messages.profiles}
-            </Text>
-            <PlainButton size='large' asChild>
-              <Link to={`/search/profiles?query=${query}`}>
-                {messages.showAll}
-              </Link>
-            </PlainButton>
-          </Flex>
-          <ProfileResultsTiles
-            skeletonCount={5}
-            limit={5}
-            data={data?.users ?? []}
-            isFetching={isLoading}
-            isPending={isPending}
-          />
-        </Flex>
+        <Carousel
+          title={messages.profiles}
+          viewAllLink={`/search/profiles?query=${query}`}
+        >
+          {isLoading
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <UserCard key={i} id={0} size='s' loading />
+              ))
+            : data?.users?.map((user) => (
+                <UserCard key={user.user_id} id={user.user_id} size='s' />
+              ))}
+        </Carousel>
       ) : null}
 
+      {/* Tracks with original layout */}
       {isLoading || data?.tracks?.length ? (
         <Flex gap='xl' direction='column'>
           <Flex justifyContent='space-between' alignItems='center'>
@@ -328,7 +323,7 @@ export const AllResults = ({ handleSearchTab }: AllResultsProps) => {
             </Text>
             <PlainButton size='large' asChild>
               <Link to={`/search/tracks?query=${query}`}>
-                {messages.showAll}
+                {messages.viewAll}
               </Link>
             </PlainButton>
           </Flex>
@@ -344,48 +339,44 @@ export const AllResults = ({ handleSearchTab }: AllResultsProps) => {
         </Flex>
       ) : null}
 
+      {/* Albums with Carousel */}
       {isLoading || data?.albums?.length ? (
-        <Flex gap='xl' direction='column'>
-          <Flex justifyContent='space-between' alignItems='center'>
-            <Text variant='heading' textAlign='left'>
-              {messages.albums}
-            </Text>
-            <PlainButton size='large' asChild>
-              <Link to={`/search/albums?query=${query}`}>
-                {messages.showAll}
-              </Link>
-            </PlainButton>
-          </Flex>
-          <AlbumResults
-            limit={5}
-            data={data?.albums ?? []}
-            isFetching={isLoading}
-            isPending={isPending}
-            skeletonCount={5}
-          />
-        </Flex>
+        <Carousel
+          title={messages.albums}
+          viewAllLink={`/search/albums?query=${query}`}
+        >
+          {isLoading
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <CollectionCard key={i} id={0} size='s' loading />
+              ))
+            : data?.albums?.map((album) => (
+                <CollectionCard
+                  key={album.playlist_id}
+                  id={album.playlist_id}
+                  size='s'
+                />
+              ))}
+        </Carousel>
       ) : null}
 
+      {/* Playlists with Carousel */}
       {isLoading || data?.playlists?.length ? (
-        <Flex gap='xl' direction='column'>
-          <Flex justifyContent='space-between' alignItems='center'>
-            <Text variant='heading' textAlign='left'>
-              {messages.playlists}
-            </Text>
-            <PlainButton size='large' asChild>
-              <Link to={`/search/playlists?query=${query}`}>
-                {messages.showAll}
-              </Link>
-            </PlainButton>
-          </Flex>
-          <PlaylistResults
-            skeletonCount={5}
-            limit={5}
-            data={data?.playlists ?? []}
-            isFetching={isLoading}
-            isPending={isPending}
-          />
-        </Flex>
+        <Carousel
+          title={messages.playlists}
+          viewAllLink={`/search/playlists?query=${query}`}
+        >
+          {isLoading
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <CollectionCard key={i} id={0} size='s' loading />
+              ))
+            : data?.playlists?.map((playlist) => (
+                <CollectionCard
+                  key={playlist.playlist_id}
+                  id={playlist.playlist_id}
+                  size='s'
+                />
+              ))}
+        </Carousel>
       ) : null}
     </Flex>
   )


### PR DESCRIPTION
### Description

We should be using carousels for "all-results" page: 
<img width="1515" height="842" alt="image" src="https://github.com/user-attachments/assets/23e15c59-84a9-4e95-9cc0-cab3c89563ef" />
applies for profiles, playlists, and albums