### PR TITLE
Fix flakey ampm test

### DIFF
--- a/packages/common/src/utils/timeUtil.test.ts
+++ b/packages/common/src/utils/timeUtil.test.ts
@@ -82,13 +82,13 @@ describe('formatContestDeadline', () => {
   test('should format deadline with card format', () => {
     const result = formatContestDeadline('2023-12-17T15:30:00Z', 'card')
     expect(result).toContain('12/17/23 at')
-    expect(result).toContain('AM') // or PM depending on timezone
+    expect(result).toMatch(/(AM|PM)/)
   })
 
   test('should format deadline with long format', () => {
     const result = formatContestDeadline('2023-12-17T15:30:00Z', 'long')
     expect(result).toContain('Sun. Dec 17, 2023 at')
-    expect(result).toContain('AM') // or PM depending on timezone
+    expect(result).toMatch(/(AM|PM)/)
     expect(result).toContain(getLocalTimezone())
   })
 


### PR DESCRIPTION
### Description

This test can flake depending on the tz of where it's run

https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/75954/workflows/5887162c-fcc0-499a-8666-c35cea7ee92d/jobs/1097120?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
```
cd packages/common
npm run test -- src/utils/timeUtil.test.ts
```