### PR TITLE
[PE-6659] Update get new blasts in comms to match api

### DIFF
--- a/comms/discovery/db/queries/get_new_blasts.go
+++ b/comms/discovery/db/queries/get_new_blasts.go
@@ -93,6 +93,18 @@ func GetNewBlasts(q db.Queryable, ctx context.Context, arg ChatMembershipParams)
 					)
 				)
 		)
+		OR from_user_id IN (
+			-- coin_holder_audience via sol_user_balances
+			SELECT ac.user_id
+			FROM artist_coins ac
+			JOIN sol_user_balances sub ON sub.mint = ac.mint
+			WHERE blast.audience = 'coin_holder_audience'
+				AND ac.user_id = blast.from_user_id
+				AND sub.user_id = @user_id
+				AND sub.balance > 0
+				-- TODO: PE-6663 This isn't entirely correct yet, need to check "time of most recent membership"
+				AND sub.created_at < blast.created_at
+		)
 	)
 	select * from all_new
 	where created_at > (select t from last_permission_change)

--- a/comms/discovery/db/queries/get_new_blasts.go
+++ b/comms/discovery/db/queries/get_new_blasts.go
@@ -24,7 +24,7 @@ type BlastRow struct {
 func GetNewBlasts(q db.Queryable, ctx context.Context, arg ChatMembershipParams) ([]BlastRow, error) {
 
 	// this query is to find new blasts for the current user
-	// which don't already have a eixsting chat.
+	// which don't already have a existing chat.
 	// see also: subtly different inverse query exists in chat_blast.go
 	// to fan out messages to existing chat
 	var findNewBlasts = `


### PR DESCRIPTION
### Description
Bitten by `comms` vs `api` fragmentation - need to update the query here to match `api` so that on chat create, `getNewBlasts` returns the right blasts to seed the chat with.

### How Has This Been Tested?

Not tested but this query is already tested on stage.
