### PR TITLE
Web Search/Explore QA fixes

### DIFF
--- a/packages/common/src/api/tan-query/tracks/useRecentlyCommentedTracks.ts
+++ b/packages/common/src/api/tan-query/tracks/useRecentlyCommentedTracks.ts
@@ -58,6 +58,7 @@ export const useRecentlyCommentedTracks = (
       const { data = [] } = await sdk.full.tracks.getTracksWithRecentComments({
         ...args,
         userId: OptionalId.parse(currentUserId),
+        limit: pageSize,
         offset: pageParam
       })
 

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -11,11 +11,39 @@ import {
   useRequiresAccountOnClick
 } from 'hooks/useRequiresAccount'
 
+/**
+ * Helper function to check if the current path matches any of the provided paths
+ * @param params - Object containing path matching parameters
+ * @param params.currentPath - The current pathname from location
+ * @param params.pathsToMatch - Array of paths to check against
+ * @param params.exact - Whether to use exact matching or startsWith
+ * @returns true if any path matches, false otherwise
+ */
+const isPathMatch = ({
+  currentPath,
+  pathsToMatch,
+  exact
+}: {
+  currentPath: string
+  pathsToMatch: string[]
+  exact: boolean
+}): boolean => {
+  if (pathsToMatch.length === 0) return false
+
+  return pathsToMatch.some((path) => {
+    if (exact) {
+      return currentPath === path
+    }
+    return currentPath.startsWith(path)
+  })
+}
+
 export type LeftNavLinkProps = Omit<NavItemProps, 'isSelected'> & {
   to?: string
   disabled?: boolean
   restriction?: RestrictionType
   exact?: boolean
+  additionalPathMatches?: string[]
 }
 
 export const LeftNavLink = (props: LeftNavLinkProps) => {
@@ -26,16 +54,21 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
     onClick,
     restriction,
     exact = false,
+    additionalPathMatches = [],
     ...other
   } = props
   const location = useLocation()
   const dispatch = useDispatch()
   const isSelected = useMemo(() => {
-    if (exact) {
-      return to ? location.pathname === to : false
-    }
-    return to ? location.pathname.startsWith(to) : false
-  }, [to, location.pathname, exact])
+    const pathsToMatch = [to, ...additionalPathMatches].filter(
+      Boolean
+    ) as string[]
+    return isPathMatch({
+      currentPath: location.pathname,
+      pathsToMatch,
+      exact
+    })
+  }, [to, additionalPathMatches, location.pathname, exact])
 
   const requiresAccountOnClick = useRequiresAccountOnClick(
     (e) => {

--- a/packages/web/src/components/nav/desktop/nav-items/ExploreNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/nav-items/ExploreNavItem.tsx
@@ -7,7 +7,7 @@ import { LeftNavLink } from '../LeftNavLink'
 import { NavSpeakerIcon } from '../NavSpeakerIcon'
 import { useNavSourcePlayingStatus } from '../useNavSourcePlayingStatus'
 
-const { EXPLORE_PAGE } = route
+const { EXPLORE_PAGE, SEARCH_BASE_ROUTE } = route
 
 export const ExploreNavItem = () => {
   const playingFromRoute = useNavSourcePlayingStatus()
@@ -16,6 +16,7 @@ export const ExploreNavItem = () => {
     <LeftNavLink
       leftIcon={IconSearch}
       to={EXPLORE_PAGE}
+      additionalPathMatches={[SEARCH_BASE_ROUTE]}
       restriction='none'
       rightIcon={
         <NavSpeakerIcon

--- a/packages/web/src/pages/explore-page/components/desktop/MoodGrid.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/MoodGrid.tsx
@@ -17,7 +17,11 @@ export const MoodGrid = () => {
 
   const handleMoodPress = useCallback(
     (mood: Mood) => {
-      setCategory(category, { mood })
+      if (category === 'all') {
+        setCategory('tracks', { mood })
+      } else {
+        setCategory(category, { mood })
+      }
     },
     [category, setCategory]
   )

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -158,7 +158,9 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
     } else if (categoryKey === SearchTabs.ALL.toLowerCase()) {
       // clear filters when searching all
       const newParams = new URLSearchParams()
-      newParams.set('query', debouncedValue)
+      if (debouncedValue) {
+        newParams.set('query', debouncedValue)
+      }
       setSearchParams(newParams)
     }
   }, [


### PR DESCRIPTION
### Description
* Fix mood buttons doing nothing when clicked from 'All' category. I updated this to match mobile, where we set the category to 'tracks' if you are coming from the 'All' filter. It's invalid to search across all items with a mood, since profiles don't support it
* Fix empty `query=` when loading the explore page or clearing your search query
* Highlight 'Explore' nav item when the route begins with `/search`. I added support to `LeftNavLink` for passing additional paths to match, since it was set up to only allow matching on the `to` prop.
* Fix 'Active Discussions' loading dozens of items despite passing a limit. I missed wiring up the `pageSize` prop a few PRs ago 😅 

### How Has This Been Tested?
A lil' click here, a lil' click there.
