### PR TITLE
Show correct image in user badge stack on AllCoinsPage

### DIFF
--- a/packages/web/src/components/user-token-badge/UserTokenBadge.tsx
+++ b/packages/web/src/components/user-token-badge/UserTokenBadge.tsx
@@ -39,12 +39,12 @@ export const UserTokenBadge = ({ mint, size = 'm' }: UserTokenBadgeProps) => {
       backgroundColor='white'
     >
       <Flex alignItems='center' gap='xs'>
-        {userId && <Avatar userId={userId} w={iconSize} h={iconSize} />}
+        {userId ? <Avatar userId={userId} w={iconSize} h={iconSize} /> : null}
         <Flex alignItems='center' gap='xs'>
           <Text variant='body' size='l'>
             {name}
           </Text>
-          {userId && <UserBadges userId={userId} size='s' inline />}
+          {userId ? <UserBadges userId={userId} size='s' inline /> : null}
         </Flex>
       </Flex>
     </Paper>


### PR DESCRIPTION
### Description
Was showing the image url for the coin instead of the user that owns it

<img width="1067" height="113" alt="image" src="https://github.com/user-attachments/assets/59c6231a-b867-4080-9e0c-17331fedee98" />


### How Has This Been Tested?

`npm run web:prod` and navigate to All coins page