### PR TITLE
Fix CI API nginx routing

### DIFF
--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -81,7 +81,7 @@ server {
 
     location ~ ^/v1/rewards(/.*)?$ {
         resolver 127.0.0.11 valid=30s;
-        proxy_pass http://host.docker.internal:1323/v1/rewards$1;
+        proxy_pass http://audius-protocol-api:1323/v1/rewards$1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
@@ -329,8 +329,7 @@ server {
 
     location / {
         resolver 127.0.0.11 valid=30s;
-        set $upstream host.docker.internal:1323;
-        proxy_pass http://$upstream;
+        proxy_pass http://audius-protocol-api:1323;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }


### PR DESCRIPTION
Linux doesn't support `host.docker.internal`