### PR TITLE
[PE-6714] Only show add cash when no USDC balance

### DIFF
--- a/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
@@ -1,4 +1,8 @@
-import { useArtistCoins, useTokenBalance } from '@audius/common/api'
+import {
+  useArtistCoins,
+  useTokenBalance,
+  useUSDCBalance
+} from '@audius/common/api'
 import { useFormattedTokenBalance } from '@audius/common/hooks'
 import { walletMessages } from '@audius/common/messages'
 import {
@@ -150,6 +154,7 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
     mint: [mint]
   })
   const { data: tokenBalance } = useTokenBalance({ mint })
+  const { data: usdcBalance } = useUSDCBalance()
 
   const coin = coinInsights?.[0]
 
@@ -172,8 +177,13 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
   }, [openBuySellModal])
 
   const handleAddCash = useRequiresAccountCallback(() => {
-    // No balance - show add cash modal (uses Coinflow)
-    openAddCashModal()
+    if (usdcBalance && usdcBalance > 0) {
+      // Has USDC balance - show buy/sell modal
+      openBuySellModal()
+    } else {
+      // No USDC balance - show add cash modal (uses Coinflow)
+      openAddCashModal()
+    }
   }, [openAddCashModal])
 
   const handleReceive = useRequiresAccountCallback(() => {


### PR DESCRIPTION
### Description
Check USDC balance and only open the add cash modal if USDC balance is 0.

### How Has This Been Tested?

tested on web stage