### PR TITLE
Raise priority fee max

### DIFF
--- a/packages/sdk/src/sdk/services/Solana/programs/SolanaClient.ts
+++ b/packages/sdk/src/sdk/services/Solana/programs/SolanaClient.ts
@@ -83,7 +83,7 @@ export class SolanaClient {
       priorityFee = {
         priority: 'VERY_HIGH',
         minimumMicroLamports: 150_000,
-        maximumMicroLamports: 1_000_000,
+        maximumMicroLamports: 10_000_000,
         multiplier: 1.5
       },
       computeLimit = { simulationMultiplier: 1.5 }


### PR DESCRIPTION
Raises our default priority fee maximum 10x.

Current theory is this is perhaps capping our fees too low.