### PR TITLE
[PE-6605] Add dropdown menu to artist coins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "pg": "8.8.0",
         "pino": "^9.1.0",
         "react-native-google-cast": "4.6.2",
+        "react-select": "^5.10.1",
         "valtio": "1.13.2"
       },
       "devDependencies": {
@@ -8379,7 +8380,6 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.1.3"
@@ -8387,7 +8387,6 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.5.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.4.2",
@@ -8408,7 +8407,6 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.1.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@gar/promisify": {
@@ -43707,7 +43705,6 @@
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -89168,9 +89165,9 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.8.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.1.tgz",
+      "integrity": "sha512-roPEZUL4aRZDx6DcsD+ZNreVl+fM8VsKn0Wtex1v4IazH60ILp5xhdlp464IsEAlJdXeD+BhDAFsBVMfvLQueA==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -89180,11 +89177,11 @@
         "memoize-one": "^6.0.0",
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0",
-        "use-isomorphic-layout-effect": "^1.1.2"
+        "use-isomorphic-layout-effect": "^1.2.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-shallow-renderer": {
@@ -89292,7 +89289,6 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
@@ -104564,11 +104560,11 @@
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "pg": "8.8.0",
     "pino": "^9.1.0",
     "react-native-google-cast": "4.6.2",
-    "react-select": "^5.10.1",
+    "react-select": "5.10.1",
     "valtio": "1.13.2"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
   },
   "dependencies": {
     "@audius/hedgehog": "3.0.0-alpha.1",
-    "@babel/core": "7.23.7",
     "@babel/compat-data": "7.27.1",
+    "@babel/core": "7.23.7",
     "@babel/generator": "7.27.1",
     "@babel/helper-compilation-targets": "7.27.1",
     "@babel/helper-module-transforms": "7.27.1",
@@ -121,11 +121,12 @@
     "@types/express": "^4.17.21",
     "@wagmi/core": "2.16.7",
     "dotenv": "^16.4.5",
+    "elliptic": "6.6.1",
     "express": "^4.19.2",
     "pg": "8.8.0",
     "pino": "^9.1.0",
     "react-native-google-cast": "4.6.2",
-    "elliptic": "6.6.1",
+    "react-select": "^5.10.1",
     "valtio": "1.13.2"
   },
   "resolutions": {

--- a/packages/web/src/components/buy-sell-modal/DropdownSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/DropdownSection.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useCallback, useRef } from 'react'
+
+import { buySellMessages as messages } from '@audius/common/messages'
+import {
+  DEFAULT_TOKEN_AMOUNT_PLACEHOLDER,
+  TokenInfo
+} from '@audius/common/store'
+import { Flex, IconCaretDown, Text } from '@audius/harmony'
+import { useTheme, css } from '@emotion/react'
+import Select, { components } from 'react-select'
+import type { SingleValue, SingleValueProps, OptionProps } from 'react-select'
+
+import { TokenIcon } from './TokenIcon'
+
+type TokenOption = {
+  value: string
+  label: string
+  tokenInfo: TokenInfo
+}
+
+type DropdownSectionProps = {
+  isStablecoin?: boolean
+  formattedAvailableBalance: string | null
+  tokenInfo: TokenInfo
+  availableTokens?: TokenInfo[]
+  onTokenChange?: (symbol: string) => void
+  showReceiveAmount?: boolean
+  formattedReceiveAmount?: string
+}
+
+type CustomSingleValueProps = {
+  symbol: string
+  isStablecoin?: boolean
+  hasReceiveAmount: boolean
+  shouldShowLargeTicker: boolean
+  formattedAvailableBalance: string | null
+  formattedReceiveAmount?: string
+}
+
+const CustomSingleValue = (
+  props: SingleValueProps<TokenOption> & CustomSingleValueProps
+) => (
+  <components.SingleValue {...props}>
+    <Flex
+      gap='s'
+      alignItems='center'
+      justifyContent='space-between'
+      w='100%'
+      data-testid='token-selection-label'
+    >
+      <Flex gap='s' alignItems='center'>
+        <TokenIcon
+          tokenInfo={props.data.tokenInfo}
+          size='2xl'
+          hex
+          data-testid='token-icon'
+        />
+        <Flex direction='column'>
+          {props.shouldShowLargeTicker ? (
+            <Flex alignSelf='flex-start'>
+              <Text variant='heading' size='s' color='subdued'>
+                {messages.tokenTicker(props.symbol, !!props.isStablecoin)}
+              </Text>
+            </Flex>
+          ) : null}
+          {!props.hasReceiveAmount ? (
+            <Text variant='title' size='s' color='default'>
+              {messages.stackedBalance(props.formattedAvailableBalance!)}
+            </Text>
+          ) : null}
+          {props.hasReceiveAmount &&
+          props.formattedReceiveAmount !== DEFAULT_TOKEN_AMOUNT_PLACEHOLDER ? (
+            <Flex direction='column'>
+              <Text variant='heading' size='s'>
+                {props.formattedReceiveAmount}
+              </Text>
+              <Text variant='title' size='s' color='subdued'>
+                {messages.tokenTicker(props.symbol, !!props.isStablecoin)}
+              </Text>
+            </Flex>
+          ) : null}
+        </Flex>
+      </Flex>
+    </Flex>
+  </components.SingleValue>
+)
+
+const CustomOption = (props: OptionProps<TokenOption>) => {
+  const { spacing, cornerRadius, color } = useTheme()
+  const isSelected = props.isSelected
+
+  return (
+    <components.Option {...props}>
+      <Flex
+        gap='s'
+        alignItems='center'
+        data-testid={`token-option-${props.data.value.toLowerCase()}`}
+        css={css({
+          padding: spacing.s,
+          borderRadius: cornerRadius.s,
+          minHeight: spacing.unit10,
+          width: '100%',
+          backgroundColor: isSelected ? color.secondary.s300 : 'transparent',
+          color: isSelected ? color.static.white : 'inherit',
+          '&:hover': {
+            backgroundColor: color.secondary.s300,
+            '& *': {
+              color: `${color.static.white} !important`
+            }
+          }
+        })}
+      >
+        <TokenIcon
+          tokenInfo={props.data.tokenInfo}
+          size='l'
+          hex
+          data-testid={`token-option-icon-${props.data.value.toLowerCase()}`}
+        />
+        <Text
+          variant='body'
+          size='s'
+          strength='strong'
+          color={isSelected ? 'staticWhite' : 'default'}
+        >
+          {props.data.tokenInfo.symbol}
+        </Text>
+      </Flex>
+    </components.Option>
+  )
+}
+
+export const DropdownSection = ({
+  formattedAvailableBalance,
+  tokenInfo,
+  isStablecoin,
+  availableTokens,
+  onTokenChange,
+  showReceiveAmount,
+  formattedReceiveAmount
+}: DropdownSectionProps) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const { color, spacing, shadows, cornerRadius } = useTheme()
+
+  const { symbol } = tokenInfo
+
+  const handleTokenSelect = useCallback(
+    (option: SingleValue<TokenOption>) => {
+      if (option) {
+        onTokenChange?.(option.value)
+      }
+    },
+    [onTokenChange]
+  )
+
+  // Show component if we have either available balance or receive amount to display
+  const hasReceiveAmount = showReceiveAmount && formattedReceiveAmount
+  const shouldShowLargeTicker =
+    !hasReceiveAmount ||
+    formattedReceiveAmount === DEFAULT_TOKEN_AMOUNT_PLACEHOLDER
+
+  const isClickable = !!(availableTokens && availableTokens.length > 0)
+
+  const options: TokenOption[] = useMemo(() => {
+    if (!availableTokens) return []
+    return availableTokens.map((token) => ({
+      value: token.symbol,
+      label: token.symbol,
+      tokenInfo: token
+    }))
+  }, [availableTokens])
+
+  // Current selected option
+  const selectedOption = useMemo(
+    () =>
+      options.find((option) => option.value === symbol) || {
+        value: symbol,
+        label: symbol,
+        tokenInfo
+      },
+    [options, symbol, tokenInfo]
+  )
+
+  if (!formattedAvailableBalance && !hasReceiveAmount) {
+    return null
+  }
+
+  return (
+    <Flex
+      ref={wrapperRef}
+      direction='column'
+      alignItems='flex-start'
+      justifyContent='center'
+      gap='xs'
+      flex={1}
+      alignSelf='stretch'
+      border='default'
+      pv='s'
+      ph='m'
+      borderRadius='s'
+      data-testid='dropdown-section-wrapper'
+      css={{
+        cursor: isClickable ? 'pointer' : 'default',
+        '&:hover': isClickable
+          ? {
+              backgroundColor: color.background.surface2
+            }
+          : undefined
+      }}
+    >
+      <Select<TokenOption>
+        value={selectedOption}
+        onChange={handleTokenSelect}
+        options={options}
+        isDisabled={!isClickable}
+        isSearchable={false}
+        data-testid='token-select'
+        components={{
+          SingleValue: (props: SingleValueProps<TokenOption>) => {
+            const { setValue, ...singleValueProps } = props
+            return (
+              <CustomSingleValue
+                {...singleValueProps}
+                setValue={setValue as any}
+                symbol={symbol}
+                isStablecoin={!!isStablecoin}
+                hasReceiveAmount={!!hasReceiveAmount}
+                shouldShowLargeTicker={shouldShowLargeTicker}
+                formattedAvailableBalance={formattedAvailableBalance}
+                formattedReceiveAmount={formattedReceiveAmount}
+              />
+            )
+          },
+          Option: (props: OptionProps<TokenOption>) => (
+            <CustomOption {...props} />
+          ),
+          DropdownIndicator: (props) => (
+            <components.DropdownIndicator {...props}>
+              <IconCaretDown size='s' color='default' />
+            </components.DropdownIndicator>
+          ),
+          IndicatorSeparator: null
+        }}
+        styles={{
+          container: (provided) => ({
+            ...provided,
+            width: '100%',
+            height: '100%'
+          }),
+          control: (provided) => ({
+            ...provided,
+            backgroundColor: 'transparent',
+            border: 'none',
+            boxShadow: 'none',
+            minHeight: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            cursor: isClickable ? 'pointer' : 'default',
+            '&:hover': {
+              border: 'none'
+            }
+          }),
+          menu: (provided) => ({
+            ...provided,
+            backgroundColor: color.background.white,
+            boxShadow: shadows.far,
+            borderRadius: cornerRadius.m,
+            padding: `${spacing.s} 0`,
+            border: `1px solid ${color.border.default}`
+          }),
+          menuList: (provided) => ({
+            ...provided,
+            padding: spacing.s,
+            maxHeight: 200,
+            overflowY: 'auto'
+          }),
+          option: (provided) => ({
+            ...provided,
+            backgroundColor: 'transparent',
+            color: color.text.default,
+            padding: 0,
+            '&:hover': {
+              backgroundColor: color.background.surface2
+            },
+            '&:active': {
+              backgroundColor: color.background.surface2
+            }
+          }),
+          singleValue: (provided) => ({
+            ...provided,
+            margin: 0,
+            padding: 0
+          }),
+          valueContainer: (provided) => ({
+            ...provided,
+            margin: 0,
+            padding: 0
+          })
+        }}
+      />
+    </Flex>
+  )
+}

