### PR TITLE
Adjust remix contest timezone

### DIFF
--- a/packages/common/src/utils/timeUtil.test.ts
+++ b/packages/common/src/utils/timeUtil.test.ts
@@ -76,19 +76,19 @@ describe('getLocalTimezone', () => {
 describe('formatContestDeadline', () => {
   test('should format deadline with short format', () => {
     const result = formatContestDeadline('2023-12-17T15:30:00Z', 'short')
-    expect(result).toContain('12/17/23')
-    expect(result).toContain(getLocalTimezone())
+    expect(result).toBe('12/17/23')
   })
 
   test('should format deadline with card format', () => {
     const result = formatContestDeadline('2023-12-17T15:30:00Z', 'card')
-    expect(result).toContain('12/17/23 at 3:30 PM')
-    expect(result).toContain(getLocalTimezone())
+    expect(result).toContain('12/17/23 at')
+    expect(result).toContain('AM') // or PM depending on timezone
   })
 
   test('should format deadline with long format', () => {
     const result = formatContestDeadline('2023-12-17T15:30:00Z', 'long')
-    expect(result).toContain('Sun. Dec 17, 2023 at 3:30 PM')
+    expect(result).toContain('Sun. Dec 17, 2023 at')
+    expect(result).toContain('AM') // or PM depending on timezone
     expect(result).toContain(getLocalTimezone())
   })
 
@@ -103,16 +103,12 @@ describe('formatContestDeadlineWithStatus', () => {
       '2023-12-17T15:30:00Z',
       false
     )
-    expect(result).toContain('Deadline:')
-    expect(result).toContain('12/17/23')
-    expect(result).toContain(getLocalTimezone())
+    expect(result).toBe('Deadline: 12/17/23')
   })
 
   test('should format ended deadline', () => {
     const result = formatContestDeadlineWithStatus('2023-12-17T15:30:00Z', true)
-    expect(result).toContain('Ended:')
-    expect(result).toContain('12/17/23')
-    expect(result).toContain(getLocalTimezone())
+    expect(result).toBe('Ended: 12/17/23')
   })
 
   test('should return empty string for undefined deadline', () => {

--- a/packages/common/src/utils/timeUtil.ts
+++ b/packages/common/src/utils/timeUtil.ts
@@ -135,34 +135,3 @@ export const formatContestDeadlineWithStatus = (
 
   return `${status}: ${date.format('MM/DD/YY')}`
 }
-
-export const formatContestDeadlineCard = (
-  deadline?: string,
-  format: 'short' | 'long' | 'card' = 'short'
-): string => {
-  if (!deadline) return ''
-
-  const date = dayjs(deadline)
-
-  switch (format) {
-    case 'long':
-      return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')}`
-    case 'card':
-      return `${date.format('MM/DD/YY')} at ${date.format('h:mm A')}`
-    case 'short':
-    default:
-      return `${date.format('MM/DD/YY')}`
-  }
-}
-
-export const formatContestDeadlineWithStatusCard = (
-  deadline?: string,
-  isEnded: boolean = false
-): string => {
-  if (!deadline) return ''
-
-  const date = dayjs(deadline)
-  const status = isEnded ? 'Ended' : 'Deadline'
-
-  return `${status}: ${date.format('MM/DD/YY')}`
-}

--- a/packages/common/src/utils/timeUtil.ts
+++ b/packages/common/src/utils/timeUtil.ts
@@ -112,16 +112,15 @@ export const formatContestDeadline = (
   if (!deadline) return ''
 
   const date = dayjs(deadline)
-  const timezone = getLocalTimezone()
 
   switch (format) {
     case 'long':
-      return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')} ${timezone}`
+      return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')} ${getLocalTimezone()}`
     case 'card':
-      return `${date.format('MM/DD/YY')} at ${date.format('h:mm A')} ${timezone}`
+      return `${date.format('MM/DD/YY')} at ${date.format('h:mm A')}`
     case 'short':
     default:
-      return `${date.format('MM/DD/YY')} ${timezone}`
+      return `${date.format('MM/DD/YY')}`
   }
 }
 
@@ -132,8 +131,38 @@ export const formatContestDeadlineWithStatus = (
   if (!deadline) return ''
 
   const date = dayjs(deadline)
-  const timezone = getLocalTimezone()
   const status = isEnded ? 'Ended' : 'Deadline'
 
-  return `${status}: ${date.format('MM/DD/YY')} ${timezone}`
+  return `${status}: ${date.format('MM/DD/YY')}`
+}
+
+export const formatContestDeadlineCard = (
+  deadline?: string,
+  format: 'short' | 'long' | 'card' = 'short'
+): string => {
+  if (!deadline) return ''
+
+  const date = dayjs(deadline)
+
+  switch (format) {
+    case 'long':
+      return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')}`
+    case 'card':
+      return `${date.format('MM/DD/YY')} at ${date.format('h:mm A')}`
+    case 'short':
+    default:
+      return `${date.format('MM/DD/YY')}`
+  }
+}
+
+export const formatContestDeadlineWithStatusCard = (
+  deadline?: string,
+  isEnded: boolean = false
+): string => {
+  if (!deadline) return ''
+
+  const date = dayjs(deadline)
+  const status = isEnded ? 'Ended' : 'Deadline'
+
+  return `${status}: ${date.format('MM/DD/YY')}`
 }

--- a/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
@@ -11,7 +11,7 @@ import { ExpandableContent, UserGeneratedText } from 'app/components/core'
 const messages = {
   due: 'Submission Due:',
   ended: 'Contest Ended:',
-  deadline: (deadline?: string) => formatContestDeadline(deadline, 'card'),
+  deadline: (deadline?: string) => formatContestDeadline(deadline, 'long'),
   fallbackDescription:
     'Enter my remix contest before the deadline for your chance to win!'
 }

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -51,8 +51,7 @@ import {
   formatReleaseDate,
   Genre,
   removeNullable,
-  dayjs,
-  formatContestDeadline
+  dayjs
 } from '@audius/common/utils'
 import type { FlatList } from 'react-native'
 import { TouchableOpacity } from 'react-native'
@@ -123,11 +122,7 @@ const messages = {
   hidden: 'Hidden',
   releases: (releaseDate: string) =>
     `Releases ${formatReleaseDate({ date: releaseDate, withHour: true })}`,
-  remixContest: 'Remix Contest',
-  contestEnded: 'Contest Ended',
-  contestDeadline: 'Contest Deadline',
-  deadline: (deadline?: string) => formatContestDeadline(deadline, 'short'),
-  uploadRemixButtonText: 'Upload Your Remix'
+  remixContest: 'Remix Contest'
 }
 
 const useStyles = makeStyles(({ palette, spacing }) => ({


### PR DESCRIPTION
### Description

Removes remix-contest deadline timezone on cards, preserving on "long" format.
Fixes mobile details-card to use long format
Removes unreferenced messages