### PR TITLE
[QA-2163] Delete collections with tan-query

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -16,6 +16,7 @@ export * from './tan-query/collection/useCollectionTracksWithUid'
 export * from './tan-query/collection/useFeaturedPlaylists'
 export * from './tan-query/collection/useLibraryCollections'
 export * from './tan-query/collection/useCollectionByParams'
+export * from './tan-query/collection/useDeleteCollection'
 
 // Coins
 export * from './tan-query/coins/useArtistCoin'

--- a/packages/common/src/api/tan-query/collection/useDeleteCollection.ts
+++ b/packages/common/src/api/tan-query/collection/useDeleteCollection.ts
@@ -9,6 +9,7 @@ import { Feature } from '~/models/ErrorReporting'
 import { ID } from '~/models/Identifiers'
 import { accountActions } from '~/store'
 
+import { QUERY_KEYS } from '../queryKeys'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { primeCollectionData } from '../utils/primeCollectionData'
 
@@ -98,20 +99,6 @@ export const useDeleteCollection = () => {
           queryClient,
           forceReplace: true
         })
-
-        // Re-add to account playlists
-        dispatch(
-          accountActions.addAccountPlaylist({
-            id: collection.playlist_id,
-            name: collection.playlist_name,
-            is_album: collection.is_album,
-            user: {
-              id: collection.playlist_owner_id,
-              handle: collection.user?.handle || ''
-            },
-            permalink: collection.permalink
-          })
-        )
       }
 
       reportToSentry({
@@ -131,7 +118,7 @@ export const useDeleteCollection = () => {
 
       // Invalidate library collections to remove from user's library
       queryClient.invalidateQueries({
-        queryKey: ['libraryCollections']
+        queryKey: QUERY_KEYS.libraryCollections
       })
     }
   })

--- a/packages/common/src/api/tan-query/collection/useDeleteCollection.ts
+++ b/packages/common/src/api/tan-query/collection/useDeleteCollection.ts
@@ -1,0 +1,138 @@
+import { Id } from '@audius/sdk'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useDispatch } from 'react-redux'
+
+import { useQueryContext } from '~/api/tan-query/utils'
+import { useAppContext } from '~/context/appContext'
+import { Name } from '~/models/Analytics'
+import { Feature } from '~/models/ErrorReporting'
+import { ID } from '~/models/Identifiers'
+import { accountActions } from '~/store'
+
+import { useCurrentUserId } from '../users/account/useCurrentUserId'
+import { primeCollectionData } from '../utils/primeCollectionData'
+
+import { getCollectionQueryKey } from './useCollection'
+
+type DeleteCollectionArgs = {
+  collectionId: ID
+  source?: string
+}
+
+type MutationContext = {
+  previousCollection: any | undefined
+}
+
+export const useDeleteCollection = () => {
+  const { audiusSdk, reportToSentry } = useQueryContext()
+  const queryClient = useQueryClient()
+  const dispatch = useDispatch()
+  const { data: currentUserId } = useCurrentUserId()
+  const {
+    analytics: { track: trackEvent }
+  } = useAppContext()
+
+  return useMutation({
+    mutationFn: async ({ collectionId }: DeleteCollectionArgs) => {
+      if (!currentUserId) throw new Error('User ID is required')
+      const sdk = await audiusSdk()
+
+      await sdk.playlists.deletePlaylist({
+        playlistId: Id.parse(collectionId),
+        userId: Id.parse(currentUserId)
+      })
+
+      return { collectionId }
+    },
+    onMutate: async ({ collectionId, source }): Promise<MutationContext> => {
+      if (!currentUserId) {
+        throw new Error('User ID is required')
+      }
+
+      // Cancel any outgoing refetches
+      await queryClient.cancelQueries({
+        queryKey: getCollectionQueryKey(collectionId)
+      })
+
+      // Snapshot the previous values
+      const previousCollection = queryClient.getQueryData(
+        getCollectionQueryKey(collectionId)
+      )
+      if (!previousCollection) throw new Error('Collection not found')
+
+      // Analytics tracking
+      trackEvent({
+        eventName: Name.DELETE,
+        properties: {
+          kind: previousCollection.is_album ? 'album' : 'playlist',
+          id: collectionId,
+          source
+        }
+      })
+
+      // Optimistic updates - mark as deleted in cache
+      primeCollectionData({
+        collections: [
+          {
+            ...previousCollection,
+            is_delete: true
+          } as any
+        ],
+        queryClient,
+        forceReplace: true
+      })
+
+      // Remove from account playlists
+      dispatch(accountActions.removeAccountPlaylist({ collectionId }))
+
+      return { previousCollection }
+    },
+    onError: (error, { collectionId }, context?: MutationContext) => {
+      // Roll back optimistic updates if the mutation fails
+      if (context?.previousCollection) {
+        const collection = context.previousCollection
+
+        // Restore collection data
+        primeCollectionData({
+          collections: [collection],
+          queryClient,
+          forceReplace: true
+        })
+
+        // Re-add to account playlists
+        dispatch(
+          accountActions.addAccountPlaylist({
+            id: collection.playlist_id,
+            name: collection.playlist_name,
+            is_album: collection.is_album,
+            user: {
+              id: collection.playlist_owner_id,
+              handle: collection.user?.handle || ''
+            },
+            permalink: collection.permalink
+          })
+        )
+      }
+
+      reportToSentry({
+        error,
+        additionalInfo: {
+          collectionId
+        },
+        feature: Feature.Edit,
+        name: 'Delete Collection'
+      })
+    },
+    onSuccess: async (_, { collectionId }) => {
+      // Invalidate and refetch collection queries to ensure cache consistency
+      queryClient.invalidateQueries({
+        queryKey: getCollectionQueryKey(collectionId)
+      })
+
+      // Invalidate library collections to remove from user's library
+      queryClient.invalidateQueries({
+        queryKey: ['libraryCollections']
+      })
+    }
+  })
+}

