### PR TITLE
Fix bug with purchase split calculation

### DIFF
--- a/packages/sdk/src/sdk/utils/preparePaymentSplits.ts
+++ b/packages/sdk/src/sdk/utils/preparePaymentSplits.ts
@@ -22,16 +22,15 @@ export const prepareSplits = async ({
   claimableTokensClient: ClaimableTokensClient
   logger: LoggerService
 }) => {
-  const userSplitCount = splits.filter((s) => !!s.userId).length
+  const userSplits = splits.filter((s) => !!s.userId)
+  const userSplitCount = userSplits.length
+  const networkSplit = splits.find((s) => !s.userId)
+
   logger.debug(
     `Splitting the extra ${extraAmount} between ${userSplitCount} user(s)...`
   )
   // Convert splits to big int and spread extra amount to every split
-  let amountSplits = splits.map((split, index) => {
-    // Only give extra payments to users
-    if (!split.userId) {
-      return { ...split, amount: BigInt(split.amount) }
-    }
+  let amountSplits = userSplits.map((split, index) => {
     const amountToAdd = extraAmount / BigInt(userSplitCount - index)
     extraAmount = USDC(extraAmount - amountToAdd).value
     return {
@@ -39,6 +38,13 @@ export const prepareSplits = async ({
       amount: BigInt(split.amount) + amountToAdd
     }
   })
+  // Add network split if it exists
+  if (networkSplit) {
+    amountSplits.push({
+      ...networkSplit,
+      amount: BigInt(networkSplit.amount)
+    })
+  }
   if (extraAmount > 0) {
     logger.debug('Calculated splits after extra amount:', amountSplits)
   }

--- a/packages/sdk/src/sdk/utils/preparePaymentSplits.ts
+++ b/packages/sdk/src/sdk/utils/preparePaymentSplits.ts
@@ -24,7 +24,7 @@ export const prepareSplits = async ({
 }) => {
   const userSplits = splits.filter((s) => !!s.userId)
   const userSplitCount = userSplits.length
-  const networkSplit = splits.find((s) => !s.userId)
+  const networkSplit = splits.filter((s) => !s.userId)
 
   logger.debug(
     `Splitting the extra ${extraAmount} between ${userSplitCount} user(s)...`
@@ -39,12 +39,12 @@ export const prepareSplits = async ({
     }
   })
   // Add network split if it exists
-  if (networkSplit) {
-    amountSplits.push({
-      ...networkSplit,
-      amount: BigInt(networkSplit.amount)
-    })
-  }
+  amountSplits = amountSplits.concat(
+    networkSplit.map((split) => ({
+      ...split,
+      amount: BigInt(split.amount)
+    }))
+  )
   if (extraAmount > 0) {
     logger.debug('Calculated splits after extra amount:', amountSplits)
   }


### PR DESCRIPTION
### Description
There was a bridge change that changed the order in which network splits occurred in the splits response.
Some brittle frontend code relied on this ordering.
Now we just remove the network split from the extra amount allocation logic entirely.

### How Has This Been Tested?

Tested purchase with extra amount on stage

<img width="738" height="510" alt="Screenshot 2025-08-19 at 11 33 11 AM" src="https://github.com/user-attachments/assets/bbf4101d-c272-4a37-ae4f-83e7f8ba97f3" />
