### PR TITLE
Be smarter are about completed block number

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/queries.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/queries.ts
@@ -140,3 +140,22 @@ export const getTrendingChallengesByDate = async (
     .where('challenge_id', '=', 'tt')
     .where('specifier', 'like', `${specifierPrefix}%`)
     .limit(100)
+
+// Get the completed block number from the first record that's older than 8 days ago
+export const getCompletedBlockNumberFromDaysAgo = async (
+  discoveryDb: Knex,
+  daysAgo: number
+): Promise<number | null> => {
+  const daysAgoDate = new Date()
+  daysAgoDate.setDate(daysAgoDate.getDate() - daysAgo)
+
+  const result = await discoveryDb
+    .select('completed_blocknumber')
+    .from<UserChallenges>(Table.UserChallenges)
+    .where('challenge_id', '=', 'tt')
+    .where('created_at', '<', daysAgoDate)
+    .orderBy('created_at', 'desc')
+    .first()
+
+  return result?.completed_blocknumber || null
+}


### PR DESCRIPTION
### Description

Right now, we just use an arbitrary completed block number from a few months ago to start querying for incomplete challenges. The problem with this is that sometimes claiming gets blocked by AAO and we never want to claim, thus every week retries the prior weeks' distributions. So the fix here is just use the most recent completed block number after last week (6 days ago for simplicity).

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run build && npm run start
```
watched for queries against api