### PR TITLE
Artist coin blast UI improvements

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -22,6 +22,7 @@ export * from './tan-query/coins/useArtistCoin'
 export * from './tan-query/coins/useArtistCoinInsights'
 export * from './tan-query/coins/useArtistCoinMembers'
 export * from './tan-query/coins/useUserCoins'
+export * from './tan-query/coins/useArtistCoinMembersCount'
 
 export * from './tan-query/coins/useArtistCoins'
 export * from './tan-query/coins/tokenUtils'

--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
@@ -71,7 +71,6 @@ export const useArtistCoinMembers = (
       const sdk = await audiusSdk()
       const mintAddress = getMintAddress(mint)
 
-      // Build query parameters
       const params: any = {
         mint: mintAddress,
         limit: pageSize,
@@ -79,12 +78,12 @@ export const useArtistCoinMembers = (
         sortDirection
       }
 
-      // Make the API call to the coin members endpoint
       const response = await sdk.coins.getCoinMembers(params)
 
-      const members: CoinMember[] = (response.data || []).map(
+      console.log('REED', { response })
+      const members: CoinMember[] = (response.data ?? []).map(
         (member: any) => ({
-          user_id: decodeHashId(member.user_id) || 0,
+          user_id: decodeHashId(member.userId) ?? 0,
           balance: member.balance
         })
       )

--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
@@ -80,7 +80,6 @@ export const useArtistCoinMembers = (
 
       const response = await sdk.coins.getCoinMembers(params)
 
-      console.log('REED', { response })
       const members: CoinMember[] = (response.data ?? []).map(
         (member: any) => ({
           user_id: decodeHashId(member.userId) ?? 0,

--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
@@ -1,0 +1,54 @@
+import { Id } from '@audius/sdk'
+import { useQuery } from '@tanstack/react-query'
+
+import { useQueryContext } from '../utils/QueryContext'
+import { removeNullable } from '~/utils/typeUtils'
+
+import { QUERY_KEYS } from '../queryKeys'
+import { QueryKey, QueryOptions } from '../types'
+import { useCurrentUserId } from '../users/account/useCurrentUserId'
+
+export type UseArtistCoinMembersCountArgs = Record<string, never>
+
+export const getArtistCoinMembersCountQueryKey = (
+  currentUserId?: number | null
+) =>
+  [
+    QUERY_KEYS.artistCoinMembersCount,
+    currentUserId
+  ] as unknown as QueryKey<number>
+
+export const useArtistCoinMembersCount = (
+  _args: UseArtistCoinMembersCountArgs = {},
+  options?: QueryOptions
+) => {
+  const { audiusSdk } = useQueryContext()
+  const { data: currentUserId } = useCurrentUserId()
+
+  return useQuery({
+    queryKey: getArtistCoinMembersCountQueryKey(currentUserId),
+    queryFn: async () => {
+      const sdk = await audiusSdk()
+      if (!currentUserId) return 0
+
+      // First, get the current user's artist coin
+      const coinsResponse = await sdk.coins.getCoins({
+        ownerId: [Id.parse(currentUserId)].filter(removeNullable),
+        limit: 1
+      })
+
+      const userCoin = coinsResponse?.data?.[0]
+      if (!userCoin?.mint) return 0
+
+      // Get the coin insights which includes the holder count
+      const insightsResponse = await sdk.coins.getCoinInsights({
+        mint: userCoin.mint
+      })
+
+      // Return the holder count from the insights
+      return insightsResponse?.data?.holder || 0
+    },
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
+  })
+}

--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
@@ -1,8 +1,6 @@
 import { Id } from '@audius/sdk'
 import { useQuery } from '@tanstack/react-query'
 
-import { removeNullable } from '~/utils/typeUtils'
-
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'

--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
@@ -1,12 +1,12 @@
 import { Id } from '@audius/sdk'
 import { useQuery } from '@tanstack/react-query'
 
-import { useQueryContext } from '../utils/QueryContext'
 import { removeNullable } from '~/utils/typeUtils'
 
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
+import { useQueryContext } from '../utils/QueryContext'
 
 export type UseArtistCoinMembersCountArgs = Record<string, never>
 
@@ -31,22 +31,18 @@ export const useArtistCoinMembersCount = (
       const sdk = await audiusSdk()
       if (!currentUserId) return 0
 
-      // First, get the current user's artist coin
       const coinsResponse = await sdk.coins.getCoins({
-        ownerId: [Id.parse(currentUserId)].filter(removeNullable),
-        limit: 1
+        ownerId: [Id.parse(currentUserId)]
       })
 
       const userCoin = coinsResponse?.data?.[0]
       if (!userCoin?.mint) return 0
 
-      // Get the coin insights which includes the holder count
       const insightsResponse = await sdk.coins.getCoinInsights({
         mint: userCoin.mint
       })
 
-      // Return the holder count from the insights
-      return insightsResponse?.data?.holder || 0
+      return insightsResponse?.data?.members
     },
     ...options,
     enabled: options?.enabled !== false && !!currentUserId

--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembersCount.ts
@@ -6,8 +6,6 @@ import { QueryKey, QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { useQueryContext } from '../utils/QueryContext'
 
-export type UseArtistCoinMembersCountArgs = Record<string, never>
-
 export const getArtistCoinMembersCountQueryKey = (
   currentUserId?: number | null
 ) =>
@@ -16,10 +14,7 @@ export const getArtistCoinMembersCountQueryKey = (
     currentUserId
   ] as unknown as QueryKey<number>
 
-export const useArtistCoinMembersCount = (
-  _args: UseArtistCoinMembersCountArgs = {},
-  options?: QueryOptions
-) => {
+export const useArtistCoinMembersCount = (options?: QueryOptions) => {
   const { audiusSdk } = useQueryContext()
   const { data: currentUserId } = useCurrentUserId()
 

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -113,5 +113,6 @@ export const QUERY_KEYS = {
   coinInsights: 'coinInsights',
   artistCoin: 'artistCoin',
   artistCoinByMint: 'artistCoinByMint',
-  userCoin: 'userCoin'
+  userCoin: 'userCoin',
+  artistCoinMembersCount: 'artistCoinMembersCount'
 } as const

--- a/packages/common/src/hooks/chats/useAudienceUsers.ts
+++ b/packages/common/src/hooks/chats/useAudienceUsers.ts
@@ -1,6 +1,8 @@
 import { ChatBlast, ChatBlastAudience, OptionalHashId } from '@audius/sdk'
 
 import {
+  useArtistCoinMembers,
+  useArtistCoins,
   useCurrentUserId,
   useFollowers,
   usePurchasers,
@@ -41,8 +43,27 @@ export const useAudienceUsers = (chat: ChatBlast, limit?: number) => {
     { enabled: chat.audience === ChatBlastAudience.REMIXERS }
   )
 
+  const { data: coins } = useArtistCoins(
+    {
+      owner_id: [currentUserId ?? 0],
+      limit: 1
+    },
+    { enabled: chat.audience === ChatBlastAudience.COIN_HOLDERS }
+  )
+  const mint = coins?.[0]?.mint
+
+  const { data: coinMembers } = useArtistCoinMembers(
+    {
+      mint: mint ?? null,
+      pageSize: limit
+    },
+    { enabled: chat.audience === ChatBlastAudience.COIN_HOLDERS }
+  )
   const { data: purchasersUsers } = useUsers(purchasers)
   const { data: remixersUsers } = useUsers(remixers)
+  const { data: coinMembersUsers } = useUsers(
+    coinMembers?.map((member) => member.user_id)
+  )
 
   let users: UserMetadata[] = []
   switch (chat.audience) {
@@ -57,6 +78,9 @@ export const useAudienceUsers = (chat: ChatBlast, limit?: number) => {
       break
     case ChatBlastAudience.REMIXERS:
       users = remixersUsers ?? []
+      break
+    case ChatBlastAudience.COIN_HOLDERS:
+      users = coinMembersUsers ?? []
       break
   }
 

--- a/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
+++ b/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
@@ -59,10 +59,9 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
     limit: 1
   })
   const coinSymbol = coins?.[0]?.ticker ?? ''
-  const { data: coinHoldersCount } = useArtistCoinMembersCount(
-    {},
-    { enabled: audience === ChatBlastAudience.COIN_HOLDERS }
-  )
+  const { data: coinHoldersCount } = useArtistCoinMembersCount({
+    enabled: audience === ChatBlastAudience.COIN_HOLDERS
+  })
 
   const audienceCount = useMemo(() => {
     switch (audience) {

--- a/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
+++ b/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
@@ -4,6 +4,7 @@ import { ChatBlast, ChatBlastAudience, OptionalHashId } from '@audius/sdk'
 
 import {
   useCollection,
+  useArtistCoinMembersCount,
   useCurrentAccountUser,
   usePurchasersCount,
   useRemixersCount,
@@ -52,6 +53,11 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
     { enabled: audience === ChatBlastAudience.REMIXERS }
   )
 
+  const { data: coinHoldersCount } = useArtistCoinMembersCount(
+    {},
+    { enabled: audience === ChatBlastAudience.COIN_HOLDERS }
+  )
+
   const audienceCount = useMemo(() => {
     switch (audience) {
       case ChatBlastAudience.FOLLOWERS:
@@ -62,6 +68,8 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
         return purchasersCount
       case ChatBlastAudience.REMIXERS:
         return remixersCount
+      case ChatBlastAudience.COIN_HOLDERS:
+        return coinHoldersCount
       default:
         return 0
     }
@@ -70,7 +78,8 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
     user?.follower_count,
     user?.supporter_count,
     purchasersCount,
-    remixersCount
+    remixersCount,
+    coinHoldersCount
   ])
 
   const contentTitle = audienceContentId

--- a/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
+++ b/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
@@ -8,7 +8,8 @@ import {
   useCurrentAccountUser,
   usePurchasersCount,
   useRemixersCount,
-  useTrack
+  useTrack,
+  useArtistCoins
 } from '~/api'
 import {
   getChatBlastAudienceDescription,
@@ -53,6 +54,11 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
     { enabled: audience === ChatBlastAudience.REMIXERS }
   )
 
+  const { data: coins } = useArtistCoins({
+    owner_id: [user?.user_id ?? 0],
+    limit: 1
+  })
+  const coinSymbol = coins?.[0]?.ticker ?? ''
   const { data: coinHoldersCount } = useArtistCoinMembersCount(
     {},
     { enabled: audience === ChatBlastAudience.COIN_HOLDERS }
@@ -88,15 +94,21 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
       : albumTitle
     : undefined
 
-  const chatBlastTitle = getChatBlastTitle(audience)
+  const chatBlastTitle = getChatBlastTitle({ audience, coinSymbol })
   const chatBlastSecondaryTitle = getChatBlastSecondaryTitle({
     audience,
-    audienceContentId
+    audienceContentId,
+    coinSymbol
   })
   const chatBlastAudienceDescription = getChatBlastAudienceDescription({
-    audience
+    audience,
+    coinSymbol
   })
-  const chatBlastCTA = getChatBlastCTA({ audience, audienceContentId })
+  const chatBlastCTA = getChatBlastCTA({
+    audience,
+    audienceContentId,
+    coinSymbol
+  })
 
   return {
     chatBlastTitle,

--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -24,12 +24,13 @@ const messages = {
   blastTitleRemixers: 'Remix Creators',
   blastTitleCustomers2: 'All Purchasers',
   blastTitleRemixers2: 'Remixed',
-  blastTitleCoinHolders: 'Coin Holders',
+  blastTitleCoinHolders: (symbol: string) => `${symbol} Members`,
   blastFollowersDescription: 'Everyone who follows you.',
   blastSupportersDescription: 'Everyone who has sent you a tip.',
   blastCustomersDescription: 'Everyone who has paid for your content.',
   blastRemixersDescription: 'Everyone who has remixed your tracks.',
-  blastCoinHoldersDescription: 'Everyone who holds your artist coin.',
+  blastCoinHoldersDescription: (symbol: string) =>
+    `Everyone who holds ${symbol}.`,
   blastCTABase: 'Send a message blast to ',
   blastCTAFollowers: 'each of your followers',
   blastCTASupporters: 'everyone who has sent you a tip',
@@ -40,7 +41,8 @@ const messages = {
   blastCTARemixers: (audienceContentId?: string) =>
     audienceContentId
       ? 'everyone who remixed this track'
-      : 'everyone who has remixed your tracks'
+      : 'everyone who has remixed your tracks',
+  blastCTACoinHolders: (symbol: string) => `everyone who holds ${symbol}`
 }
 
 /**
@@ -183,7 +185,13 @@ export const makeBlastChatId = ({
   )
 }
 
-export const getChatBlastTitle = (audience: ChatBlastAudience) => {
+export const getChatBlastTitle = ({
+  audience,
+  coinSymbol
+}: {
+  audience: ChatBlastAudience
+  coinSymbol?: string
+}) => {
   switch (audience) {
     case ChatBlastAudience.FOLLOWERS:
       return messages.blastTitleFollowers
@@ -194,16 +202,18 @@ export const getChatBlastTitle = (audience: ChatBlastAudience) => {
     case ChatBlastAudience.REMIXERS:
       return messages.blastTitleRemixers
     case ChatBlastAudience.COIN_HOLDERS:
-      return messages.blastTitleCoinHolders
+      return messages.blastTitleCoinHolders(coinSymbol ?? '')
   }
 }
 
 export const getChatBlastSecondaryTitle = ({
   audience,
-  audienceContentId
+  audienceContentId,
+  coinSymbol
 }: {
   audience: ChatBlastAudience
-  audienceContentId: string | undefined
+  audienceContentId?: string
+  coinSymbol?: string
 }) => {
   switch (audience) {
     case ChatBlastAudience.FOLLOWERS:
@@ -219,14 +229,16 @@ export const getChatBlastSecondaryTitle = ({
         ? messages.blastTitleRemixers2
         : messages.blastTitleRemixers
     case ChatBlastAudience.COIN_HOLDERS:
-      return messages.blastTitleCoinHolders
+      return messages.blastTitleCoinHolders(coinSymbol ?? '')
   }
 }
 
 export const getChatBlastAudienceDescription = ({
-  audience
+  audience,
+  coinSymbol
 }: {
   audience: ChatBlastAudience
+  coinSymbol?: string
 }) => {
   switch (audience) {
     case ChatBlastAudience.FOLLOWERS:
@@ -238,16 +250,18 @@ export const getChatBlastAudienceDescription = ({
     case ChatBlastAudience.REMIXERS:
       return messages.blastRemixersDescription
     case ChatBlastAudience.COIN_HOLDERS:
-      return messages.blastCoinHoldersDescription
+      return messages.blastCoinHoldersDescription(coinSymbol ?? '')
   }
 }
 
 export const getChatBlastCTA = ({
   audience,
-  audienceContentId
+  audienceContentId,
+  coinSymbol
 }: {
   audience: ChatBlastAudience
-  audienceContentId: string | undefined
+  audienceContentId?: string
+  coinSymbol?: string
 }) => {
   switch (audience) {
     case ChatBlastAudience.FOLLOWERS:
@@ -261,6 +275,10 @@ export const getChatBlastCTA = ({
     case ChatBlastAudience.REMIXERS:
       return (
         messages.blastCTABase + messages.blastCTARemixers(audienceContentId)
+      )
+    case ChatBlastAudience.COIN_HOLDERS:
+      return (
+        messages.blastCTABase + messages.blastCTACoinHolders(coinSymbol ?? '')
       )
   }
 }

--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -24,10 +24,12 @@ const messages = {
   blastTitleRemixers: 'Remix Creators',
   blastTitleCustomers2: 'All Purchasers',
   blastTitleRemixers2: 'Remixed',
+  blastTitleCoinHolders: 'Coin Holders',
   blastFollowersDescription: 'Everyone who follows you.',
   blastSupportersDescription: 'Everyone who has sent you a tip.',
   blastCustomersDescription: 'Everyone who has paid for your content.',
   blastRemixersDescription: 'Everyone who has remixed your tracks.',
+  blastCoinHoldersDescription: 'Everyone who holds your artist coin.',
   blastCTABase: 'Send a message blast to ',
   blastCTAFollowers: 'each of your followers',
   blastCTASupporters: 'everyone who has sent you a tip',
@@ -191,6 +193,8 @@ export const getChatBlastTitle = (audience: ChatBlastAudience) => {
       return messages.blastTitleCustomers
     case ChatBlastAudience.REMIXERS:
       return messages.blastTitleRemixers
+    case ChatBlastAudience.COIN_HOLDERS:
+      return messages.blastTitleCoinHolders
   }
 }
 
@@ -214,6 +218,8 @@ export const getChatBlastSecondaryTitle = ({
       return audienceContentId
         ? messages.blastTitleRemixers2
         : messages.blastTitleRemixers
+    case ChatBlastAudience.COIN_HOLDERS:
+      return messages.blastTitleCoinHolders
   }
 }
 
@@ -231,6 +237,8 @@ export const getChatBlastAudienceDescription = ({
       return messages.blastCustomersDescription
     case ChatBlastAudience.REMIXERS:
       return messages.blastRemixersDescription
+    case ChatBlastAudience.COIN_HOLDERS:
+      return messages.blastCoinHoldersDescription
   }
 }
 

--- a/packages/mobile/src/screens/chat-screen/ArtistCoinHeader.tsx
+++ b/packages/mobile/src/screens/chat-screen/ArtistCoinHeader.tsx
@@ -1,5 +1,4 @@
 import { useArtistCoinMessageHeader } from '@audius/common/hooks'
-import { walletMessages } from '@audius/common/messages'
 import type { ID } from '@audius/common/models'
 import type { ChatBlastAudience } from '@audius/sdk'
 import { Platform } from 'react-native'
@@ -41,7 +40,6 @@ export const ArtistCoinHeader = ({
         {/* Alignment bug for label text variant on iOS */}
         <Flex mt={Platform.OS === 'ios' ? '2xs' : 'none'}>
           <Text variant='label' size='s'>
-            {walletMessages.dollarSign}
             {artistCoinSymbol}
           </Text>
         </Flex>

--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -2,7 +2,9 @@ import { useCallback } from 'react'
 
 import {
   useArtistCoinMembersCount,
-  useCurrentAccountUser
+  useArtistCoins,
+  useCurrentAccountUser,
+  useCurrentUserId
 } from '@audius/common/api'
 import {
   useFeatureFlag,
@@ -48,9 +50,9 @@ const messages = {
     search: 'Search for tracks with remixes'
   },
   coinHolders: {
-    label: 'Coin Holders',
-    description:
-      'Send a bulk message to users who have Bonk coins in their wallet.',
+    label: (symbol: string) => `${symbol} Members`,
+    description: (symbol: string) =>
+      `Send a bulk message to users who have ${symbol} coins in their wallet.`,
     placeholder: 'Coin Holders'
   },
   count: (count: number) => ` (${formatNumberCommas(count)})`
@@ -252,7 +254,13 @@ const CoinHoldersMessageField = () => {
   )
   const [{ value: targetAudience }] = useField(TARGET_AUDIENCE_FIELD)
   const isSelected = targetAudience === ChatBlastAudience.COIN_HOLDERS
+  const { data: currentUserId } = useCurrentUserId()
   const { data: coinMembersCount } = useArtistCoinMembersCount()
+  const { data: coins } = useArtistCoins({
+    owner_id: [currentUserId ?? 0],
+    limit: 1
+  })
+  const coinSymbol = coins?.[0]?.ticker ?? ''
   const isDisabled = !isArtistCoinEnabled || coinMembersCount === 0
   if (!isArtistCoinEnabled) {
     return null
@@ -264,12 +272,12 @@ const CoinHoldersMessageField = () => {
       disabled={isDisabled}
       label={
         <LabelWithCount
-          label={messages.coinHolders.label}
+          label={messages.coinHolders.label(coinSymbol)}
           count={coinMembersCount}
           isSelected={isSelected}
         />
       }
-      description={messages.coinHolders.description}
+      description={messages.coinHolders.description(coinSymbol)}
     />
   )
 }

--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -52,7 +52,7 @@ const messages = {
   coinHolders: {
     label: (symbol: string) => `${symbol} Members`,
     description: (symbol: string) =>
-      `Send a bulk message to users who have ${symbol} coins in their wallet.`,
+      `Send a bulk message to every holder of ${symbol} on Audius.`,
     placeholder: 'Coin Holders'
   },
   count: (count: number) => ` (${formatNumberCommas(count)})`

--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -1,6 +1,9 @@
 import { useCallback } from 'react'
 
-import { useCurrentAccountUser } from '@audius/common/api'
+import {
+  useArtistCoinMembersCount,
+  useCurrentAccountUser
+} from '@audius/common/api'
 import {
   useFeatureFlag,
   usePurchasersAudience,
@@ -49,7 +52,8 @@ const messages = {
     description:
       'Send a bulk message to users who have Bonk coins in their wallet.',
     placeholder: 'Coin Holders'
-  }
+  },
+  count: (count: number) => ` (${formatNumberCommas(count)})`
 }
 
 export const ChatBlastSelectAudienceFields = () => {
@@ -75,7 +79,7 @@ const LabelWithCount = (props: {
     <Text>
       {label}
       {isSelected && count ? (
-        <Text color='subdued'>{formatNumberCommas(count)}</Text>
+        <Text color='subdued'>{messages.count(count)}</Text>
       ) : null}
     </Text>
   )
@@ -248,8 +252,8 @@ const CoinHoldersMessageField = () => {
   )
   const [{ value: targetAudience }] = useField(TARGET_AUDIENCE_FIELD)
   const isSelected = targetAudience === ChatBlastAudience.COIN_HOLDERS
-  const isDisabled = !isArtistCoinEnabled
-  const coinHoldersCount = 0
+  const { data: coinMembersCount } = useArtistCoinMembersCount()
+  const isDisabled = !isArtistCoinEnabled || coinMembersCount === 0
   if (!isArtistCoinEnabled) {
     return null
   }
@@ -261,7 +265,7 @@ const CoinHoldersMessageField = () => {
       label={
         <LabelWithCount
           label={messages.coinHolders.label}
-          count={coinHoldersCount}
+          count={coinMembersCount}
           isSelected={isSelected}
         />
       }

--- a/packages/web/src/pages/chat-page/components/ArtistCoinHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ArtistCoinHeader.tsx
@@ -1,5 +1,4 @@
 import { useArtistCoinMessageHeader } from '@audius/common/hooks'
-import { walletMessages } from '@audius/common/messages'
 import { ID } from '@audius/common/models'
 import { useTokens } from '@audius/common/store'
 import { Flex, Text } from '@audius/harmony'
@@ -40,7 +39,6 @@ export const ArtistCoinHeader = ({
       <Flex gap='xs' alignItems='center'>
         {ArtistCoinIcon ? <ArtistCoinIcon size='xs' /> : null}
         <Text variant='label' size='s'>
-          {walletMessages.dollarSign}
           {artistCoinSymbol}
         </Text>
       </Flex>

--- a/packages/web/src/pages/chat-page/components/ChatBlastAudienceDisplay.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastAudienceDisplay.tsx
@@ -60,6 +60,9 @@ export const ChatBlastAudienceDisplay = (
     case ChatBlastAudience.REMIXERS:
       userListType = UserListType.REMIXER
       break
+    case ChatBlastAudience.COIN_HOLDERS:
+      userListType = UserListType.COIN_LEADERBOARD
+      break
     default:
       userListType = UserListType.FOLLOWER
   }

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -361,7 +361,7 @@ const CoinHoldersMessageField = () => {
 
   const isSelected = targetAudience === ChatBlastAudience.COIN_HOLDERS
   const { data: membersCount } = useArtistCoinMembersCount()
-  const isDisabled = !isArtistCoinEnabled
+  const isDisabled = !isArtistCoinEnabled || membersCount === 0
   if (!isArtistCoinEnabled) {
     return null
   }

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -1,4 +1,7 @@
-import { useCurrentAccountUser } from '@audius/common/api'
+import {
+  useArtistCoinMembersCount,
+  useCurrentAccountUser
+} from '@audius/common/api'
 import {
   useFeatureFlag,
   useFirstAvailableBlastAudience,
@@ -357,7 +360,7 @@ const CoinHoldersMessageField = () => {
   )
 
   const isSelected = targetAudience === ChatBlastAudience.COIN_HOLDERS
-  const coinHoldersCount = 0
+  const { data: membersCount } = useArtistCoinMembersCount()
   const isDisabled = !isArtistCoinEnabled
   if (!isArtistCoinEnabled) {
     return null
@@ -375,7 +378,7 @@ const CoinHoldersMessageField = () => {
       <Flex direction='column' gap='xs' css={{ cursor: 'pointer' }}>
         <LabelWithCount
           label={messages.coinHolders.label}
-          count={coinHoldersCount}
+          count={membersCount}
           isSelected={isSelected}
         />
         {isSelected ? (

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -1,6 +1,8 @@
 import {
+  useArtistCoins,
   useArtistCoinMembersCount,
-  useCurrentAccountUser
+  useCurrentAccountUser,
+  useCurrentUserId
 } from '@audius/common/api'
 import {
   useFeatureFlag,
@@ -61,9 +63,9 @@ const messages = {
     placeholder: 'Tracks with Remixes'
   },
   coinHolders: {
-    label: 'Coin Holders',
-    description:
-      'Send a bulk message to users who have Bonk coins in their wallet.',
+    label: (symbol: string) => `${symbol} Members`,
+    description: (symbol: string) =>
+      `Send a bulk message to users who have ${symbol} coins in their wallet.`,
     placeholder: 'Coin Holders'
   }
 }
@@ -353,8 +355,13 @@ const RemixCreatorsMessageField = () => {
 }
 
 const CoinHoldersMessageField = () => {
+  const { data: currentUserId } = useCurrentUserId()
   const [{ value: targetAudience }] = useField(TARGET_AUDIENCE_FIELD)
-
+  const { data: coins } = useArtistCoins({
+    owner_id: [currentUserId ?? 0],
+    limit: 1
+  })
+  const coinSymbol = coins?.[0]?.ticker ?? ''
   const { isEnabled: isArtistCoinEnabled } = useFeatureFlag(
     FeatureFlags.ARTIST_COINS
   )
@@ -377,13 +384,13 @@ const CoinHoldersMessageField = () => {
       <Radio value={ChatBlastAudience.COIN_HOLDERS} disabled={isDisabled} />
       <Flex direction='column' gap='xs' css={{ cursor: 'pointer' }}>
         <LabelWithCount
-          label={messages.coinHolders.label}
+          label={messages.coinHolders.label(coinSymbol)}
           count={membersCount}
           isSelected={isSelected}
         />
         {isSelected ? (
           <Flex direction='column' gap='l'>
-            <Text size='s'>{messages.coinHolders.description}</Text>
+            <Text size='s'>{messages.coinHolders.description(coinSymbol)}</Text>
           </Flex>
         ) : null}
       </Flex>

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -65,7 +65,7 @@ const messages = {
   coinHolders: {
     label: (symbol: string) => `${symbol} Members`,
     description: (symbol: string) =>
-      `Send a bulk message to users who have ${symbol} coins in their wallet.`,
+      `Send a bulk message to every holder of ${symbol} on Audius.`,
     placeholder: 'Coin Holders'
   }
 }


### PR DESCRIPTION
### Description
Adds the sender-side UI for the artist coin message blasts

### How Has This Been Tested?

<img width="556" height="487" alt="Screenshot 2025-08-08 at 2 30 05 PM" src="https://github.com/user-attachments/assets/478a6c97-c71d-4de5-bcc2-1fea11df1365" />
<img width="460" height="206" alt="Screenshot 2025-08-08 at 2 30 16 PM" src="https://github.com/user-attachments/assets/97e9f6c4-6172-4bc5-bde8-2d1affc1753a" />


<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-08 at 15 43 24" src="https://github.com/user-attachments/assets/e6a8897b-004f-4cc3-8edd-75116595e82a" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-08 at 15 43 38" src="https://github.com/user-attachments/assets/501d1d0f-54bf-474d-bf2b-2f3d990c5f8b" />
