### PR TITLE
[PE-6570] Hide user contextual content when logged out

### DIFF
--- a/packages/common/src/api/tan-query/users/account/useCurrentUserId.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentUserId.ts
@@ -4,8 +4,7 @@ import { useCurrentAccount } from './useCurrentAccount'
  * Hook to get the currently logged in user's ID
  */
 export const useCurrentUserId = () => {
-  const { data: currentUserId } = useCurrentAccount({
+  return useCurrentAccount({
     select: (account) => account?.userId
   })
-  return { data: currentUserId }
 }

--- a/packages/web/src/pages/explore-page/components/desktop/MoodGrid.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/MoodGrid.tsx
@@ -9,10 +9,7 @@ import { useSearchCategory } from 'pages/search-page/hooks'
 import { MOODS } from 'pages/search-page/moods'
 import { labelByCategoryView } from 'pages/search-page/types'
 
-import { useDeferredElement } from './useDeferredElement'
-
 export const MoodGrid = () => {
-  const { ref, inView } = useDeferredElement()
   const [category, setCategory] = useSearchCategory()
   const { color } = useTheme()
 
@@ -27,56 +24,51 @@ export const MoodGrid = () => {
 
   return (
     <Flex
-      ref={ref}
       direction='column'
       mh='l'
       gap={isMobile ? 'l' : 'xl'}
       alignItems='center'
     >
-      {!inView ? null : (
-        <>
-          <Text
-            variant={isMobile ? 'title' : 'heading'}
-            size={isMobile ? 'l' : 'm'}
-          >
-            {messages.exploreByMood(
-              category === 'all' ? undefined : labelByCategoryView[category]
-            )}
-          </Text>
-          <Flex
-            gap={isMobile ? 'm' : 's'}
-            justifyContent='center'
-            alignItems='flex-start'
-            wrap='wrap'
-          >
-            {Object.entries(MOODS)
-              .sort()
-              .map(([mood, moodInfo]) => (
-                <Paper
-                  key={mood}
-                  pv='l'
-                  ph='xl'
-                  gap='s'
-                  borderRadius='m'
-                  border='default'
-                  backgroundColor='white'
-                  onClick={() => handleMoodPress(moodInfo.value)}
-                  css={{
-                    ':hover': {
-                      background: color.neutral.n25,
-                      border: `1px solid ${color.neutral.n150}`
-                    }
-                  }}
-                >
-                  {moodInfo.icon}
-                  <Text variant='title' size='s'>
-                    {moodInfo.label}
-                  </Text>
-                </Paper>
-              ))}
-          </Flex>
-        </>
-      )}
+      <Text
+        variant={isMobile ? 'title' : 'heading'}
+        size={isMobile ? 'l' : 'm'}
+      >
+        {messages.exploreByMood(
+          category === 'all' ? undefined : labelByCategoryView[category]
+        )}
+      </Text>
+      <Flex
+        gap={isMobile ? 'm' : 's'}
+        justifyContent='center'
+        alignItems='flex-start'
+        wrap='wrap'
+      >
+        {Object.entries(MOODS)
+          .sort()
+          .map(([mood, moodInfo]) => (
+            <Paper
+              key={mood}
+              pv='l'
+              ph='xl'
+              gap='s'
+              borderRadius='m'
+              border='default'
+              backgroundColor='white'
+              onClick={() => handleMoodPress(moodInfo.value)}
+              css={{
+                ':hover': {
+                  background: color.neutral.n25,
+                  border: `1px solid ${color.neutral.n150}`
+                }
+              }}
+            >
+              {moodInfo.icon}
+              <Text variant='title' size='s'>
+                {moodInfo.label}
+              </Text>
+            </Paper>
+          ))}
+      </Flex>
     </Flex>
   )
 }

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
 
+import { useCurrentUserId } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { exploreMessages as messages } from '@audius/common/messages'
 import { FeatureFlags } from '@audius/common/services'
@@ -110,6 +111,8 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
   const showSearchResults = useShowSearchResults()
   const [tracksLayout, setTracksLayout] = useState<ViewLayout>('list')
   const searchBarRef = useRef<HTMLInputElement>(null)
+  const { data: currentUserId, isLoading: isCurrentUserIdLoading } =
+    useCurrentUserId()
   const { motion } = useTheme()
   const { isLarge } = useMedia()
   const { isEnabled: isSearchExploreGoodiesEnabled } = useFeatureFlag(
@@ -188,6 +191,7 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
     img.onload = () => setBannerIsVisible(true)
   }, [])
 
+  const showUserContextualContent = isCurrentUserIdLoading || !!currentUserId
   const showTrackContent = categoryKey === 'tracks' || categoryKey === 'all'
   const showPlaylistContent =
     categoryKey === 'playlists' || categoryKey === 'all'
@@ -304,8 +308,12 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
         >
           {isSearchExploreGoodiesEnabled ? (
             <>
-              {showTrackContent && <RecommendedTracksSection />}
-              {showTrackContent && <RecentlyPlayedSection />}
+              {showTrackContent && showUserContextualContent && (
+                <RecommendedTracksSection />
+              )}
+              {showTrackContent && showUserContextualContent && (
+                <RecentlyPlayedSection />
+              )}
               {showTrackContent && <QuickSearchGrid />}
             </>
           ) : null}
@@ -328,10 +336,12 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
               {showTrackContent && <MostSharedSection />}
               {(showTrackContent || showAlbumContent) && <BestSellingSection />}
               {showTrackContent && <RecentPremiumTracksSection />}
-              {showTrackContent && <FeelingLuckySection />}
+              {showTrackContent && showUserContextualContent && (
+                <FeelingLuckySection />
+              )}
             </>
           ) : null}
