### PR TITLE
OEmbed: Don't use OG url

### DIFF
--- a/packages/web/src/components/meta-tags/MetaTags.tsx
+++ b/packages/web/src/components/meta-tags/MetaTags.tsx
@@ -155,7 +155,7 @@ export const MetaTags = (props: MetaTagsProps) => {
         <link
           rel='alternate'
           type='application/json+oembed'
-          href={`${env.AUDIUS_URL}/oembed?url=${ogUrl || canonicalUrl}&format=json`}
+          href={`${env.AUDIUS_URL}/oembed?url=${canonicalUrl}&format=json`}
           title={formattedTitle}
         />
       </Helmet>


### PR DESCRIPTION
OEmbed links didn't work in the case they were rendered via SSR because the `ogUrl` is not what we want