### PR TITLE
[QA-2255] Revert "[QA-2193] Fix android playback stuck on one track (#12460)"

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -679,49 +679,23 @@ export const AudioPlayer = () => {
       queuableTracks: QueueableTrack[],
       queueIndex = -1
     ) => {
-      // If queueIndex is -1, we're appending tracks - enqueue them all sequentially
-      if (queueIndex === -1) {
-        for (const track of queuableTracks) {
-          if (abortEnqueueControllerRef.current.signal.aborted) {
-            return
-          }
-          if (track) {
-            await TrackPlayer.add(await makeTrackData(track))
-          }
-        }
-        return
-      }
-
-      // Safety check: Don't proceed if queueIndex is invalid
-      if (queueIndex < 0 || queueIndex >= queuableTracks.length) {
-        return
-      }
-
       let currentPivot = 1
       while (
         queueIndex - currentPivot >= 0 ||
-        queueIndex + currentPivot < queuableTracks.length
+        queueIndex + currentPivot < queueTracks.length
       ) {
         if (abortEnqueueControllerRef.current.signal.aborted) {
           return
         }
 
-        // Only add next track if index is valid
-        const nextIndex = queueIndex + currentPivot
-        if (nextIndex < queuableTracks.length) {
-          const nextTrack = queuableTracks[nextIndex]
-          if (nextTrack) {
-            await TrackPlayer.add(await makeTrackData(nextTrack))
-          }
+        const nextTrack = queuableTracks[queueIndex + currentPivot]
+        if (nextTrack) {
+          await TrackPlayer.add(await makeTrackData(nextTrack))
         }
 
-        // Only add previous track if index is valid
-        const prevIndex = queueIndex - currentPivot
-        if (prevIndex >= 0) {
-          const previousTrack = queuableTracks[prevIndex]
-          if (previousTrack) {
-            await TrackPlayer.add(await makeTrackData(previousTrack), 0)
-          }
+        const previousTrack = queuableTracks[queueIndex - currentPivot]
+        if (previousTrack) {
+          await TrackPlayer.add(await makeTrackData(previousTrack), 0)
         }
         currentPivot++
       }
@@ -741,10 +715,7 @@ export const AudioPlayer = () => {
 
       await TrackPlayer.add(await makeTrackData(firstTrack))
 
-      // Only call enqueueTracks if we have a valid queue index and more than 1 track
-      if (queueIndex >= 0 && newQueueTracks.length > 1) {
-        enqueueTracksJobRef.current = enqueueTracks(newQueueTracks, queueIndex)
-      }
+      enqueueTracksJobRef.current = enqueueTracks(newQueueTracks, queueIndex)
       await enqueueTracksJobRef.current
       enqueueTracksJobRef.current = undefined
     }
@@ -758,26 +729,16 @@ export const AudioPlayer = () => {
   ])
 
   const handleQueueIdxChange = useCallback(async () => {
-    try {
-      await enqueueTracksJobRef.current
-      const playerIdx = await TrackPlayer.getActiveTrackIndex()
-      const queue = await TrackPlayer.getQueue()
+    await enqueueTracksJobRef.current
+    const playerIdx = await TrackPlayer.getActiveTrackIndex()
+    const queue = await TrackPlayer.getQueue()
 
-      if (
-        queueIndex !== -1 &&
-        queueIndex !== playerIdx &&
-        queueIndex < queue.length
-      ) {
-        // Only skip if the target track exists and has a valid URL
-        const targetTrack = queue[queueIndex]
-        if (targetTrack?.url && targetTrack.url.trim() !== '') {
-          await TrackPlayer.skip(queueIndex)
-        }
-        // If the track doesn't have a URL yet, don't skip but also don't return early
-        // This allows the queue change to be processed when the URL becomes available
-      }
-    } catch (error) {
-      console.error('Error in handleQueueIdxChange:', error)
+    if (
+      queueIndex !== -1 &&
+      queueIndex !== playerIdx &&
+      queueIndex < queue.length
+    ) {
+      await TrackPlayer.skip(queueIndex)
     }
   }, [queueIndex])
 


### PR DESCRIPTION
This reverts commit 4746f2ba9b1b1fac6f59af16e68405f8b23a08de.

### Description
[This PR](https://github.com/AudiusProject/audius-protocol/pull/12460) caused a bug where if the user scrolled quickly on feed on mobile (both ios and android), they could get into a state where the audio playback would get stuck, or just play silence.

By reverting changes to `AudioPlayer.tsx` @dylanjeffers and i found that this PR was the root cause.

We'll revert that commit and come back and try to solve the original bug of that PR. That bug was less severe, android-only and only on collections.

### How Has This Been Tested?

Tested manually on local ios prod sim
