### PR TITLE
[API-299] Add AAO check in solana-relay

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
@@ -57,6 +57,7 @@ type Config = {
   listensTrackHourlyRateLimit: number
   listensTrackDailyRateLimit: number
   listensTrackWeeklyRateLimit: number
+  antiAbuseOracle: string
 }
 
 let cachedConfig: Config | null = null
@@ -148,7 +149,10 @@ const readConfig = (): Config => {
     audius_solana_listens_ip_weekly_rate_limit: num({ default: 50000000 }),
     audius_solana_listens_track_hourly_rate_limit: num({ default: 120 }),
     audius_solana_listens_track_daily_rate_limit: num({ default: 50000 }),
-    audius_solana_listens_track_weekly_rate_limit: num({ default: 50000000 })
+    audius_solana_listens_track_weekly_rate_limit: num({ default: 50000000 }),
+    audius_anti_abuse_oracle: str({
+      default: 'http://audius-protocol-anti-abuse-oracle-1:8000'
+    })
   })
   const solanaFeePayerWalletsParsed = env.audius_solana_fee_payer_wallets
   let solanaFeePayerWallets: Keypair[] = []
@@ -194,7 +198,8 @@ const readConfig = (): Config => {
     listensTrackDailyRateLimit:
       env.audius_solana_listens_track_daily_rate_limit,
     listensTrackWeeklyRateLimit:
-      env.audius_solana_listens_track_weekly_rate_limit
+      env.audius_solana_listens_track_weekly_rate_limit,
+    antiAbuseOracle: env.audius_anti_abuse_oracle
   }
   return readConfig()
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/antiAbuse.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/antiAbuse.ts
@@ -1,0 +1,31 @@
+import fetch from 'cross-fetch'
+import { Logger } from 'pino'
+
+import { config } from '../../config'
+import { logger } from '../../logger'
+
+/**
+ * Checks if a user is abusive by querying the anti-abuse oracle
+ * @param wallet - The wallet address to check
+ * @param log - Optional logger instance, defaults to the module logger
+ * @returns Promise<boolean> - true if user is abusive (response not 200), false otherwise
+ */
+export const isUserAbusive = async (
+  wallet: string,
+  log: Logger = logger
+): Promise<boolean> => {
+  try {
+    const url = `${config.antiAbuseOracle}/attestation/check?wallet=${wallet}`
+    const response = await fetch(url)
+    if (response.status !== 200) {
+      return true
+    }
+    return false
+  } catch (error) {
+    log.error(
+      { error, wallet },
+      'Error checking anti-abuse status, defaulting to not abusive'
+    )
+    return false
+  }
+}


### PR DESCRIPTION
### Description

Makes a request to AAO service.
I wish it could do db stuff, but it requires a lot of custom code + linking identity service db.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

after some ugly env wrangling
```
# aao
npm run dev
curl localhost:6002/attestation/check?wallet=0xf6b983a131755072c7ec1505910c8bb5c25e2215

# solana relay
# i added a test endpoint that just called my helper and validated the response worked as well
```
