### PR TITLE
[QA-2272] Fix X share

### DIFF
--- a/packages/common/src/utils/xShare.ts
+++ b/packages/common/src/utils/xShare.ts
@@ -2,5 +2,5 @@ export const makeXShareUrl = (url: string | null, text: string) => {
   const textString = `?text=${encodeURIComponent(text)}`
   const urlString = url ? `&url=${encodeURIComponent(url)}` : ''
 
-  return `http://x.com/intent/post${textString}${urlString}`
+  return `http://x.com/intent/tweet${textString}${urlString}`
 }


### PR DESCRIPTION
### Description
Bug: when clicking X share, it opens up in an iframe (web browser view) _inside_ of the X app. Instead it should just try to open a new tweet inside the X app.

Originally while working on [this PR](https://github.com/AudiusProject/audius-protocol/pull/12435/files) I noticed that the original twitter url was redirecting to `x.com/intent/post`, but I guess navigating to that url directly is the source of this problem.
See the difference between `packages/common/src/utils/twitter.ts` and `packages/common/src/utils/xShare.ts` in https://github.com/AudiusProject/audius-protocol/pull/12435.

### How Has This Been Tested?

Tested on ios device stage
