### PR TITLE
Drop user-link touch target in track-list-item

### DIFF
--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -410,7 +410,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
                 </View>
               )}
             </View>
-            {user_id && <UserLink userId={user_id} size='s' />}
+            {user_id && <UserLink userId={user_id} size='s' disabled />}
           </View>
           {isUnlisted ? (
             <IconVisibilityHidden


### PR DESCRIPTION
### Description

Drops user-link touch target in track-list item since we want the whole item to play track on press