### PR TITLE
[QA-2278] Fix layout left align on small screens

### DIFF
--- a/packages/web/src/components/page/FlushPageContainer.tsx
+++ b/packages/web/src/components/page/FlushPageContainer.tsx
@@ -9,17 +9,10 @@ import {
 export const FlushPageContainer = (props: FlexProps) => {
   const { children, ...flexProps } = props
   return (
-    <Flex
-      w='100%'
-      flex='1 1 0'
-      ph={PAGE_GUTTER_PX}
-      justifyContent='center'
-      {...flexProps}
-    >
+    <Flex w='100%' flex='1 1 0' ph={PAGE_GUTTER_PX} {...flexProps}>
       <Flex
         flex='1'
         w='100%'
-        justifyContent='center'
         css={{
           maxWidth: MAX_PAGE_WIDTH_PX,
           minWidth: MIN_PAGE_WIDTH_PX


### PR DESCRIPTION
### Description

Fixes issue where at small viewports the main content would try to center itself rather than remain left-aligned