### PR TITLE
[PE-6592] Update chat composer line indexing logic

### DIFF
--- a/packages/web/src/components/composer-input/ComposerInput.tsx
+++ b/packages/web/src/components/composer-input/ComposerInput.tsx
@@ -1,5 +1,6 @@
 import {
   ChangeEvent,
+  ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -48,7 +49,7 @@ const ESCAPE_KEY = 'Escape'
 const SPACE_KEY = ' '
 
 const ComposerText = ({
-  color,
+  color = 'default',
   children
 }: Pick<TextProps, 'color' | 'children'>) => {
   return (
@@ -61,14 +62,12 @@ const ComposerText = ({
 const createTextSections = (
   text: string,
   lineIndex: number
-): [JSX.Element[], number] => {
+): [ReactNode[], number] => {
   const splitText = splitOnNewline(text)
 
   return [
     splitText.map((t, index) => (
-      <ComposerText key={`${t}-${index + lineIndex}`} color='default'>
-        {t}
-      </ComposerText>
+      <ComposerText key={`${t}-${index + lineIndex}`}>{t}</ComposerText>
     )),
     splitText.length
   ]

--- a/packages/web/src/components/composer-input/ComposerInput.tsx
+++ b/packages/web/src/components/composer-input/ComposerInput.tsx
@@ -59,18 +59,12 @@ const ComposerText = ({
   )
 }
 
-const createTextSections = (
-  text: string,
-  lineIndex: number
-): [ReactNode[], number] => {
+const createTextSections = (text: string, lineIndex: number): ReactNode[] => {
   const splitText = splitOnNewline(text)
 
-  return [
-    splitText.map((t, index) => (
-      <ComposerText key={`${t}-${index + lineIndex}`}>{t}</ComposerText>
-    )),
-    splitText.length
-  ]
+  return splitText.map((t, index) => (
+    <ComposerText key={`${t}-${index + lineIndex}`}>{t}</ComposerText>
+  ))
 }
 
 export const ComposerInput = (props: ComposerInputProps) => {
@@ -406,8 +400,7 @@ export const ComposerInput = (props: ComposerInputProps) => {
 
       // If there are no highlightable sections, render text normally
       if (!fullMatches.length && !isUserAutocompleteActive) {
-        const [textSections] = createTextSections(value, lineIndex)
-        return textSections
+        return createTextSections(value, lineIndex)
       }
 
       const renderedTextSections = []
@@ -450,12 +443,12 @@ export const ComposerInput = (props: ComposerInputProps) => {
 
         // Add text before the match
         if (index > lastIndex) {
-          const [textSections, textSectionsLength] = createTextSections(
+          const textSections = createTextSections(
             value.slice(lastIndex, index),
             lineIndex
           )
           renderedTextSections.push(...textSections)
-          lineIndex += textSectionsLength
+          lineIndex += textSections.length
         }
 
         // Add the matched word with accent color
@@ -486,12 +479,12 @@ export const ComposerInput = (props: ComposerInputProps) => {
 
       // Add remaining text after the last match
       if (lastIndex < value.length) {
-        const [textSections, textSectionsLength] = createTextSections(
+        const textSections = createTextSections(
           value.slice(lastIndex),
           lineIndex
         )
         renderedTextSections.push(...textSections)
-        lineIndex += textSectionsLength
+        lineIndex += textSections.length
       }
 
       return renderedTextSections


### PR DESCRIPTION
### Description
Bug with the composer when there were duplicate line text and index combinations in the rendered text sections. Updated to update and track the line number across the different text sections

Root cause of bug: There were multiple lines in the renderedTextSections that had the same text value and index resulting in the same key, which caused issues when trying to rerender and update them. 

Fix: Added a lineIndex variable to keep track of the number of lines so that the key will increment properly with the number of lines in the rendered text section

### How Has This Been Tested?
Manually Tested
