### PR TITLE
Drop track tile on upload complete screen

### DIFF
--- a/packages/mobile/src/screens/upload-screen/screens/UploadCompleteScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadCompleteScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { useCurrentAccountUser, useTrack } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import { Name, ShareSource } from '@audius/common/models'
 import type { CommonState } from '@audius/common/store'
 import {
@@ -21,7 +21,6 @@ import {
 } from '@audius/harmony-native'
 import EmojiRaisedHands from 'app/assets/images/emojis/person-raising-both-hands-in-celebration.png'
 import { Text, Tile } from 'app/components/core'
-import { LineupTileSkeleton, TrackTile } from 'app/components/lineup-tile'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { FormScreen } from 'app/screens/form-screen'
 import { makeStyles } from 'app/styles'
@@ -81,7 +80,6 @@ export const UploadCompleteScreen = () => {
   )
   const navigation = useNavigation()
   const dispatch = useDispatch()
-  const { data: accountUser } = useCurrentAccountUser()
   const { data: track } = useTrack(trackId)
   const trackRoute = track ? getTrackRoute(track, true) : ''
 
@@ -89,11 +87,6 @@ export const UploadCompleteScreen = () => {
     navigation.getParent()?.goBack()
     dispatch(reset())
   }, [navigation, dispatch])
-
-  const handlePressTrack = useCallback(() => {
-    handleClose()
-    navigation.push('Track', { trackId })
-  }, [handleClose, navigation, trackId])
 
   const handleDone = useCallback(() => {
     handleClose()
@@ -175,17 +168,6 @@ export const UploadCompleteScreen = () => {
             </>
           ) : null}
         </Tile>
-        {accountUser && track ? (
-          <TrackTile
-            id={track.track_id}
-            uid={''}
-            index={0}
-            togglePlay={() => {}}
-            onPress={handlePressTrack}
-          />
-        ) : (
-          <LineupTileSkeleton />
-        )}
       </View>
     </FormScreen>
   )


### PR DESCRIPTION
### Description

Issue where track is typically not available at upload complete on mobile due to unknown issue. For now just dropping the skeleton so it doesn't look extra weird. user can go to profile and will see the track