-          <RecentSearchesSection />
+          {showUserContextualContent && <RecentSearchesSection />}
         </Flex>
       </Flex>
     </Flex>

--- a/packages/web/src/pages/explore-page/components/desktop/QuickSearchGrid.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/QuickSearchGrid.tsx
@@ -12,8 +12,6 @@ import { useIsMobile } from 'hooks/useIsMobile'
 import { useSearchCategory } from 'pages/search-page/hooks'
 import { MOODS } from 'pages/search-page/moods'
 
-import { useDeferredElement } from './useDeferredElement'
-
 const QuickSearchPresetButton = ({
   preset,
   onClick
@@ -103,7 +101,6 @@ const QuickSearchPresetButton = ({
 }
 
 export const QuickSearchGrid = () => {
-  const { ref, inView } = useDeferredElement()
   const isMobile = useIsMobile()
   const [, setCategory] = useSearchCategory()
 
@@ -122,36 +119,26 @@ export const QuickSearchGrid = () => {
 
   return (
     <Flex
-      ref={ref}
       direction='column'
       gap={isMobile ? 'l' : 'xl'}
       alignItems='center'
       mh='l'
     >
-      {!inView ? null : (
-        <>
-          <Text
-            variant={isMobile ? 'title' : 'heading'}
-            size={isMobile ? 'l' : 'm'}
-          >
-            {messages.quickSearch}
-          </Text>
-          <Flex
-            gap='s'
-            justifyContent='center'
-            alignItems='flex-start'
-            wrap='wrap'
-          >
-            {QUICK_SEARCH_PRESETS.map((preset, idx) => (
-              <QuickSearchPresetButton
-                key={idx}
-                onClick={() => handleClickPreset(preset)}
-                preset={preset}
-              />
-            ))}
-          </Flex>
-        </>
-      )}
+      <Text
+        variant={isMobile ? 'title' : 'heading'}
+        size={isMobile ? 'l' : 'm'}
+      >
+        {messages.quickSearch}
+      </Text>
+      <Flex gap='s' justifyContent='center' alignItems='flex-start' wrap='wrap'>
+        {QUICK_SEARCH_PRESETS.map((preset, idx) => (
+          <QuickSearchPresetButton
+            key={idx}
+            onClick={() => handleClickPreset(preset)}
+            preset={preset}
+          />
+        ))}
+      </Flex>
     </Flex>
   )
 }

--- a/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
@@ -7,6 +7,7 @@ import {
   ChangeEvent
 } from 'react'
 
+import { useCurrentUserId } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { exploreMessages as messages } from '@audius/common/messages'
 import { FeatureFlags } from '@audius/common/services'
@@ -78,6 +79,8 @@ const ExplorePage = () => {
   const showSearchResults = useShowSearchResults()
   const [tracksLayout] = useState<ViewLayout>('list')
   const searchBarRef = useRef<HTMLInputElement>(null)
+  const { data: currentUserId, isLoading: isCurrentUserIdLoading } =
+    useCurrentUserId()
 
   const { isEnabled: isSearchExploreGoodiesEnabled } = useFeatureFlag(
     FeatureFlags.SEARCH_EXPLORE_GOODIES
@@ -157,6 +160,7 @@ const ExplorePage = () => {
     setCenter(CenterPreset.LOGO)
   }, [setLeft, setCenter, setRight])
 
+  const showUserContextualContent = isCurrentUserIdLoading || !!currentUserId
   const showTrackContent = categoryKey === 'tracks' || categoryKey === 'all'
   const showPlaylistContent =
     categoryKey === 'playlists' || categoryKey === 'all'
@@ -225,8 +229,12 @@ const ExplorePage = () => {
         >
           {isSearchExploreGoodiesEnabled && showTrackContent && (
             <>
-              {showTrackContent && <RecommendedTracksSection />}
-              {showTrackContent && <RecentlyPlayedSection />}
+              {showTrackContent && showUserContextualContent && (
+                <RecommendedTracksSection />
+              )}
+              {showTrackContent && showUserContextualContent && (
+                <RecentlyPlayedSection />
+              )}
               <QuickSearchGrid />
             </>
           )}
@@ -251,10 +259,12 @@ const ExplorePage = () => {
               {showTrackContent && <MostSharedSection />}
               {(showAlbumContent || showTrackContent) && <BestSellingSection />}
               {showTrackContent && <RecentPremiumTracksSection />}
-              {showTrackContent && <FeelingLuckySection />}
+              {showTrackContent && showUserContextualContent && (
+                <FeelingLuckySection />
+              )}
             </>
           ) : null}
-          <RecentSearchesSection />
+          {showUserContextualContent && <RecentSearchesSection />}
         </Flex>
       </Flex>
     </MobilePageContainer>


### PR DESCRIPTION
### Description
Skip rendering the sections that are specific to the current logged in user if there isn't one. Also decided to remove the inView checks for quick search and moods since they don't fetch data and the intersection observer was causing them to flash nothing on their first render.

### How Has This Been Tested?
Local web/mobile web clients against staging, both logged in an incognito.
