### PR TITLE
[PE-6664] Fix small screen coin page layout issues

### DIFF
--- a/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
@@ -18,7 +18,8 @@ const useStyles = makeResponsiveStyles(({ media, theme }) => ({
     },
     mobile: {
       flexDirection: 'column',
-      width: '100%'
+      width: '100%',
+      paddingBottom: theme.spacing.m
     },
     tablet: {
       flexDirection: 'column',

--- a/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailContent.tsx
@@ -17,10 +17,12 @@ const useStyles = makeResponsiveStyles(({ media, theme }) => ({
       gap: theme.spacing.l
     },
     mobile: {
-      flexDirection: 'column'
+      flexDirection: 'column',
+      width: '100%'
     },
     tablet: {
-      flexDirection: 'column'
+      flexDirection: 'column',
+      width: '100%'
     }
   },
   leftSection: {
@@ -62,7 +64,6 @@ export const AssetDetailContent = ({ mint }: AssetDetailProps) => {
         <BalanceSection mint={mint} />
         <AssetInfoSection mint={mint} />
       </Flex>
-
       <Flex css={styles.rightSection}>
         <AssetInsights mint={mint} />
         <AssetLeaderboardCard mint={mint} />

--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -23,7 +23,11 @@ export const AssetDetailPage = () => {
 
   if (coinLoading) {
     return (
-      <Flex justifyContent='center' alignItems='center' h='100vh'>
+      <Flex
+        justifyContent='center'
+        alignItems='center'
+        css={{ minHeight: '100vh' }}
+      >
         <LoadingSpinner />
       </Flex>
     )


### PR DESCRIPTION
### Description

- Tablet layout was teeny, tweaks container to stretch it
- Mobile web was getting cut off at the bottom, fixed the height and added padding. 
  - TODO: padding on the page seems too much but this kinda seems like an issue with our page container?

![2025-08-15 11 00 11](https://github.com/user-attachments/assets/8c287596-ed80-412d-960f-857c6e941861)

<img width="521" height="849" alt="image" src="https://github.com/user-attachments/assets/712db0e0-5d5c-454f-a42f-58ddfacba538" />


### How Has This Been Tested?

web:stage