### PR TITLE
Update postgres version in local dev to 15.5

### DIFF
--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     <<: *common
 
   db:
-    image: postgres:11.22-bookworm
+    image: postgres:15.5
     shm_size: 2g
     command: postgres -c shared_buffers=2GB -c max_connections=300
     restart: unless-stopped


### PR DESCRIPTION
Needed for `gen_random_uuid()` support. Matches the version used in our audius-docker-compose.