### PR TITLE
Fix supporter error for chat user search results

### DIFF
--- a/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
+++ b/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
@@ -159,7 +159,6 @@ export const CreateChatUserResult = (props: UserResultComposeProps) => {
         className={styles.artistChip}
         userId={user.user_id}
         showPopover={false}
-        showSupportFor={currentUserId ?? undefined}
         customChips={canCreateChat ? null : renderCustomChip(callToAction)}
         onClickArtistName={handleComposeClicked}
       />


### PR DESCRIPTION
### Description
Small update to remove the showSupportFor prop from the user results as it is unused and was flooding the console with errors

### How Has This Been Tested?
Manually Tested
