### PR TITLE
Fix trending playlists playback on web

### DIFF
--- a/packages/web/src/components/track/desktop/CollectionTile.tsx
+++ b/packages/web/src/components/track/desktop/CollectionTile.tsx
@@ -80,7 +80,7 @@ export type DesktopCollectionTileProps = {
   index: number
   size: TrackTileSize
   containerClassName?: string
-  togglePlay: () => void
+  togglePlay: (uid: UID, id: ID) => void
   playTrack: (uid: string) => void
   playingTrackId?: ID
   pauseTrack: () => void

--- a/packages/web/src/pages/explore-page/components/desktop/TrendingPlaylistsSection.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/TrendingPlaylistsSection.tsx
@@ -1,6 +1,6 @@
 import { useTrendingPlaylists, UseLineupQueryData } from '@audius/common/api'
 import { exploreMessages as messages } from '@audius/common/messages'
-import { ID, PlaybackSource, Status, UID } from '@audius/common/models'
+import { ID, Status, UID } from '@audius/common/models'
 import { Flex } from '@audius/harmony'
 import { full } from '@audius/sdk'
 import { ClassNames } from '@emotion/react'
@@ -73,9 +73,9 @@ const CollectionLineupCarousel = ({
   Tile
 }: {
   lineup: UseLineupQueryData['lineup']
-  play: (uid: UID, id: ID, source: PlaybackSource) => void
-  pause: (uid: UID, id: ID, source: PlaybackSource) => void
-  togglePlay: (uid: UID, id: ID, source: PlaybackSource) => void
+  play: (uid?: UID) => void
+  pause: () => void
+  togglePlay: (uid: UID, id: ID) => void
   size: TrackTileSize
   Tile: TileType
 }) => {
@@ -97,19 +97,9 @@ const CollectionLineupCarousel = ({
                 <Tile
                   ordered={true}
                   size={size}
-                  togglePlay={() =>
-                    togglePlay(
-                      item.uid,
-                      item.id,
-                      PlaybackSource.PLAYLIST_TILE_TRACK
-                    )
-                  }
-                  playTrack={() =>
-                    play(item.uid, item.id, PlaybackSource.PLAYLIST_TILE_TRACK)
-                  }
-                  pauseTrack={() =>
-                    pause(item.uid, item.id, PlaybackSource.PLAYLIST_TILE_TRACK)
-                  }
+                  togglePlay={togglePlay}
+                  playTrack={play}
+                  pauseTrack={pause}
                   id={item.id}
                   index={index}
                   isTrending={true}


### PR DESCRIPTION
### Description
Lineups
Are.
Gnarly.

I made a mistake when implementing this originally and we weren't letting the uid from the tracks inside the collection tiles to flow through to the actions. This was resulting in most of the playlists sending the wrong UID for playback, which would get ignored by the queue sagas and it would just call `next` can begin playing at the top of the trending playlists lineup.

### How Has This Been Tested?
Explore page on web, just click around in various trending playlists (including play buttons on track item rows) and make sure we correctly change the queued item. Also tested next/previous across collection boundaries and it matches the behavior from the trending playlists page.