--- a/packages/web/src/components/buy-sell-modal/DropdownSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/DropdownSection.tsx
@@ -169,7 +169,6 @@ export const DropdownSection = ({
     }))
   }, [availableTokens])
 
-  // Current selected option
   const selectedOption = useMemo(
     () =>
       options.find((option) => option.value === symbol) || {
@@ -280,7 +279,8 @@ export const DropdownSection = ({
             color: color.text.default,
             padding: 0,
             '&:hover': {
-              backgroundColor: color.background.surface2
+              backgroundColor: color.background.surface2,
+              cursor: 'pointer'
             },
             '&:active': {
               backgroundColor: color.background.surface2

--- a/packages/web/src/components/buy-sell-modal/DropdownSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/DropdownSection.tsx
@@ -41,20 +41,9 @@ const CustomSingleValue = (
   props: SingleValueProps<TokenOption> & CustomSingleValueProps
 ) => (
   <components.SingleValue {...props}>
-    <Flex
-      gap='s'
-      alignItems='center'
-      justifyContent='space-between'
-      w='100%'
-      data-testid='token-selection-label'
-    >
+    <Flex gap='s' alignItems='center' justifyContent='space-between' w='100%'>
       <Flex gap='s' alignItems='center'>
-        <TokenIcon
-          tokenInfo={props.data.tokenInfo}
-          size='2xl'
-          hex
-          data-testid='token-icon'
-        />
+        <TokenIcon tokenInfo={props.data.tokenInfo} size='2xl' hex />
         <Flex direction='column'>
           {props.shouldShowLargeTicker ? (
             <Flex alignSelf='flex-start'>
@@ -94,7 +83,6 @@ const CustomOption = (props: OptionProps<TokenOption>) => {
       <Flex
         gap='s'
         alignItems='center'
-        data-testid={`token-option-${props.data.value.toLowerCase()}`}
         css={css({
           padding: spacing.s,
           borderRadius: cornerRadius.s,
@@ -110,12 +98,7 @@ const CustomOption = (props: OptionProps<TokenOption>) => {
           }
         })}
       >
-        <TokenIcon
-          tokenInfo={props.data.tokenInfo}
-          size='l'
-          hex
-          data-testid={`token-option-icon-${props.data.value.toLowerCase()}`}
-        />
+        <TokenIcon tokenInfo={props.data.tokenInfo} size='l' hex />
         <Text
           variant='body'
           size='s'
@@ -196,7 +179,6 @@ export const DropdownSection = ({
       pv='s'
       ph='m'
       borderRadius='s'
-      data-testid='dropdown-section-wrapper'
       css={{
         cursor: isClickable ? 'pointer' : 'default',
         '&:hover': isClickable
@@ -212,7 +194,6 @@ export const DropdownSection = ({
         options={options}
         isDisabled={!isClickable}
         isSearchable={false}
-        data-testid='token-select'
         components={{
           SingleValue: (props: SingleValueProps<TokenOption>) => {
             const { setValue, ...singleValueProps } = props

--- a/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
@@ -1,9 +1,8 @@
-import { useMemo, useCallback, useState, useRef } from 'react'
+import { useMemo, useCallback } from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
 import { FeatureFlags } from '@audius/common/services'
 import {
-  DEFAULT_TOKEN_AMOUNT_PLACEHOLDER,
   TokenAmountSectionProps,
   TokenInfo,
   useTokenAmountFormatting,
@@ -13,19 +12,18 @@ import {
   Button,
   Divider,
   Flex,
-  IconCaretDown,
   IconTransaction,
   Text,
   TextInput,
   TokenAmountInput,
-  TokenAmountInputChangeHandler,
-  Popup
+  TokenAmountInputChangeHandler
 } from '@audius/harmony'
 import { useTheme } from '@emotion/react'
 import { TooltipPlacement } from 'antd/lib/tooltip'
 
 import { useFlag } from '../../hooks/useRemoteConfig'
 
+import { DropdownSection } from './DropdownSection'
 import { TokenIcon } from './TokenIcon'
 import { TooltipInfoIcon } from './TooltipInfoIcon'
 
@@ -80,194 +78,6 @@ const DefaultBalanceSection = ({
         {formattedAvailableBalance}
       </Text>
     </Flex>
-  )
-}
-
-const TokenSelectionPopup = ({
-  availableTokens,
-  activeTokenSymbol,
-  onTokenSelect,
-  onClose
-}: {
-  availableTokens: TokenInfo[]
-  activeTokenSymbol: string
-  onTokenSelect: (symbol: string) => void
-  onClose: () => void
-}) => {
-  const { spacing, color } = useTheme()
-
-  const handleTokenClick = useCallback(
-    (symbol: string) => {
-      onTokenSelect(symbol)
-      onClose()
-    },
-    [onTokenSelect, onClose]
-  )
-
-  const filteredTokens = availableTokens.filter(
-    (token) => token.symbol !== activeTokenSymbol
-  )
-
-  return (
-    <Flex direction='column' gap='xs' p='s'>
-      {filteredTokens.map((token) => {
-        const { symbol, name } = token
-
-        return (
-          <Button
-            key={symbol}
-            variant='tertiary'
-            onClick={() => handleTokenClick(symbol)}
-            css={{
-              justifyContent: 'flex-start',
-              padding: spacing.s,
-              '&:hover': {
-                backgroundColor: color.background.surface2
-              }
-            }}
-          >
-            <Flex gap='s' alignItems='center'>
-              <TokenIcon tokenInfo={token} size='l' hex />
-              <Flex direction='column' alignItems='flex-start'>
-                <Text variant='body' size='s' strength='strong'>
-                  {symbol}
-                </Text>
-                <Text variant='body' size='xs' color='subdued'>
-                  {name}
-                </Text>
-              </Flex>
-            </Flex>
-          </Button>
-        )
-      })}
-    </Flex>
-  )
-}
-
-const DropdownSection = ({
-  formattedAvailableBalance,
-  tokenInfo,
-  isStablecoin,
-  availableTokens,
-  onTokenChange,
-  showReceiveAmount,
-  formattedReceiveAmount
-}: BalanceSectionProps) => {
-  const [isPopupVisible, setIsPopupVisible] = useState(false)
-  const anchorRef = useRef<HTMLDivElement>(null)
-  const { color } = useTheme()
-
-  const { symbol } = tokenInfo
-
-  const handleClick = useCallback(() => {
-    if (availableTokens && availableTokens.length > 0) {
-      setIsPopupVisible(true)
-    }
-  }, [availableTokens])
-
-  const handleTokenSelect = useCallback(
-    (selectedSymbol: string) => {
-      onTokenChange?.(selectedSymbol)
-      setIsPopupVisible(false)
-    },
-    [onTokenChange]
-  )
-
-  const handlePopupClose = useCallback(() => {
-    setIsPopupVisible(false)
-  }, [])
-
-  // Show component if we have either available balance or receive amount to display
-  const hasReceiveAmount = showReceiveAmount && formattedReceiveAmount
-  const shouldShowLargeTicker =
-    !hasReceiveAmount ||
-    formattedReceiveAmount === DEFAULT_TOKEN_AMOUNT_PLACEHOLDER
-
-  if (!formattedAvailableBalance && !hasReceiveAmount) {
-    return null
-  }
-
-  const isClickable = availableTokens && availableTokens.length > 0
-
-  return (
-    <>
-      <Flex
-        ref={anchorRef}
-        direction='column'
-        alignItems='flex-start'
-        justifyContent='center'
-        gap='xs'
-        flex={1}
-        alignSelf='stretch'
-        border='default'
-        pv='s'
-        ph='m'
-        borderRadius='s'
-        onClick={isClickable ? handleClick : undefined}
-        css={{
-          cursor: isClickable ? 'pointer' : 'default',
-          '&:hover': isClickable
-            ? {
-                backgroundColor: color.background.surface2
-              }
-            : undefined
-        }}
-      >
-        <Flex
-          gap='s'
-          alignItems='center'
-          justifyContent='space-between'
-          w='100%'
-        >
-          <Flex gap='s' alignItems='center'>
-            <TokenIcon tokenInfo={tokenInfo} size='2xl' hex />
-            <Flex direction='column'>
-              {shouldShowLargeTicker ? (
-                <Flex alignSelf='flex-start'>
-                  <Text variant='heading' size='s' color='subdued'>
-                    {messages.tokenTicker(symbol, !!isStablecoin)}
-                  </Text>
-                </Flex>
-              ) : null}
-              {!hasReceiveAmount ? (
-                <Text variant='title' size='s' color='default'>
-                  {messages.stackedBalance(formattedAvailableBalance!)}
-                </Text>
-              ) : null}
-              {hasReceiveAmount &&
-              formattedReceiveAmount !== DEFAULT_TOKEN_AMOUNT_PLACEHOLDER ? (
-                <Flex direction='column'>
-                  <Text variant='heading' size='s'>
-                    {formattedReceiveAmount}
-                  </Text>
-                  <Text variant='title' size='s' color='subdued'>
-                    {messages.tokenTicker(symbol, !!isStablecoin)}
-                  </Text>
-                </Flex>
-              ) : null}
-            </Flex>
-          </Flex>
-          <IconCaretDown size='s' color='default' />
-        </Flex>
-      </Flex>
-
-      {isClickable && (
-        <Popup
-          isVisible={isPopupVisible}
-          onClose={handlePopupClose}
-          anchorRef={anchorRef}
-          anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-          transformOrigin={{ horizontal: 'right', vertical: 'top' }}
-        >
-          <TokenSelectionPopup
-            availableTokens={availableTokens}
-            activeTokenSymbol={symbol}
-            onTokenSelect={handleTokenSelect}
-            onClose={handlePopupClose}
-          />
-        </Popup>
-      )}
-    </>
   )
 }
 
@@ -527,7 +337,13 @@ export const TokenAmountSection = ({
       isArtistCoinsEnabled
     ) {
       return (
-        <Flex p='l' alignItems='center' gap='s' justifyContent='space-between'>
+        <Flex
+          p='l'
+          alignItems='center'
+          gap='s'
+          justifyContent='space-between'
+          data-testid='you-receive-section'
+        >
           <DropdownSection
             formattedAvailableBalance={formattedAvailableBalance}
             tokenInfo={tokenInfo}

--- a/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
@@ -337,13 +337,7 @@ export const TokenAmountSection = ({
       isArtistCoinsEnabled
     ) {
       return (
-        <Flex
-          p='l'
-          alignItems='center'
-          gap='s'
-          justifyContent='space-between'
-          data-testid='you-receive-section'
-        >
+        <Flex p='l' alignItems='center' gap='s' justifyContent='space-between'>
           <DropdownSection
             formattedAvailableBalance={formattedAvailableBalance}
             tokenInfo={tokenInfo}


### PR DESCRIPTION
### Description
This PR introduces the dropdown as seen in Figma. I also chose to add `react-select` as it works better than `antd/lib/select` with our `emotioncss` system.

### How Has This Been Tested?

`npm run web:prod` and play around with buy/sell with `artist_coins` flag enabled
