### PR TITLE
[PE-6643] Add unauth state for Wallet pages

### DIFF
--- a/packages/common/src/utils/route.ts
+++ b/packages/common/src/utils/route.ts
@@ -225,7 +225,6 @@ export const authenticatedRoutes = [
   SALES_PAGE,
   PAYMENTS_PAGE,
   WITHDRAWALS_PAGE,
-  WALLET_PAGE,
   ALL_COINS_PAGE
 ]
 

--- a/packages/web/src/components/nav/desktop/nav-items/WalletNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/nav-items/WalletNavItem.tsx
@@ -1,3 +1,6 @@
+import { useHasAccount } from '@audius/common/api'
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import { route } from '@audius/common/utils'
 import { IconWallet } from '@audius/harmony'
 
@@ -10,8 +13,18 @@ const messages = {
 }
 
 export const WalletNavItem = () => {
+  const hasAccount = useHasAccount()
+  const { isEnabled: isArtistCoinsEnabled } = useFeatureFlag(
+    FeatureFlags.ARTIST_COINS
+  )
+
   return (
-    <LeftNavLink leftIcon={IconWallet} to={WALLET_PAGE} restriction='none'>
+    <LeftNavLink
+      leftIcon={IconWallet}
+      to={WALLET_PAGE}
+      disabled={!hasAccount && !isArtistCoinsEnabled}
+      restriction={!hasAccount && !isArtistCoinsEnabled ? 'account' : 'none'}
+    >
       {messages.wallet}
     </LeftNavLink>
   )

--- a/packages/web/src/components/nav/desktop/nav-items/WalletNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/nav-items/WalletNavItem.tsx
@@ -1,4 +1,3 @@
-import { useHasAccount } from '@audius/common/api'
 import { route } from '@audius/common/utils'
 import { IconWallet } from '@audius/harmony'
 
@@ -11,14 +10,8 @@ const messages = {
 }
 
 export const WalletNavItem = () => {
-  const hasAccount = useHasAccount()
   return (
-    <LeftNavLink
-      leftIcon={IconWallet}
-      to={WALLET_PAGE}
-      disabled={!hasAccount}
-      restriction='account'
-    >
+    <LeftNavLink leftIcon={IconWallet} to={WALLET_PAGE} restriction='none'>
       {messages.wallet}
     </LeftNavLink>
   )

--- a/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
@@ -13,6 +13,7 @@ import { useModalState } from 'common/hooks/useModalState'
 import { componentWithErrorBoundary } from 'components/error-wrapper/componentWithErrorBoundary'
 import Skeleton from 'components/skeleton/Skeleton'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 
 import { AssetDetailProps } from '../types'
 
@@ -159,42 +160,42 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
   const dispatch = useDispatch()
   const isMobile = useIsMobile()
 
+  // Action destructuring
+  const { pressReceive, pressSend } = tokenDashboardPageActions
+
+  // Handler functions with account requirements - defined before early return
+  const handleBuySell = useRequiresAccountCallback(() => {
+    // Has balance - show buy/sell modal
+    openBuySellModal()
+  }, [openBuySellModal])
+
+  const handleAddCash = useRequiresAccountCallback(() => {
+    // No balance - show add cash modal (uses Coinflow)
+    openAddCashModal()
+  }, [openAddCashModal])
+
+  const handleReceive = useRequiresAccountCallback(() => {
+    if (isMobile) {
+      openTransferDrawer(true)
+    } else {
+      dispatch(pressReceive())
+    }
+  }, [isMobile, openTransferDrawer, dispatch, pressReceive])
+
+  const handleSend = useRequiresAccountCallback(() => {
+    if (isMobile) {
+      openTransferDrawer(true)
+    } else {
+      dispatch(pressSend())
+    }
+  }, [isMobile, openTransferDrawer, dispatch, pressSend])
+
   if (coinsLoading || !coin) {
     return <BalanceSectionSkeleton />
   }
 
   const title = coin.ticker ?? ''
   const logoURI = coin.logoUri
-
-  // Action destructuring
-  const { pressReceive, pressSend } = tokenDashboardPageActions
-
-  // Handler functions
-  const handleBuySell = () => {
-    // Has balance - show buy/sell modal
-    openBuySellModal()
-  }
-
-  const handleAddCash = () => {
-    // No balance - show add cash modal (uses Coinflow)
-    openAddCashModal()
-  }
-
-  const handleReceive = () => {
-    if (isMobile) {
-      openTransferDrawer(true)
-    } else {
-      dispatch(pressReceive())
-    }
-  }
-
-  const handleSend = () => {
-    if (isMobile) {
-      openTransferDrawer(true)
-    } else {
-      dispatch(pressSend())
-    }
-  }
 
   return (
     <Paper ph='xl' pv='l'>

--- a/packages/web/src/pages/wallet-page/WalletPage.tsx
+++ b/packages/web/src/pages/wallet-page/WalletPage.tsx
@@ -1,6 +1,8 @@
 import { useContext, useEffect } from 'react'
 
 import { useHasAccount } from '@audius/common/api'
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import { Flex, IconWallet } from '@audius/harmony'
 import { useTheme } from '@emotion/react'
 
@@ -23,6 +25,10 @@ export const WalletPage = () => {
   const { spacing } = useTheme()
   const hasAccount = useHasAccount()
 
+  const { isEnabled: isArtistCoinsEnabled } = useFeatureFlag(
+    FeatureFlags.ARTIST_COINS
+  )
+
   const { setLeft } = useContext(NavContext)!
   useEffect(() => {
     setLeft(LeftPreset.BACK)
@@ -33,8 +39,7 @@ export const WalletPage = () => {
     title: messages.title
   })
 
-  // If user doesn't have an account, show AllCoinsPage
-  if (!hasAccount) {
+  if (!hasAccount && isArtistCoinsEnabled) {
     return <AllCoinsPage />
   }
 

--- a/packages/web/src/pages/wallet-page/WalletPage.tsx
+++ b/packages/web/src/pages/wallet-page/WalletPage.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect } from 'react'
 
+import { useHasAccount } from '@audius/common/api'
 import { Flex, IconWallet } from '@audius/harmony'
 import { useTheme } from '@emotion/react'
 
@@ -9,6 +10,7 @@ import MobilePageContainer from 'components/mobile-page-container/MobilePageCont
 import NavContext, { LeftPreset } from 'components/nav/mobile/NavContext'
 import Page from 'components/page/Page'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { AllCoinsPage } from 'pages/all-coins-page/AllCoinsPage'
 import { CashWallet } from 'pages/pay-and-earn-page/components/CashWallet'
 import { YourCoins } from 'pages/pay-and-earn-page/components/YourCoins'
 
@@ -19,6 +21,7 @@ const messages = {
 export const WalletPage = () => {
   const isMobile = useIsMobile()
   const { spacing } = useTheme()
+  const hasAccount = useHasAccount()
 
   const { setLeft } = useContext(NavContext)!
   useEffect(() => {
@@ -29,6 +32,11 @@ export const WalletPage = () => {
   useMobileHeader({
     title: messages.title
   })
+
+  // If user doesn't have an account, show AllCoinsPage
+  if (!hasAccount) {
+    return <AllCoinsPage />
+  }
 
   const header = <Header primary={messages.title} icon={IconWallet} />
 


### PR DESCRIPTION
### Description
- Makes clicking any of the buttons on the Wallet pages when unauthed redirect 
- Shows the `AllCoinsPage` on the `Wallet` tab when unauthed

### How Has This Been Tested?

`npm run web:stage` and play around unauthed
