### PR TITLE
[PE-6654] Real-time artist coin blasts show holders UI

### DIFF
--- a/comms/discovery/rpcz/chat_blast.go
+++ b/comms/discovery/rpcz/chat_blast.go
@@ -97,6 +97,7 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 					Message:     params.Message,
 					MessageID:   messageID,
 					IsPlaintext: &isPlaintext,
+					Audience:    &params.Audience,
 				}}})
 
 		if err := chatUpdateLatestFields(tx, result.ChatID); err != nil {

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -67,11 +67,12 @@ type ChatMessageRPC struct {
 }
 
 type ChatMessageRPCParams struct {
-	ChatID          string  `json:"chat_id"`
-	IsPlaintext     *bool   `json:"is_plaintext,omitempty"`
-	Message         string  `json:"message"`
-	MessageID       string  `json:"message_id"`
-	ParentMessageID *string `json:"parent_message_id,omitempty"`
+	ChatID          string             `json:"chat_id"`
+	IsPlaintext     *bool              `json:"is_plaintext,omitempty"`
+	Message         string             `json:"message"`
+	MessageID       string             `json:"message_id"`
+	ParentMessageID *string            `json:"parent_message_id,omitempty"`
+	Audience        *ChatBlastAudience `json:"audience,omitempty"`
 }
 
 type ChatReactRPC struct {


### PR DESCRIPTION
### Description
When an artist sends a artist coin blast, and the recipient is logged in, the blast messages don't show the custom "token holders" UI. This PR should fix that.

### How Has This Been Tested?

Tested with `make steve.test`