### PR TITLE
[PE-6632] Fix selected category display for mobile web search/explore

### DIFF
--- a/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/SearchExplorePage.tsx
@@ -4,7 +4,8 @@ import {
   useEffect,
   useRef,
   useState,
-  ChangeEvent
+  ChangeEvent,
+  useMemo
 } from 'react'
 
 import { useCurrentUserId } from '@audius/common/api'
@@ -156,6 +157,23 @@ const ExplorePage = () => {
     [setCategory]
   )
 
+  const categoryList = useMemo(() => {
+    const entries = Object.entries(categories)
+    const allCategory = entries.find(([key]) => key === 'all')
+    const currentCategory = entries.find(([key]) => key === categoryKey)
+    const restCategories = entries.filter(
+      ([key]) => key !== 'all' && key !== categoryKey
+    )
+
+    return [
+      ...(allCategory ? [allCategory] : []),
+      ...(currentCategory && currentCategory[0] !== 'all'
+        ? [currentCategory]
+        : []),
+      ...restCategories
+    ]
+  }, [categoryKey])
+
   // Hide search header
   useEffect(() => {
     setRight(null)
@@ -203,8 +221,9 @@ const ExplorePage = () => {
               padding: '16px 50vw'
             }}
           >
-            {Object.entries(categories).map(([key, category]) => (
+            {categoryList.map(([key, category]) => (
               <SelectablePill
+                isSelected={categoryKey === key}
                 aria-label={`${key} search category`}
                 icon={(category as Category).icon}
                 key={key}


### PR DESCRIPTION
### Description
This fixes the selection of categories on mobile web. I don't think the `SelectablePill` component works with RadioGroup context properly. But it supports controlled passing of `isSelected`, so the easiest thing right now is to just pass that to the selected pill.

I also updated the display logic to move the selected category to the second position (similar to native mobile) because the container we use to display them gets its scroll position reset when the category changes and after an hour of futzing with it I couldn't get it to stop doing that. This is a more elegant solution to the problem than manually adjusting scroll position in an effect.

### How Has This Been Tested?
Local mobile web client against staging, tapping around on categories and making sure things work correctly.


<img width="595" height="688" alt="image" src="https://github.com/user-attachments/assets/48daaba5-3337-4b4d-ab36-0e988f5ce270" />
