### PR TITLE
[PE-6709|PE-6710|PE-6707] Artist coin QA pass

### DIFF
--- a/packages/common/src/api/tan-query/coins/useUserCoin.ts
+++ b/packages/common/src/api/tan-query/coins/useUserCoin.ts
@@ -35,9 +35,6 @@ export const useUserCoin = <TResult = UserCoinWithAccounts | null>(
     queryKey: getUserCoinQueryKey(params.mint, userId),
     queryFn: async () => {
       const sdk = await audiusSdk()
-      if (!userId || !params.mint) {
-        return null
-      }
 
       const response = await sdk.users.getUserCoin({
         id: Id.parse(userId),

--- a/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
+++ b/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
@@ -6,7 +6,11 @@ import {
 } from '@solana/web3.js'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-import { useCurrentAccountUser, useQueryContext } from '~/api'
+import {
+  getUserCoinQueryKey,
+  useCurrentAccountUser,
+  useQueryContext
+} from '~/api'
 import { Feature } from '~/models'
 import {
   convertJupiterInstructions,
@@ -15,8 +19,6 @@ import {
 } from '~/services/Jupiter'
 import { useTokens } from '~/store/ui/buy-sell'
 import { TokenInfo } from '~/store/ui/buy-sell/types'
-
-import { QUERY_KEYS } from '../queryKeys'
 
 import {
   ClaimableTokenMint,
@@ -207,18 +209,6 @@ export const useSwapTokens = () => {
         errorStage = 'TRANSACTION_RELAY'
         signature = await sdk.services.solanaClient.sendTransaction(swapTx)
 
-        // ---------- 6. Success & Optimistic Updates ----------
-        if (user?.wallet) {
-          // Invalidate USDC balance separately if needed
-          queryClient.invalidateQueries({
-            queryKey: [QUERY_KEYS.usdcBalance, user.wallet]
-          })
-        }
-
-        await queryClient.invalidateQueries({
-          queryKey: [QUERY_KEYS.userCoins]
-        })
-
         return {
           status: SwapStatus.SUCCESS,
           signature,
@@ -243,6 +233,41 @@ export const useSwapTokens = () => {
           inputAmount: quoteResult?.inputAmount,
           outputAmount: quoteResult?.outputAmount
         })
+      }
+    },
+    onSuccess: (result, params) => {
+      const { inputMint, outputMint } = params
+      const { inputAmount, outputAmount } = result
+      if (inputMint) {
+        queryClient.setQueryData(
+          getUserCoinQueryKey(inputMint, user?.user_id),
+          (prevAccountBalances) => {
+            if (!prevAccountBalances) return null
+
+            return {
+              ...prevAccountBalances,
+              // Update aggregate balance (includes connected wallets)
+              balance: prevAccountBalances?.balance - (inputAmount?.amount ?? 0)
+              // TODO: Update internal wallet balance
+            }
+          }
+        )
+      }
+      if (outputMint) {
+        queryClient.setQueryData(
+          getUserCoinQueryKey(outputMint, user?.user_id),
+          (prevAccountBalances) => {
+            if (!prevAccountBalances) return null
+
+            return {
+              ...prevAccountBalances,
+              // Update aggregate balance
+              balance:
+                prevAccountBalances?.balance + (outputAmount?.amount ?? 0)
+              // TODO: Update internal wallet balance
+            }
+          }
+        )
       }
     },
     onMutate: () => {

--- a/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
+++ b/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
@@ -246,9 +246,18 @@ export const useSwapTokens = () => {
 
             return {
               ...prevAccountBalances,
-              // Update aggregate balance (includes connected wallets)
-              balance: prevAccountBalances?.balance - (inputAmount?.amount ?? 0)
-              // TODO: Update internal wallet balance
+              // Update aggregate account balance (includes connected wallets)
+              balance:
+                prevAccountBalances?.balance - (inputAmount?.amount ?? 0),
+              // Update internal wallet balance (we only do swaps against internal wallets)
+              accounts: prevAccountBalances.accounts.map((account) =>
+                account.isInAppWallet
+                  ? {
+                      ...account,
+                      balance: account.balance - (inputAmount?.amount ?? 0)
+                    }
+                  : account
+              )
             }
           }
         )
@@ -261,10 +270,18 @@ export const useSwapTokens = () => {
 
             return {
               ...prevAccountBalances,
-              // Update aggregate balance
+              // Update aggregate account balance (includes connected wallets)
               balance:
-                prevAccountBalances?.balance + (outputAmount?.amount ?? 0)
-              // TODO: Update internal wallet balance
+                prevAccountBalances?.balance + (outputAmount?.amount ?? 0),
+              // Update internal wallet balance (we only do swaps against internal wallets)
+              accounts: prevAccountBalances.accounts.map((account) =>
+                account.isInAppWallet
+                  ? {
+                      ...account,
+                      balance: account.balance + (outputAmount?.amount ?? 0)
+                    }
+                  : account
+              )
             }
           }
         )

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -96,7 +96,6 @@ export const QUERY_KEYS = {
   eventsByEntityId: 'eventsByEntityId',
   walletOwner: 'walletOwner',
   tokenPrice: 'tokenPrice',
-  tokenBalance: 'tokenBalance',
   usdcBalance: 'usdcBalance',
   fileSizes: 'fileSizes',
   managedAccounts: 'managedAccounts',

--- a/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenSwapForm.ts
@@ -110,7 +110,8 @@ export const useTokenSwapForm = ({
 
   const { data: inputTokenBalanceData, isPending: isBalanceLoading } =
     useTokenBalance({
-      mint: inputToken.address
+      mint: inputToken.address,
+      includeExternalWallets: false
     })
 
   // Get token price for USD-based limit calculations

--- a/packages/web/src/pages/asset-detail-page/components/ExternalWallets.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/ExternalWallets.tsx
@@ -164,7 +164,7 @@ const WalletRow = ({
 }
 
 export const ExternalWallets = ({ mint }: AssetDetailProps) => {
-  const { data: userCoins, isPending } = useUserCoin({
+  const { data: userCoins, isLoading } = useUserCoin({
     mint
   })
   const { accounts: unsortedAccounts = [], decimals } = userCoins ?? {}
@@ -213,7 +213,7 @@ export const ExternalWallets = ({ mint }: AssetDetailProps) => {
         </Text>
       </Flex>
       <Divider css={{ width: '100%' }} />
-      {!hasAccounts && !isPending && (
+      {!hasAccounts && !isLoading && (
         <Flex direction='column' pv='m' ph='l'>
           <Text variant='body' size='m' color='subdued'>
             {messages.description}
@@ -232,7 +232,7 @@ export const ExternalWallets = ({ mint }: AssetDetailProps) => {
             />
           ))}
         </Flex>
-      ) : isPending ? (
+      ) : isLoading ? (
         <Flex
           direction='column'
           alignItems='center'


### PR DESCRIPTION
### Description

Combined 3 QA items into one PR

- PE-6709 - Fix swap balances accounting for your external wallets - added a prop to `useTokenBalance` to ignore external wallets
- PE-6710 - Fix optimistic updates after swaps - `invalidateQueries` doesnt seem to be timing out right, I've seen it work a handful of times but I think its a race condition. Swapped it to a calculated mutation instead
- PE-6707 - Link external wallet infinite spinning - Fixed by using `isLoading` instead of `isPending`, bit of a tan-query quirk here where if your queryFn never runs you get `isPending` forever. `isLoading` is the more correct status to use here since 

### How Has This Been Tested?

web:stage 
- swap modal shows internal wallet balance 
- unauthed user shows external wallets as expected
- did convert flow, mutations look good
TODO: test buy & sell flows as well
![2025-08-15 17 15 23](https://github.com/user-attachments/assets/e26bd178-37f2-4597-8188-599455176b11)


