### PR TITLE
[PE-6656] Fix dupe playlist track uids

### DIFF
--- a/packages/common/src/api/tan-query/collection/useCollectionTracksWithUid.ts
+++ b/packages/common/src/api/tan-query/collection/useCollectionTracksWithUid.ts
@@ -15,7 +15,9 @@ export type CollectionTrackWithUid = TrackMetadata & {
  * NOTE: not an actual query hook, more of a selector
  */
 export const useCollectionTracksWithUid = (
-  collection: Pick<TQCollection, 'playlist_contents' | 'trackIds'> | undefined,
+  collection:
+    | Pick<TQCollection, 'playlist_contents' | 'trackIds' | 'playlist_id'>
+    | undefined,
   collectionUid: UID | undefined
 ) => {
   const collectionSource = Uid.fromString(collectionUid ?? '')?.source
@@ -33,7 +35,7 @@ export const useCollectionTracksWithUid = (
       .map((t, i) => {
         const { uid, track: trackId } = t ?? {}
         const trackUid = Uid.fromString(`${uid}`)
-        trackUid.source = `${collectionSource}:${trackUid.source}`
+        trackUid.source = `${collectionSource}:${trackUid.source}-${collection?.playlist_id}`
         trackUid.count = i
 
         if (!byId?.[trackId]) {
@@ -50,6 +52,7 @@ export const useCollectionTracksWithUid = (
     isPending,
     collection?.playlist_contents?.track_ids,
     collectionSource,
+    collection?.playlist_id,
     byId
   ])
 }


### PR DESCRIPTION
### Description

Add collection id to the uid generation to dedupe tracks in multiple playlists.

### How Has This Been Tested?

web:stage with cuba luba

<img width="891" height="645" alt="image" src="https://github.com/user-attachments/assets/7d8d940d-8011-48d5-b3c1-e4265832b2c5" />

