### PR TITLE
Parallelize and cache user pubkeys in chat create

### DIFF
--- a/packages/sdk/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/sdk/src/sdk/api/chats/ChatsApi.ts
@@ -780,11 +780,16 @@ export class ChatsApi
   }
 
   private async getPublicKey(userId: string): Promise<Uint8Array> {
-    // Use cached promise to avoid duplicate requests for the same user
     if (!this.publicKeyCache[userId]) {
       this.publicKeyCache[userId] = this.fetchPublicKey(userId)
     }
-    return this.publicKeyCache[userId]
+    const cachedPromise = this.publicKeyCache[userId]
+    if (!cachedPromise) {
+      throw new Error(
+        `Public key cache is unexpectedly empty for user ${userId}`
+      )
+    }
+    return await cachedPromise
   }
 
   private async fetchPublicKey(userId: string): Promise<Uint8Array> {


### PR DESCRIPTION
### Description
In Chats SDK, Add a cache for user pubkeys and parallelize fetch requests for the pubkeys.

### How Has This Been Tested?

Tested on local web stage
Timing was fairly inconsistent. Before this change I was observing chat creates taking ~4.5 seconds.

After the change I observed instances as low as 3.5s and as high as 6s.. guessing network instability. But I did notice that we saved a call to`/pubkey` for the current user, so this is probably still worth shipping?