### PR TITLE
Make asset overview page responsive

### DIFF
--- a/packages/common/src/messages/walletMessages.ts
+++ b/packages/common/src/messages/walletMessages.ts
@@ -65,7 +65,8 @@ export const walletMessages = {
     invalidAddress: 'A valid Solana USDC wallet address is required',
     minCashTransfer: 'A minimum of $5 is required for cash withdrawals.',
     pleaseConfirm:
-      'Please confirm you have reviewed this transaction and accept responsibility for errors.'
+      'Please confirm you have reviewed this transaction and accept responsibility for errors.',
+    unableToLoadBalance: 'Unable to load balance information'
   },
 
   // YourCoins messages

--- a/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@audius/harmony'
+import { Flex, makeResponsiveStyles } from '@audius/harmony'
 
 import { AssetInfoSection } from './components/AssetInfoSection'
 import { AssetInsights } from './components/AssetInsights'
@@ -8,15 +8,60 @@ import { AssetDetailProps } from './types'
 const LEFT_SECTION_WIDTH = '704px'
 const RIGHT_SECTION_WIDTH = '360px'
 
+const useStyles = makeResponsiveStyles(({ media, theme }) => ({
+  container: {
+    base: {
+      display: 'flex',
+      gap: theme.spacing.l
+    },
+    mobile: {
+      flexDirection: 'column'
+    },
+    tablet: {
+      flexDirection: 'column'
+    }
+  },
+  leftSection: {
+    base: {
+      width: LEFT_SECTION_WIDTH,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing.m
+    },
+    mobile: {
+      width: '100%'
+    },
+    tablet: {
+      width: '100%'
+    }
+  },
+  rightSection: {
+    base: {
+      width: RIGHT_SECTION_WIDTH,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing.m
+    },
+    mobile: {
+      width: '100%'
+    },
+    tablet: {
+      width: '100%'
+    }
+  }
+}))
+
 export const AssetDetailContent = ({ mint }: AssetDetailProps) => {
+  const styles = useStyles()
+
   return (
-    <Flex gap='l'>
-      <Flex w={LEFT_SECTION_WIDTH} direction='column' gap='m'>
+    <Flex css={styles.container}>
+      <Flex css={styles.leftSection}>
         <BalanceSection mint={mint} />
         <AssetInfoSection mint={mint} />
       </Flex>
 
-      <Flex w={RIGHT_SECTION_WIDTH} direction='column' gap='m'>
+      <Flex css={styles.rightSection}>
         <AssetInsights mint={mint} />
       </Flex>
     </Flex>

--- a/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
@@ -10,6 +10,7 @@ import { Button, Flex, Paper, Text, useTheme, Artwork } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
+import { componentWithErrorBoundary } from 'components/error-wrapper/componentWithErrorBoundary'
 import { useIsMobile } from 'hooks/useIsMobile'
 
 import { AssetDetailProps } from '../types'
@@ -124,7 +125,7 @@ const HasBalanceState = ({
   )
 }
 
-export const BalanceSection = ({ mint }: AssetDetailProps) => {
+const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
   const { data: coin, isLoading: coinsLoading } = useArtistCoin({ mint })
   const { data: tokenBalance } = useTokenBalance({ mint })
 
@@ -214,3 +215,19 @@ export const BalanceSection = ({ mint }: AssetDetailProps) => {
     </Paper>
   )
 }
+
+export const BalanceSection = componentWithErrorBoundary(
+  BalanceSectionContent,
+  {
+    name: 'BalanceSection',
+    fallback: (
+      <Paper ph='xl' pv='l'>
+        <Flex direction='column' gap='l' w='100%'>
+          <Text variant='body' size='m' color='subdued'>
+            {walletMessages.errors.unableToLoadBalance}
+          </Text>
+        </Flex>
+      </Paper>
+    )
+  }
+)


### PR DESCRIPTION
### Description
This PR makes the asset pages responsive as seen in the design. On tablet and smaller screens, we move all of the content into a full width single row column. The PR also introduces an error boundary state for the `BalanceSection`

### How Has This Been Tested?

`npm run web:prod` and navigate to an asset page
