### PR TITLE
add best of section back to mobile if we aren't showing new explore content

### DIFF
--- a/packages/mobile/src/screens/explore-screen/components/BestOfAudiusTiles.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/BestOfAudiusTiles.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback, useMemo } from 'react'
+
+import { exploreMessages as messages } from '@audius/common/messages'
+
+import { Flex } from '@audius/harmony-native'
+import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
+import { useNavigation } from 'app/hooks/useNavigation'
+
+import {
+  useSearchCategory,
+  useSearchFilters
+} from '../../search-screen/searchState'
+import {
+  PREMIUM_TRACKS,
+  TRENDING_PLAYLISTS,
+  TRENDING_UNDERGROUND
+} from '../collections'
+
+import { ColorTile } from './ColorTile'
+import { ExploreSection } from './ExploreSection'
+
+const tiles = [TRENDING_PLAYLISTS, TRENDING_UNDERGROUND, PREMIUM_TRACKS]
+
+interface BestOfAudiusTilesProps {
+  isLoading?: boolean
+}
+
+export const BestOfAudiusTiles = ({
+  isLoading: externalLoading
+}: BestOfAudiusTilesProps) => {
+  const isUSDCPurchasesEnabled = useIsUSDCEnabled()
+  const [, setCategory] = useSearchCategory()
+  const [, setFilters] = useSearchFilters()
+  const { navigate } = useNavigation()
+  const filteredTiles = useMemo(
+    () =>
+      tiles.filter((tile) => {
+        const isPremiumTracksTile = tile.title === PREMIUM_TRACKS.title
+        return !isPremiumTracksTile || isUSDCPurchasesEnabled
+      }),
+    [isUSDCPurchasesEnabled]
+  )
+  const handleTilePress = useCallback(
+    (title: string) => {
+      if (title === PREMIUM_TRACKS.title) {
+        setCategory('tracks')
+        setFilters({ isPremium: true })
+      } else if (title === TRENDING_PLAYLISTS.title) {
+        navigate('TrendingPlaylists')
+      } else if (title === TRENDING_UNDERGROUND.title) {
+        navigate('TrendingUnderground')
+      }
+    },
+    [navigate, setCategory, setFilters]
+  )
+  return (
+    <ExploreSection title={messages.bestOfAudius} isLoading={externalLoading}>
+      <Flex gap='s'>
+        {filteredTiles.map((tile) => (
+          <ColorTile
+            style={{ flex: 1, flexBasis: '100%' }}
+            key={tile.title}
+            {...tile}
+            onPress={() => handleTilePress(tile.title)}
+          />
+        ))}
+      </Flex>
+    </ExploreSection>
+  )
+}

--- a/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
@@ -8,6 +8,7 @@ import { useSearchCategory } from 'app/screens/search-screen/searchState'
 
 import { ActiveDiscussions } from './ActiveDiscussions'
 import { ArtistSpotlight } from './ArtistSpotlight'
+import { BestOfAudiusTiles } from './BestOfAudiusTiles'
 import { BestSelling } from './BestSelling'
 import { FeaturedPlaylists } from './FeaturedPlaylists'
 import { FeaturedRemixContests } from './FeaturedRemixContests'
@@ -68,6 +69,7 @@ const MemoizedExploreContent = () => {
           {showTrackContent && <FeelingLucky />}
         </>
       ) : null}
+      {!isSearchExploreGoodiesEnabled && <BestOfAudiusTiles />}
       <RecentSearches />
     </ProgressiveScrollView>
   )


### PR DESCRIPTION
### Description
Semi-reverts a previous PR and shows the best of audius tiles on the explore page if the search/explore goodies flag isn't enabled.

### How Has This Been Tested?
Local simulator, feature flag off
