### PR TITLE
Fix listening history

### DIFF
--- a/packages/common/src/api/tan-query/tracks/useTrackHistory.ts
+++ b/packages/common/src/api/tan-query/tracks/useTrackHistory.ts
@@ -65,8 +65,11 @@ export const useTrackHistory = (
       const sdk = await audiusSdk()
       if (!currentUserId) return []
 
+      const id = Id.parse(currentUserId)
+
       const { data: activityData } = await sdk.full.users.getUsersTrackHistory({
-        id: Id.parse(currentUserId),
+        id,
+        userId: id,
         limit: pageSize,
         offset: pageParam,
         query,

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -246,7 +246,7 @@ export const TracksTable = ({
       } = track
       const isOwner = ownerId === userId
       if (!isOwner && (isStreamGated || isUnlisted || isDelete)) return null
-      return formatCount(track.plays)
+      return formatCount(track.play_count)
     },
     [userId]
   )

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -246,7 +246,7 @@ export const TracksTable = ({
       } = track
       const isOwner = ownerId === userId
       if (!isOwner && (isStreamGated || isUnlisted || isDelete)) return null
-      return formatCount(track.play_count)
+      return formatCount(track.plays ?? track.play_count)
     },
     [userId]
   )


### PR DESCRIPTION
### Description
Since we render the favorite/repost buttons on the history page for each track, we need to pass userId to make sure we get the personalization info back.

Also we have some kind of weird formatting thing in most places for TracksTable that reassigns `play_count` to `plays`. I don't know why we did that, but it broke when we converted history page to use a lineup, since it's no longer calling some version of `formatTrackMetadata`. So I update the table to support using either field and now we have play counts again.


Bonus SDK generation for some other endpoint changes that weren't mine! Happy wednesday.

### How Has This Been Tested?
Local web client against stage, making sure tracks I favorite actually show the thing.
