### PR TITLE
Add audius/api to local development stack (audius-compose)

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -24,6 +24,7 @@ audius-protocol-eth-ganache-1 \
 audius-protocol-pedalboard \
 audius-protocol-anti-abuse-oracle-1 \
 audius-protocol-discovery-provider-redis-1 \
+audius-protocol-api \
 """
 
 

--- a/dev-tools/compose/docker-compose.api.yml
+++ b/dev-tools/compose/docker-compose.api.yml
@@ -1,0 +1,13 @@
+services:
+  api:
+    container_name: api
+    image: audius/api:latest
+    restart: unless-stopped
+    pull_policy: always
+    profiles:
+      - discovery
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - 1323:1323

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -24,6 +24,7 @@ x-common: &common
     - 'audius-protocol-solana-test-validator-1:host-gateway'
     - 'audius-protocol-eth-ganache-1:host-gateway'
     - 'audius-protocol-pedalboard:host-gateway'
+    - 'audius-protocol-api:host-gateway'
   deploy:
     resources:
       limits:
@@ -64,6 +65,17 @@ services:
       service: audius-cmd
     <<: *common
 
+  # API
+  api:
+    extends:
+      file: docker-compose.api.yml
+      service: api
+    container_name: audius-protocol-api
+    env_file:
+      - ${PROJECT_ROOT}/dev-tools/environment/api.env
+    <<: *common
+
+  # Validators
   audiusd-1:
     extends:
       file: docker-compose.audiusd.yml

--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -322,3 +322,16 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }
+
+server {
+    listen 80;
+    server_name audius-protocol-api;
+
+    location / {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream host.docker.internal:1323;
+        proxy_pass http://$upstream;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/dev-tools/environment/api.env
+++ b/dev-tools/environment/api.env
@@ -1,0 +1,9 @@
+ENV=dev
+logLevel=debug
+delegatePrivateKey=
+readDbUrl=postgresql://postgres:postgres@db:5432/discovery_provider_1
+writeDbUrl=postgresql://postgres:postgres@db:5432/discovery_provider_1
+antiAbuseOracle=http://audius-protocol-anti-abuse-oracle-1:8000
+antiAbuseOracleAddress=0xF0D5BC18421fa04D0a2A2ef540ba5A9f04014BE3
+solanaFeePayerKeys=4Qs6go7q8pnEwoxbLP3PD1nvZif5mnfA9kPAxgsGAqX1cDYMFMjEQVyTLEsq8HP8K5qePAjsfj1cyGPhgdt582Gv
+solanaRpcProviders=http://localhost:8899

--- a/packages/sdk/src/sdk/config/development.ts
+++ b/packages/sdk/src/sdk/config/development.ts
@@ -7,7 +7,7 @@ import type { SdkServicesConfig } from './types'
 export const developmentConfig: SdkServicesConfig = {
   "network": {
     "minVersion": "0.0.0",
-    "apiEndpoint": "http://audius-protocol-discovery-provider-1",
+    "apiEndpoint": "http://audius-protocol-api",
     "discoveryNodes": [
       {
         "delegateOwnerWallet": "0xd09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8",

--- a/packages/sdk/src/sdk/config/production.ts
+++ b/packages/sdk/src/sdk/config/production.ts
@@ -19,16 +19,6 @@ export const productionConfig: SdkServicesConfig = {
         "delegateOwnerWallet": "0x4E2C78d0d3303ed459BF8a3CD87f11A6bc936140"
       },
       {
-        "endpoint": "https://discoveryprovider3.audius.co",
-        "ownerWallet": "0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d",
-        "delegateOwnerWallet": "0xF2897993951d53a7E3eb2242D6A14D2028140DC8"
-      },
-      {
-        "endpoint": "https://discoveryprovider2.audius.co",
-        "ownerWallet": "0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d",
-        "delegateOwnerWallet": "0xc97d40C0B992882646D64814151941A1c520b460"
-      },
-      {
         "endpoint": "https://discoveryprovider.audius.co",
         "ownerWallet": "0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d",
         "delegateOwnerWallet": "0xf1a1Bd34b2Bc73629aa69E50E3249E89A3c16786"
@@ -52,16 +42,6 @@ export const productionConfig: SdkServicesConfig = {
         "endpoint": "https://audius-dn1.tikilabs.com",
         "ownerWallet": "0xe4882D9A38A2A1fc652996719AF0fb15CB968d0a",
         "delegateOwnerWallet": "0x1cF73c5023572F2d5dc6BD3c5E4F24b4F3b6B76F"
-      },
-      {
-        "endpoint": "https://audius-disc1.nodemagic.com",
-        "ownerWallet": "0xf13612C7d6E31636eCC2b670d6F8a3CC50f68A48",
-        "delegateOwnerWallet": "0xFD005a90cc8AF8B766F9F9cD95ee91921cC9286d"
-      },
-      {
-        "endpoint": "https://audius-disc2.nodemagic.com",
-        "ownerWallet": "0xf13612C7d6E31636eCC2b670d6F8a3CC50f68A48",
-        "delegateOwnerWallet": "0x5cA0d3a6590074B9fF31972824178f69e8dAB547"
       }
     ],
     "apiEndpoint": "https://api.audius.co",

--- a/packages/sdk/src/sdk/config/staging.ts
+++ b/packages/sdk/src/sdk/config/staging.ts
@@ -13,21 +13,6 @@ export const stagingConfig: SdkServicesConfig = {
         "endpoint": "https://discoveryprovider.staging.audius.co",
         "ownerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA",
         "delegateOwnerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA"
-      },
-      {
-        "endpoint": "https://discoveryprovider2.staging.audius.co",
-        "ownerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2",
-        "delegateOwnerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2"
-      },
-      {
-        "endpoint": "https://discoveryprovider3.staging.audius.co",
-        "ownerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056",
-        "delegateOwnerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056"
-      },
-      {
-        "endpoint": "https://discoveryprovider5.staging.audius.co",
-        "ownerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1",
-        "delegateOwnerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1"
       }
     ],
     "storageNodes": [

--- a/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
+++ b/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
@@ -162,7 +162,7 @@ const stagingConfig: SdkServicesConfig = {
 const developmentConfig: SdkServicesConfig = {
   network: {
     minVersion: '0.0.0',
-    apiEndpoint: 'http://audius-protocol-discovery-provider-1',
+    apiEndpoint: 'http://audius-protocol-api',
     discoveryNodes: [
       {
         delegateOwnerWallet:


### PR DESCRIPTION
Adds `audius/api` to the `audius-compose` stack.

Follows the `audiusd` strategy of pulling the latest image.

Instead of having everything route via ingress, I opted to route to the host machine and expose the API container port there. This allows devs to simply run the API repository locally if they're making edits rather than have to reconfigure anything. If the ports conflict, simply stop the `audius-protocol-api` container.

Regenerates the SDK config so also removes some unregistered nodes.