### PR TITLE
[QA-2273] Fix type issue in useAudioBalance

### DIFF
--- a/packages/common/src/api/tan-query/utils/combineQueryResults.ts
+++ b/packages/common/src/api/tan-query/utils/combineQueryResults.ts
@@ -43,7 +43,7 @@ export const combineQueryStatuses = (
  */
 export const combineQueryResults = <T>(
   queries: UseQueryResult<T, Error>[]
-): UseQueryResult<T | undefined, Error> => {
+): UseQueryResult<T, Error> => {
   const { isPending, isFetching, isLoading, isSuccess, isError } =
     combineQueryStatuses(queries)
 
@@ -122,5 +122,5 @@ export const combineQueryResults = <T>(
     promise
   } as UseQueryResult<T | undefined>
 
-  return result as UseQueryResult<T | undefined, Error>
+  return result as UseQueryResult<T, Error>
 }

--- a/packages/common/src/api/tan-query/utils/combineQueryResults.ts
+++ b/packages/common/src/api/tan-query/utils/combineQueryResults.ts
@@ -43,7 +43,7 @@ export const combineQueryStatuses = (
  */
 export const combineQueryResults = <T>(
   queries: UseQueryResult<T, Error>[]
-): UseQueryResult<T, Error> => {
+): UseQueryResult<T | undefined, Error> => {
   const { isPending, isFetching, isLoading, isSuccess, isError } =
     combineQueryStatuses(queries)
 
@@ -122,5 +122,5 @@ export const combineQueryResults = <T>(
     promise
   } as UseQueryResult<T | undefined>
 
-  return result as UseQueryResult<T, Error>
+  return result as UseQueryResult<T | undefined, Error>
 }

--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -207,7 +207,9 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   let accountBalance = AUDIO(0).value
   const isAccountBalanceLoading = accountBalances.isPending
   for (const balanceRes of accountBalances.data ?? []) {
-    accountBalance = AUDIO(accountBalance + balanceRes.balance).value
+    accountBalance = AUDIO(
+      accountBalance + (balanceRes.balance ?? BigInt(0))
+    ).value
   }
 
   // Get linked/connected wallets balances
@@ -229,7 +231,7 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   if (includeConnectedWallets) {
     for (const balanceRes of connectedWalletsBalances.data ?? []) {
       connectedWalletsBalance = AUDIO(
-        connectedWalletsBalance + balanceRes.balance
+        connectedWalletsBalance + (balanceRes.balance ?? BigInt(0))
       ).value
     }
   }

--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -207,9 +207,7 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   let accountBalance = AUDIO(0).value
   const isAccountBalanceLoading = accountBalances.isPending
   for (const balanceRes of accountBalances.data ?? []) {
-    accountBalance = AUDIO(
-      accountBalance + (balanceRes.balance ?? BigInt(0))
-    ).value
+    accountBalance = AUDIO(accountBalance + balanceRes.balance).value
   }
 
   // Get linked/connected wallets balances
@@ -231,7 +229,7 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   if (includeConnectedWallets) {
     for (const balanceRes of connectedWalletsBalances.data ?? []) {
       connectedWalletsBalance = AUDIO(
-        connectedWalletsBalance + (balanceRes.balance ?? BigInt(0))
+        connectedWalletsBalance + balanceRes.balance
       ).value
     }
   }


### PR DESCRIPTION
- https://github.com/AudiusProject/audius-protocol/pull/12617

#12617 changed the underlying cache object type without updating the `getQueryKey` typing, which masked an issue in some optimism code. That code would then try to add a bigint to an object, and then JS in it's everlasting wisdom would autoconvert the object to a string and concat the two. Then, when reading that object back, we think it's an object with a `balance` property, but it's a string with no such property, and is thus undefined. Unlike adding an object to a bigint, adding undefined to a bigint throws an error (thanks JS) so that was the underlying root cause of the issue, only present during swaps.

I updated the optimistic code to all be in one place and use the same underlying function to prevent any future confusion.