### PR TITLE
switch stage rewards to no cooldown

### DIFF
--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -7,7 +7,7 @@
     "step_count": 7,
     "starting_block": 0,
     "weekly_pool": 25000,
-    "cooldown_days": 7
+    "cooldown_days": 0
   },
   {
     "id": "e",
@@ -26,7 +26,7 @@
     "starting_block": 0,
     "amount": 1,
     "weekly_pool": 25000,
-    "cooldown_days": 7
+    "cooldown_days": 0
   },
   {
     "id": "r",
@@ -105,7 +105,7 @@
     "active": true,
     "starting_block": 0,
     "weekly_pool": 25000,
-    "cooldown_days": 7
+    "cooldown_days": 0
   },
   {
     "id": "fp",
@@ -158,7 +158,7 @@
     "step_count": 2147483647,
     "starting_block": 0,
     "weekly_pool": 2147483647,
-    "cooldown_days": 7
+    "cooldown_days": 0
   },
   {
     "id": "p1",


### PR DESCRIPTION
### Description
- switches upload, first tip, first weekly comment, and profile completion to 0 cooldown for quicker testing on stage
- multiple are switched to 0 to be able to test the "all rewards" flow
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
