### PR TITLE
Drop es indexes before reindexing

### DIFF
--- a/dev-tools/compose/docker-compose.api.yml
+++ b/dev-tools/compose/docker-compose.api.yml
@@ -13,7 +13,7 @@ services:
         condition: service_healthy
     ports:
       - 1323:1323
-    command: ['/bin/sh', '-c', 'bridge es-indexer && bridge']
+    command: ['/bin/sh', '-c', 'bridge es-indexer drop && bridge']
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2


### PR DESCRIPTION
Fixes:
```
Reindexing ElasticSearch (collections=[], drop=false)...
panic: error creating index users: 400 {"error":{"root_cause":[{"type":"resource_already_exists_exception","reason":"index [users/grXkToXgSoiaqnb41ysO9A] already exists","index_uuid":"grXkToXgSoiaqnb41ysO9A","index":"users"}],"type":"resource_already_exists_exception","reason":"index [users/grXkToXgSoiaqnb41ysO9A] already exists","index_uuid":"grXkToXgSoiaqnb41ysO9A","index":"users"},"status":400}

goroutine 1 [running]:
bridgerton.audius.co/esindexer.Reindex(0xc000364900, 0xc000330280, 0x0, {0xc00004e0a0, 0x0, 0xc0000d2340?})
	/app/esindexer/reindex.go:105 +0x5c5
bridgerton.audius.co/esindexer.ReindexLegacy(0x0, {0xc00004e0a0, 0x0, 0x0})
	/app/esindexer/reindex.go:141 +0x51
main.main()
	/app/main.go:54 +0x6ad
```