### PR TITLE
$AUDIO balance includes staked

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -168,13 +168,14 @@ export const useWalletAudioBalances = (
 type UseAudioBalanceOptions = {
   /** Whether to include connected/linked wallets in the balance calculation. Defaults to true. */
   includeConnectedWallets?: boolean
+  includeStaked?: boolean
 }
 
 /**
  * Hook for getting the AUDIO balance of the current user, optionally including connected wallets.
  */
 export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
-  const { includeConnectedWallets = true } = options
+  const { includeConnectedWallets = true, includeStaked = false } = options
 
   // Get account balances
   const { data: currentUserId } = useCurrentUserId()
@@ -210,7 +211,8 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   } = useConnectedWallets()
   const connectedWalletsBalances = useWalletAudioBalances(
     {
-      wallets: connectedWallets
+      wallets: connectedWallets,
+      includeStaked
     },
     { enabled: isConnectedWalletsFetched && includeConnectedWallets }
   )

--- a/packages/web/src/pages/audio-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-page/components/WalletManagementTile.tsx
@@ -277,7 +277,8 @@ const ManageWalletsButton = () => {
 export const WalletManagementTile = () => {
   const isManagedAccount = useIsManagedAccount()
   const { totalBalance, isLoading: isBalanceLoading } = useAudioBalance({
-    includeConnectedWallets: true
+    includeConnectedWallets: true,
+    includeStaked: true
   })
   const { data: connectedWallets } = useConnectedWallets()
   const [, setOpen] = useModalState('AudioBreakdown')


### PR DESCRIPTION
### Description
While playing around with $AUDIO recovery I noticed my $AUDIO balance didn't match the amount reported in the $AUDIO breakdown modal. Discovered the total $AUDIO balance wasn't including the staked amount, which the modal was. So piped the `includeStaked` option down from the component.

### How Has This Been Tested?

Now they match:

https://github.com/user-attachments/assets/1f92018a-de49-4a17-8d9b-bc58d99fdc22

