### PR TITLE
[PE-6721] Fix badge hover card in left nav profile

### DIFF
--- a/packages/harmony/src/components/hover-card/HoverCard.tsx
+++ b/packages/harmony/src/components/hover-card/HoverCard.tsx
@@ -85,7 +85,6 @@ const HoverCardComponent = ({
         anchorRef={anchorRef}
         isVisible={isVisible}
         onClose={handleClose}
-        dismissOnMouseLeave={triggeredBy !== 'click'}
         hideCloseButton
         zIndex={30000}
         anchorOrigin={anchorOrigin}

--- a/packages/web/src/components/user-badges/UserBadges.tsx
+++ b/packages/web/src/components/user-badges/UserBadges.tsx
@@ -39,6 +39,10 @@ import { AudioHoverCard } from 'components/hover-card/AudioHoverCard'
 
 import styles from './UserBadges.module.css'
 
+const messages = {
+  verified: 'Verified'
+}
+
 export const audioTierMap: {
   [tier in BadgeTier]: Nullable<ReactElement>
 } = {
@@ -121,7 +125,7 @@ const UserBadges = ({
           <Flex alignItems='center' justifyContent='center' gap='s' p='s'>
             <IconVerified size='l' />
             <Text variant='title' size='l'>
-              Verified
+              {messages.verified}
             </Text>
           </Flex>
         }


### PR DESCRIPTION
### Description
Why dismissOnMouseLeave Causes Issues in LeftNav
Looking at the LeftNav structure, there are multiple overflow: 'hidden' containers:
LeftNav main container (line 93): overflow: 'hidden'
AccountDetails container (line 90): overflow: 'hidden'
Flex containers (line 112): overflow: 'hidden'
When dismissOnMouseLeave={triggeredBy !== 'click'} is active, the Popup component listens for mouse leave events. In the constrained LeftNav layout, when you move your mouse from the trigger badge to the hover card content, your mouse briefly passes through areas that are clipped by overflow: hidden. This makes the Popup think you've left the hover area entirely, triggering the dismiss.

The fix disables the Popup's mouse leave detection and relies entirely on the HoverCard's own useHoverDelay hook for mouse enter/leave handling. The useHoverDelay hook is more robust because it only tracks mouse events on the direct trigger element, not the entire popup area.

Why It Works Elsewhere
In other contexts (like the main content area), there are fewer nested containers with overflow: hidden, so the mouse path from trigger to popup content doesn't get interrupted by clipped areas.

### How Has This Been Tested?



https://github.com/user-attachments/assets/3ffa6c68-8167-4b91-aeb0-e34b75b03ebf

