### PR TITLE
Fix chat create blast seeding

### DIFF
--- a/comms/discovery/db/queries/get_new_blasts.go
+++ b/comms/discovery/db/queries/get_new_blasts.go
@@ -100,7 +100,7 @@ func GetNewBlasts(q db.Queryable, ctx context.Context, arg ChatMembershipParams)
 			JOIN sol_user_balances sub ON sub.mint = ac.mint
 			WHERE blast.audience = 'coin_holder_audience'
 				AND ac.user_id = blast.from_user_id
-				AND sub.user_id = @user_id
+				AND sub.user_id = $1
 				AND sub.balance > 0
 				-- TODO: PE-6663 This isn't entirely correct yet, need to check "time of most recent membership"
 				AND sub.created_at < blast.created_at


### PR DESCRIPTION
### Description
Copied this code over from `api` codebase without changing the arg formatting.

### How Has This Been Tested?

Not tested, but the query logic itself is tested in `api`.
