### PR TITLE
Fix E2E tests by fixing remix notification

### DIFF
--- a/.circleci/src/jobs/@integration-jobs.yml
+++ b/.circleci/src/jobs/@integration-jobs.yml
@@ -66,7 +66,7 @@ e2e-test:
         name: run playwright tests
         command: |
           cd packages/web
-          RUN_AGAINST_LOCAL_STACK=true npx playwright test
+          CLEAN=true npx playwright test
         when: always
     - store_test_results:
         path: packages/web/report.xml

--- a/packages/common/src/adapters/notification.ts
+++ b/packages/common/src/adapters/notification.ts
@@ -296,7 +296,7 @@ export const notificationFromSDK = (
         const data = action.data
         childTrackId = HashId.parse(data.trackId)
         parentTrackId = HashId.parse(data.parentTrackId)
-        trackOwnerId = HashId.parse(data.trackOwnerId)
+        trackOwnerId = HashId.parse(action.specifier)
       })
       return {
         type: NotificationType.RemixCreate,

--- a/packages/common/src/api/tan-query/notifications/useNotifications.ts
+++ b/packages/common/src/api/tan-query/notifications/useNotifications.ts
@@ -157,6 +157,10 @@ const collectEntityIds = (notifications: Notification[]): EntityIds => {
         .slice(0, USER_INITIAL_LOAD_COUNT)
         .forEach((id) => userIds.add(id))
     }
+    if (type === NotificationType.RemixCreate) {
+      trackIds.add(notification.parentTrackId)
+      trackIds.add(notification.childTrackId)
+    }
   })
 
   return {

--- a/packages/web/e2e/auth.setup.ts
+++ b/packages/web/e2e/auth.setup.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test'
+import fs from 'fs'
 
 import { getUser } from './data'
 import { test as setup } from './test'
@@ -6,6 +7,14 @@ import { test as setup } from './test'
 const authFile = 'playwright/.auth/user.json'
 
 setup('authenticate', async ({ page }) => {
+  const authFileExists = fs.existsSync('playwright/.auth/user.json')
+  if (authFileExists && !process.env.CLEAN) {
+    console.info(
+      'Authentication file already exists and CLEAN is not true, skipping authentication.'
+    )
+    return
+  }
+
   const user = getUser()
   const base64Entropy = btoa(user.entropy.trim())
   await page.goto(`/feed?login=${base64Entropy}`)

--- a/packages/web/e2e/data.seed.ts
+++ b/packages/web/e2e/data.seed.ts
@@ -11,8 +11,18 @@ const audiusCmdPath = '$HOME/.local/bin/audius-cmd'
 const dataFilePath = (filename: string) => `${dataDir}/${filename}`
 
 setup('seed data', async () => {
+  if (process.env.RUN_AGAINST_STAGE === 'true') {
+    console.info('Skipping data seeding as RUN_AGAINST_STAGE is set to true.')
+    return
+  }
+
   if (!existsSync(dataDir)) {
     mkdirSync(dataDir)
+  } else {
+    if (process.env.CLEAN !== 'true') {
+      console.info('Skipping data seeding as CLEAN is false and data exists.')
+      return
+    }
   }
 
   const audiusCmd = async (cmd: string) => {

--- a/packages/web/e2e/data.ts
+++ b/packages/web/e2e/data.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import type { full } from '@audius/sdk'
 
-const runAgainstLocalStack = process.env.RUN_AGAINST_LOCAL_STACK === 'true'
+const runAgainstLocalStack = process.env.RUN_AGAINST_STAGE !== 'true'
 
 const getData = (filename: string) =>
   JSON.parse(readFileSync(path.resolve('../web/e2e/data/', filename), 'utf8'))

--- a/packages/web/src/components/notification/Notification/CommentThreadNotification.tsx
+++ b/packages/web/src/components/notification/Notification/CommentThreadNotification.tsx
@@ -10,6 +10,7 @@ import { CommentThreadNotification as CommentThreadNotificationType } from '@aud
 import { IconMessage } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
+import { UserProfilePictureList } from 'components/user-profile-picture-list'
 import { useIsMobile } from 'hooks/useIsMobile'
 import { make, track } from 'services/analytics'
 import {
@@ -26,7 +27,6 @@ import { NotificationHeader } from './components/NotificationHeader'
 import { NotificationTile } from './components/NotificationTile'
 import { OthersLink } from './components/OthersLink'
 import { UserNameLink } from './components/UserNameLink'
-import { UserProfilePictureList } from 'components/user-profile-picture-list'
 import { entityToUserListEntity, USER_LENGTH_LIMIT } from './utils'
 
 const messages = {

--- a/packages/web/src/components/notification/Notification/RemixCreateNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RemixCreateNotification.tsx
@@ -1,11 +1,8 @@
 import { useCallback } from 'react'
 
-import { useNotificationEntities, useUser } from '@audius/common/api'
+import { useTracks, useUser } from '@audius/common/api'
 import { Name, TrackMetadata } from '@audius/common/models'
-import {
-  RemixCreateNotification as RemixCreateNotificationType,
-  TrackEntity
-} from '@audius/common/store'
+import { RemixCreateNotification as RemixCreateNotificationType } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
 
 import { make } from 'common/store/analytics/actions'
@@ -42,13 +39,21 @@ export const RemixCreateNotification = (
   const dispatch = useDispatch()
   const { data: user } = useUser(notification.userId)
 
-  const entities = useNotificationEntities(notification) as TrackEntity[] | null
-  const childTrackEntity = entities?.find(
-    (track) => track.track_id === childTrackId
-  )
-  const parentTrackEntity = entities?.find(
-    (track) => track.track_id === parentTrackId
-  )
+  // useNotificationEntities is not used here because the ids are not in the
+  // entities list and we need to fetch them directly
+  const { data: tracks } = useTracks([childTrackId, parentTrackId])
+  const childTrack = tracks?.find((track) => track.track_id === childTrackId)
+
+  // unnecessary but makes types happy
+  const childTrackEntity =
+    childTrack && user
+      ? {
+          ...childTrack,
+          user
+        }
+      : null
+
+  const parentTrack = tracks?.find((track) => track.track_id === parentTrackId)
 
   const handleClick = useCallback(() => {
     if (childTrackEntity) {
@@ -58,18 +63,18 @@ export const RemixCreateNotification = (
 
   const handleShare = useCallback(
     (twitterHandle: string) => {
-      if (!parentTrackEntity) return null
-      const shareText = messages.shareXText(parentTrackEntity, twitterHandle)
+      if (!parentTrack) return null
+      const shareText = messages.shareXText(parentTrack, twitterHandle)
       const analytics = make(
         Name.NOTIFICATIONS_CLICK_REMIX_CREATE_TWITTER_SHARE,
         { text: shareText }
       )
       return { shareText, analytics }
     },
-    [parentTrackEntity]
+    [parentTrack]
   )
 
-  if (!user || !parentTrackEntity || !childTrackEntity) return null
+  if (!user || !parentTrack || !childTrackEntity) return null
 
   return (
     <NotificationTile notification={notification} onClick={handleClick}>
@@ -83,7 +88,7 @@ export const RemixCreateNotification = (
       <XShareButton
         type='dynamic'
         handle={user.handle}
-        url={getEntityLink(parentTrackEntity, true)}
+        url={getEntityLink(parentTrack, true)}
         shareData={handleShare}
       />
       <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />

--- a/packages/web/src/components/notification/Notification/RemixCreateNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RemixCreateNotification.tsx
@@ -1,6 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import { useTracks, useUser } from '@audius/common/api'
+import { useTrack, useUser } from '@audius/common/api'
 import { Name, TrackMetadata } from '@audius/common/models'
 import { RemixCreateNotification as RemixCreateNotificationType } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
@@ -41,19 +41,20 @@ export const RemixCreateNotification = (
 
   // useNotificationEntities is not used here because the ids are not in the
   // entities list and we need to fetch them directly
-  const { data: tracks } = useTracks([childTrackId, parentTrackId])
-  const childTrack = tracks?.find((track) => track.track_id === childTrackId)
+  const { data: childTrack } = useTrack(childTrackId)
+  const { data: parentTrack } = useTrack(parentTrackId)
 
   // unnecessary but makes types happy
-  const childTrackEntity =
-    childTrack && user
-      ? {
-          ...childTrack,
-          user
-        }
-      : null
-
-  const parentTrack = tracks?.find((track) => track.track_id === parentTrackId)
+  const childTrackEntity = useMemo(
+    () =>
+      childTrack && user
+        ? {
+            ...childTrack,
+            user
+          }
+        : null,
+    [childTrack, user]
+  )
 
   const handleClick = useCallback(() => {
     if (childTrackEntity) {

--- a/packages/web/src/components/notification/Notification/utils.ts
+++ b/packages/web/src/components/notification/Notification/utils.ts
@@ -1,3 +1,4 @@
+import type { Track } from '@audius/common/models'
 import { Entity, EntityType } from '@audius/common/store'
 import { route } from '@audius/common/utils'
 
@@ -5,8 +6,10 @@ import { UserListEntityType } from 'store/application/ui/userListModal/types'
 import { fullCollectionPage, fullTrackPage } from 'utils/route'
 const { collectionPage } = route
 
-export const getEntityLink = (entity: EntityType, fullRoute = false) => {
-  if (!entity.user) return ''
+export const getEntityLink = (
+  entity: EntityType | Track,
+  fullRoute = false
+) => {
   if ('track_id' in entity) {
     return fullRoute ? fullTrackPage(entity.permalink) : entity.permalink
   } else if (entity.user && entity.playlist_id) {


### PR DESCRIPTION
Remix Notifications were broken by the API changes on the backend, as we weren't setting `action.data.track_owner_id` anymore (it's the specifier, so just use that).

Also fixes remix notifications generally, as the entities were not being fetched correctly, and restructures the e2e test defaults to be more sane (local first, don't reseed).
