### PR TITLE
Fix left-align page container

### DIFF
--- a/packages/web/src/components/page/FlushPageContainer.tsx
+++ b/packages/web/src/components/page/FlushPageContainer.tsx
@@ -15,7 +15,10 @@ export const FlushPageContainer = (props: FlexProps) => {
         w='100%'
         css={{
           maxWidth: MAX_PAGE_WIDTH_PX,
-          minWidth: MIN_PAGE_WIDTH_PX
+          minWidth: MIN_PAGE_WIDTH_PX,
+          // Center content when viewport is wider than max content width
+          // Left-align when viewport is narrower than max content width
+          margin: '0 auto'
         }}
       >
         {children}


### PR DESCRIPTION
### Description

Fixes issue introduced where left-align applied for big screens too. Now we have center aligned until small viewport which becomes left-aligned