### PR TITLE
[PE-6725] Remove ai-attribution from uploadTrack e2e test

### DIFF
--- a/packages/web/e2e/data.ts
+++ b/packages/web/e2e/data.ts
@@ -132,18 +132,3 @@ export const getPlaylist = () => {
     name: 'PROBERS_PLAYLIST_DO_NOT_DELETE'
   }
 }
-
-export const getAiAttributionUser = () => {
-  if (runAgainstLocalStack) {
-    const { handle, name } = user2()
-
-    return {
-      handle,
-      name
-    }
-  }
-
-  return {
-    name: 'probers ai DO NOT DELETE'
-  }
-}

--- a/packages/web/e2e/uploadTrack.test.ts
+++ b/packages/web/e2e/uploadTrack.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 
-import { getAiAttributionUser, getTrack } from './data'
+import { getTrack } from './data'
 import {
   RemixSettingsModal,
   TrackPriceAndAudienceModal,
@@ -50,9 +50,8 @@ test('should upload a track', async ({ page }) => {
 
 // TODO: re-enable if we decide it's critical path
 // https://linear.app/audius/issue/INF-703/re-enable-uploadtracktestts-advanced-test-cases
-test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
+test('should upload a remix hidden track', async ({ page }) => {
   const { title, permalink } = getTrack()
-  const { name: aiAttributionName } = getAiAttributionUser()
   const trackTitle = `Test track ${Date.now()}`
   const trackDescription = 'Test description'
   const genre = 'Alternative'
@@ -103,7 +102,6 @@ test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
 
   await editPage.openAttributionSettings()
   const attributionModal = new AdvancedModal(page)
-  await attributionModal.markAsAIGenerated(aiAttributionName)
   await attributionModal.setISRC(isrc)
   await attributionModal.setISWC(iswc)
   await attributionModal.setAllowAttribution(true)
@@ -154,9 +152,6 @@ test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
   // Assert remix
   await expect(page.getByText('ORIGINAL TRACK')).toBeVisible()
   await expect(page.getByRole('link', { name: remixName })).toBeVisible()
-
-  // Assert AI generated
-  await expect(page.getByText('generated with ai').first()).toBeVisible()
 
   // Assert ISRC
   // TODO


### PR DESCRIPTION
### Description
Removing this ai attribution test to get e2e green. See linear ticket for more details.

### How Has This Been Tested?

CI