### PR TITLE
Fix share profile drawer issue

### DIFF
--- a/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
+++ b/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
@@ -1,12 +1,7 @@
 import { useProfileUser } from '@audius/common/api'
 import type { BadgeTierInfo } from '@audius/common/store'
-import {
-  useTierAndVerifiedForUser,
-  profilePageSelectors,
-  badgeTiers
-} from '@audius/common/store'
+import { useTierAndVerifiedForUser, badgeTiers } from '@audius/common/store'
 import { Text, View } from 'react-native'
-import { useSelector } from 'react-redux'
 
 import { makeStyles } from 'app/styles'
 

--- a/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
+++ b/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
@@ -1,3 +1,4 @@
+import { useProfileUser } from '@audius/common/api'
 import type { BadgeTierInfo } from '@audius/common/store'
 import {
   useTierAndVerifiedForUser,
@@ -13,7 +14,6 @@ import { IconAudioBadge } from '../core/IconAudioBadge'
 import { AppDrawer } from '../drawer/AppDrawer'
 
 import { TierText } from './TierText'
-const { getProfileUserId } = profilePageSelectors
 
 export const MODAL_NAME = 'TiersExplainer'
 
@@ -69,7 +69,8 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
 export const TiersExplainerDrawer = () => {
   const styles = useStyles()
 
-  const profileId = useSelector(getProfileUserId)
+  const { user } = useProfileUser()
+  const profileId = user?.user_id
   const { tier, tierNumber } = useTierAndVerifiedForUser(profileId)
 
   const { humanReadableAmount } = badgeTiers.find(

--- a/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
+++ b/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
@@ -6,7 +6,6 @@ import { commentsMessages } from '@audius/common/messages'
 import { ShareSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
-  profilePageSelectors,
   chatActions,
   chatSelectors,
   shareModalUIActions

--- a/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
+++ b/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { useMutedUsers } from '@audius/common/api'
+import { useMutedUsers, useProfileUser } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { commentsMessages } from '@audius/common/messages'
 import { ShareSource } from '@audius/common/models'
@@ -14,11 +14,9 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 
 import ActionDrawer from 'app/components/action-drawer'
-import type { AppState } from 'app/store'
 import { setVisibility } from 'app/store/drawers/slice'
 
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
-const { getProfileUserId } = profilePageSelectors
 const { getBlockees } = chatSelectors
 const { fetchBlockees } = chatActions
 
@@ -32,7 +30,8 @@ const messages = {
 
 export const ProfileActionsDrawer = () => {
   const dispatch = useDispatch()
-  const userId = useSelector((state: AppState) => getProfileUserId(state))
+  const { user } = useProfileUser()
+  const userId = user?.user_id
   const blockeeList = useSelector(getBlockees)
   const isBlockee = userId ? blockeeList.includes(userId) : false
   const { isEnabled: commentPostFlag = false } = useFeatureFlag(

--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react'
 import { useCurrentAccountUser, useProfileUser } from '@audius/common/api'
 import { FollowSource, statusIsNotFinalized } from '@audius/common/models'
 import {
-  profilePageSelectors,
   chatActions,
   chatSelectors,
   reachabilitySelectors
@@ -23,7 +22,6 @@ import { SubscribeButton } from './SubscribeButton'
 
 const { useCanCreateChat, getChatPermissionsStatus } = chatSelectors
 const { fetchBlockees, fetchBlockers, fetchPermissions } = chatActions
-const { getProfileUserId } = profilePageSelectors
 
 type ProfileInfoProps = {
   onFollow: () => void
@@ -39,9 +37,8 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
   })
   const dispatch = useDispatch()
 
-  const profileUserId = useSelector((state) =>
-    getProfileUserId(state, params.handle)
-  )
+  const { user } = useProfileUser()
+  const profileUserId = user?.user_id
   const { canCreateChat } = useCanCreateChat(profileUserId)
   const chatPermissionStatus = useSelector(getChatPermissionsStatus)
 


### PR DESCRIPTION
### Description

Michael cullen reported prod bug where share profile doesnt work. It's due to the drawer checking for `userId` first and it being undefined.

This change updates how it's selecting userId to use our newer hook to select userId. 

### How Has This Been Tested?

![2025-08-15 10 31 19](https://github.com/user-attachments/assets/63411c62-a13d-4b78-8c65-926f727ac727)


ios:stage