### PR TITLE
Fix entityId validation

### DIFF
--- a/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
@@ -206,7 +206,8 @@ export class EntityManagerClient implements EntityManagerService {
     if (
       !userId ||
       !entityType ||
-      !entityId ||
+      // 0 is a valid entityId for some actions
+      (!entityId && entityId !== 0n) ||
       !action ||
       // Empty string is valid metadata for some actions
       (!metadata && metadata !== '') ||


### PR DESCRIPTION
### Description

0 is used for "create app" entity action. Not sure why, but we need to allow it.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
audiusSdk.services.entityManager.decodeManageEntity('0xd622c72d000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000016049d93b24912b2e59f742f72be26f253b2471922475f16d9c87d9ac69359cacf100000000000000000000000000000000000000000000000000000000000002a0000000000000000000000000000000000000000000000000000000000000000c446576656c6f70657241707000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006437265617465000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001037b226e616d65223a227465737433222c226465736372697074696f6e223a227465737433222c226170705f7369676e6174757265223a7b226d657373616765223a224372656174696e672041756469757320646576656c6f706572206170702061742031373534303637383938222c227369676e6174757265223a22307835343766363333326238666333376361623333346636626161353836643431643737396137333734653265613038313537306266333535383331616432366433313433616663313930353137626266633062663963613937653737353561646138373464643863623030613232663235376438343234313261646362346562643162227d7d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004157f5e77e6f65d591330810bc2e4a84121de9c63e0433f2a275f3af3a06833d462a558a26a5a0df822c9d38ed18e92f1a5aa27f03a923fde06a42da606869a1fd1c00000000000000000000000000000000000000000000000000000000000000')
```