--- a/packages/common/src/store/cache/collections/actions.ts
+++ b/packages/common/src/store/cache/collections/actions.ts
@@ -23,10 +23,6 @@ export const ORDER_PLAYLIST_FAILED = 'ORDER_PLAYLIST_FAILED'
 
 export const PUBLISH_PLAYLIST = 'PUBLISH_PLAYLIST'
 export const PUBLISH_PLAYLIST_FAILED = 'PUBLISH_PLAYLIST_FAILED'
-export const DELETE_PLAYLIST = 'DELETE_PLAYLIST'
-export const DELETE_PLAYLIST_REQUESTED = 'DELETE_PLAYLIST_REQUESTED'
-export const DELETE_PLAYLIST_SUCCEEDED = 'DELETE_PLAYLIST_SUCCEEDED'
-export const DELETE_PLAYLIST_FAILED = 'DELETE_PLAYLIST_FAILED'
 
 /**
  * @param initTrackId optional track id to pull artwork from.
@@ -168,24 +164,4 @@ export function publishPlaylistFailed(
   metadata: Record<string, unknown>
 ) {
   return { type: PUBLISH_PLAYLIST_FAILED, error, params, metadata }
-}
-
-export function deletePlaylist(playlistId: ID) {
-  return { type: DELETE_PLAYLIST, playlistId }
-}
-
-export function deletePlaylistRequested() {
-  return { type: DELETE_PLAYLIST_REQUESTED }
-}
-
-export function deletePlaylistSucceeded() {
-  return { type: DELETE_PLAYLIST_SUCCEEDED }
-}
-
-export function deletePlaylistFailed(
-  error: Error,
-  params: Record<string, unknown>,
-  metadata: Record<string, unknown>
-) {
-  return { type: DELETE_PLAYLIST_FAILED, error, params, metadata }
 }

--- a/packages/mobile/src/components/delete-playlist-confirmation-drawer/DeletePlaylistConfirmationDrawer.tsx
+++ b/packages/mobile/src/components/delete-playlist-confirmation-drawer/DeletePlaylistConfirmationDrawer.tsx
@@ -33,10 +33,7 @@ export const DeletePlaylistConfirmationDrawer = () => {
     if (playlistId) {
       try {
         // Use the TanStack Query mutation for optimistic updates
-        await deleteCollection({
-          collectionId: playlistId,
-          source: 'delete_playlist_confirmation_drawer'
-        })
+        await deleteCollection({ collectionId: playlistId })
         onClose()
         navigation.goBack()
       } catch (error) {

--- a/packages/mobile/src/components/drawers/ConfirmationDrawer.tsx
+++ b/packages/mobile/src/components/drawers/ConfirmationDrawer.tsx
@@ -19,6 +19,7 @@ export type BaseConfirmationDrawerProps = {
     header: string
     description: string
     confirm: string
+    confirmLoading?: string
     cancel?: string
   }
   onConfirm: () => void
@@ -27,6 +28,7 @@ export type BaseConfirmationDrawerProps = {
   icon?: IconComponent
   addBottomInset?: boolean
   children?: ReactNode | ReactNode[]
+  isConfirming?: boolean
 }
 
 type NativeConfirmationDrawerProps = BaseConfirmationDrawerProps & {
@@ -54,7 +56,8 @@ export const ConfirmationDrawerContent = (props: DrawerContentProps) => {
     variant = 'destructive',
     icon: Icon,
     addBottomInset,
-    children
+    children,
+    isConfirming = false
   } = props
   const messages = { ...defaultMessages, ...messagesProp }
   const insets = useSafeAreaInsets()
@@ -88,10 +91,19 @@ export const ConfirmationDrawerContent = (props: DrawerContentProps) => {
           variant={variant === 'destructive' ? 'destructive' : 'primary'}
           fullWidth
           onPress={handleConfirm}
+          disabled={isConfirming}
+          isLoading={isConfirming}
         >
-          {messages.confirm}
+          {isConfirming && messages.confirmLoading
+            ? messages.confirmLoading
+            : messages.confirm}
         </Button>
-        <Button variant='secondary' fullWidth onPress={handleCancel}>
+        <Button
+          variant='secondary'
+          fullWidth
+          onPress={handleCancel}
+          disabled={isConfirming}
+        >
           {messages.cancel}
         </Button>
       </Flex>

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useEffect } from 'react'
 
 import {
   useCollectionByParams,
@@ -75,6 +75,7 @@ const useStyles = makeStyles(({ spacing }) => ({
  */
 export const CollectionScreen = () => {
   const { params } = useRoute<'Collection'>()
+  const navigation = useNavigation()
 
   // params is incorrectly typed and can sometimes be undefined
   const {
@@ -93,6 +94,19 @@ export const CollectionScreen = () => {
 
   const collection = cachedCollection ?? searchCollection
   const user = cachedUser ?? searchCollection?.user
+
+  const isDeleted = collection?.is_delete
+  const isMarkedDeleted =
+    collection && '_marked_deleted' in collection
+      ? collection._marked_deleted
+      : false
+
+  // Navigate back if collection is deleted or marked for deletion
+  useEffect(() => {
+    if (isDeleted || isMarkedDeleted) {
+      navigation.goBack()
+    }
+  }, [isDeleted, isMarkedDeleted, navigation])
 
   if (!collection || !user) {
     return <CollectionScreenSkeleton collectionType={collectionType} />

--- a/packages/web/src/common/store/cache/collections/errorSagas.ts
+++ b/packages/web/src/common/store/cache/collections/errorSagas.ts
@@ -8,7 +8,6 @@ type CollectionErrors =
   | ReturnType<typeof cacheCollectionsActions.addTrackToPlaylistFailed>
   | ReturnType<typeof cacheCollectionsActions.removeTrackFromPlaylistFailed>
   | ReturnType<typeof cacheCollectionsActions.orderPlaylistFailed>
-  | ReturnType<typeof cacheCollectionsActions.deletePlaylistFailed>
   | ReturnType<typeof cacheCollectionsActions.publishPlaylistFailed>
 
 const errorSagas = createErrorSagas<CollectionErrors>({
@@ -18,7 +17,6 @@ const errorSagas = createErrorSagas<CollectionErrors>({
     cacheCollectionsActions.ADD_TRACK_TO_PLAYLIST_FAILED,
     cacheCollectionsActions.REMOVE_TRACK_FROM_PLAYLIST_FAILED,
     cacheCollectionsActions.ORDER_PLAYLIST_FAILED,
-    cacheCollectionsActions.DELETE_PLAYLIST_FAILED,
     cacheCollectionsActions.PUBLISH_PLAYLIST_FAILED
   ],
   getShouldRedirect: () => false,

--- a/packages/web/src/components/delete-confirmation/DeleteConfirmationModal.tsx
+++ b/packages/web/src/components/delete-confirmation/DeleteConfirmationModal.tsx
@@ -13,7 +13,8 @@ const messages = {
   description: (entity: string) =>
     `Are you sure you want to delete this ${entity.toLowerCase()}?`,
   cancel: 'Cancel',
-  delete: (entity: string) => `Delete ${entity}`
+  delete: (entity: string) => `Delete ${entity}`,
+  deleting: `Deleting`
 }
 
 export type DeleteConfirmationModalProps = {
@@ -24,6 +25,7 @@ export type DeleteConfirmationModalProps = {
   entity: string
   onDelete: () => void
   onCancel: () => void
+  isDeleting?: boolean
 }
 
 const DeleteConfirmationModal = (props: DeleteConfirmationModalProps) => {
@@ -34,7 +36,8 @@ const DeleteConfirmationModal = (props: DeleteConfirmationModalProps) => {
     description = messages.description(entity),
     visible,
     onDelete,
-    onCancel
+    onCancel,
+    isDeleting = false
   } = props
 
   return (
@@ -49,11 +52,21 @@ const DeleteConfirmationModal = (props: DeleteConfirmationModalProps) => {
         </div>
       </ModalContent>
       <ModalFooter>
-        <Button variant='secondary' onClick={onCancel} fullWidth>
+        <Button
+          variant='secondary'
+          onClick={onCancel}
+          fullWidth
+          disabled={isDeleting}
+        >
           {messages.cancel}
         </Button>
-        <Button variant='destructive' onClick={onDelete} fullWidth>
-          {messages.delete(entity)}
+        <Button
+          variant='destructive'
+          onClick={onDelete}
+          fullWidth
+          isLoading={isDeleting}
+        >
+          {isDeleting ? messages.deleting : messages.delete(entity)}
         </Button>
       </ModalFooter>
     </Modal>

--- a/packages/web/src/components/delete-playlist-confirmation-modal/DeletePlaylistConfirmationModal.tsx
+++ b/packages/web/src/components/delete-playlist-confirmation-modal/DeletePlaylistConfirmationModal.tsx
@@ -35,10 +35,7 @@ const DeletePlaylistConfirmationModal = () => {
 
   const handleDelete = useCallback(async () => {
     try {
-      await deleteCollection({
-        collectionId: playlistId,
-        source: 'delete_playlist_confirmation_modal'
-      })
+      await deleteCollection({ collectionId: playlistId })
       setStackReset(true)
       // Navigate to trending page after successful deletion
       dispatch(push(TRENDING_PAGE))

--- a/packages/web/src/components/edit-collection/DeleteCollectionConfirmationModal.tsx
+++ b/packages/web/src/components/edit-collection/DeleteCollectionConfirmationModal.tsx
@@ -1,10 +1,8 @@
 import { useCallback } from 'react'
 
-import { useCurrentAccount } from '@audius/common/api'
+import { useCurrentAccount, useDeleteCollection } from '@audius/common/api'
 import { ID } from '@audius/common/models'
-import { cacheCollectionsActions } from '@audius/common/store'
 import { route } from '@audius/common/utils'
-import { useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { useLastLocation } from 'react-router-last-location'
 import { SetRequired } from 'type-fest'
@@ -13,7 +11,6 @@ import { DeleteConfirmationModal } from 'components/delete-confirmation'
 import { DeleteConfirmationModalProps } from 'components/delete-confirmation/DeleteConfirmationModal'
 
 const { FEED_PAGE } = route
-const { deletePlaylist } = cacheCollectionsActions
 
 const messages = {
   edit: 'Edit',
@@ -45,25 +42,43 @@ export const DeleteCollectionConfirmationModal = (
     select: (account) => account?.collections?.[collectionId]
   })
   const { is_album, permalink } = accountCollection ?? {}
-  const dispatch = useDispatch()
+  const { mutateAsync: deleteCollection, isPending } = useDeleteCollection()
 
-  const handleDelete = useCallback(() => {
-    dispatch(deletePlaylist(collectionId))
-    onDelete?.()
-    if (lastLocation?.pathname === permalink) {
-      history.replace(FEED_PAGE)
+  const handleDelete = useCallback(async () => {
+    try {
+      await deleteCollection({
+        collectionId,
+        source: 'delete_collection_confirmation_modal'
+      })
+      onDelete?.()
+
+      if (lastLocation?.pathname === permalink) {
+        history.replace(FEED_PAGE)
+      }
+    } catch (error) {
+      console.error('Failed to delete collection:', error)
+      // Error is handled by the mutation's onError callback
     }
-  }, [dispatch, collectionId, onDelete, lastLocation, permalink, history])
+  }, [
+    deleteCollection,
+    collectionId,
+    onDelete,
+    lastLocation?.pathname,
+    permalink,
+    history
+  ])
+
+  const entity = is_album ? messages.type.album : messages.type.playlist
+  const title = `${messages.delete} ${is_album ? messages.title.album : messages.title.playlist}`
 
   return (
     <DeleteConfirmationModal
-      title={`${messages.delete} ${
-        is_album ? messages.title.album : messages.title.playlist
-      }`}
-      entity={is_album ? messages.type.album : messages.type.playlist}
+      title={title}
+      entity={entity}
       visible={visible}
       onCancel={onCancel}
       onDelete={handleDelete}
+      isDeleting={isPending}
     />
   )
 }

--- a/packages/web/src/components/edit-collection/DeleteCollectionConfirmationModal.tsx
+++ b/packages/web/src/components/edit-collection/DeleteCollectionConfirmationModal.tsx
@@ -42,7 +42,8 @@ export const DeleteCollectionConfirmationModal = (
     select: (account) => account?.collections?.[collectionId]
   })
   const { is_album, permalink } = accountCollection ?? {}
-  const { mutateAsync: deleteCollection, isPending } = useDeleteCollection()
+  const { mutateAsync: deleteCollection, isPending: isDeleting } =
+    useDeleteCollection()
 
   const handleDelete = useCallback(async () => {
     try {
@@ -78,7 +79,7 @@ export const DeleteCollectionConfirmationModal = (
       visible={visible}
       onCancel={onCancel}
       onDelete={handleDelete}
-      isDeleting={isPending}
+      isDeleting={isDeleting}
     />
   )
 }

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -108,8 +108,7 @@ const {
   editPlaylist,
   removeTrackFromPlaylist,
   orderPlaylist,
-  publishPlaylist,
-  deletePlaylist
+  publishPlaylist
 } = cacheCollectionsActions
 
 type OwnProps = {
@@ -906,8 +905,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(orderPlaylist(playlistId, trackIds, trackUids)),
     publishPlaylist: (playlistId: number) =>
       dispatch(publishPlaylist(playlistId)),
-    deletePlaylist: (playlistId: number) =>
-      dispatch(deletePlaylist(playlistId)),
 
     saveCollection: (playlistId: number) =>
       dispatch(


### PR DESCRIPTION
### Description

Noticing some fairly gross optimistic updates when deleting playlists, especially in mobile. Went ahead and implemented useDeleteCollection and removed all the related redux logic.

Changes:
add useDeleteCollection
use useDeleteCollection in all the confirmation modals/drawers
Update confirmation-drawers to have optional loading state
Removed all redux logic