### PR TITLE
[PE-6708] Fixes to artist coin members leaderboard

### DIFF
--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
@@ -1,12 +1,16 @@
 import { FixedDecimal } from '@audius/fixed-decimal'
 import { HashId } from '@audius/sdk'
-import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  UseInfiniteQueryOptions
+} from '@tanstack/react-query'
 
 import { useQueryContext } from '~/api/tan-query/utils'
 import { ID } from '~/models'
 
 import { QUERY_KEYS } from '../queryKeys'
-import { QueryKey, QueryOptions } from '../types'
+import { QueryKey } from '../types'
 
 import { useArtistCoin } from './useArtistCoin'
 
@@ -39,14 +43,17 @@ export const getCoinLeaderboardQueryKey = (
     sortDirection
   ] as unknown as QueryKey<InfiniteData<CoinMember[], number>>
 
-export const useArtistCoinMembers = (
+export const useArtistCoinMembers = <TResult = CoinMember[]>(
   {
     mint,
     pageSize = DEFAULT_PAGE_SIZE,
     minBalance,
     sortDirection = 'desc'
   }: UseArtistCoinMembersArgs,
-  options?: QueryOptions
+  options?: Pick<
+    UseInfiniteQueryOptions<CoinMember[], Error, TResult>,
+    'select' | 'enabled'
+  >
 ) => {
   const { audiusSdk } = useQueryContext()
 
@@ -69,7 +76,7 @@ export const useArtistCoinMembers = (
       if (lastPage.length < pageSize) return undefined
       return allPages.length * pageSize
     },
-    queryFn: async ({ pageParam }): Promise<CoinMember[]> => {
+    queryFn: async ({ pageParam }) => {
       if (!mint) return []
 
       const sdk = await audiusSdk()
@@ -103,8 +110,7 @@ export const useArtistCoinMembers = (
 
       return members
     },
-    select: (data) => data.pages.flat(),
-    ...options,
+    select: options?.select ?? ((data) => data.pages.flat() as TResult),
     enabled: options?.enabled !== false && !!mint
   })
 }

--- a/packages/web/src/components/user-profile-picture-list/UserProfilePictureList.tsx
+++ b/packages/web/src/components/user-profile-picture-list/UserProfilePictureList.tsx
@@ -36,7 +36,7 @@ export type UserProfileListProps = {
    * When this is the case, we use this totalUserCount prop to inform how many total users there are.
    */
   users: Array<User>
-  totalUserCount: number
+  totalUserCount: number | undefined | null // Note: undefined/null was added to support case where totalUserCount is loading separately
   limit?: number
   disableProfileClick?: boolean
   disablePopover?: boolean
@@ -140,7 +140,9 @@ export const UserProfilePictureList = ({
               user={lastUser}
             />
             <span className={styles.profilePictureCount}>
-              {messages.count(remainingUsersCount)}
+              {remainingUsersCount > 0
+                ? messages.count(remainingUsersCount)
+                : null}
             </span>
           </div>
         </Tooltip>

--- a/packages/web/src/pages/asset-detail-page/components/AssetLeaderboardCard.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetLeaderboardCard.tsx
@@ -1,4 +1,8 @@
-import { useArtistCoinMembers, useUsers } from '@audius/common/api'
+import {
+  useArtistCoinInsights,
+  useArtistCoinMembers,
+  useUsers
+} from '@audius/common/api'
 import { coinDetailsMessages } from '@audius/common/messages'
 import {
   Flex,
@@ -39,14 +43,23 @@ type AssetLeaderboardCardProps = {
 }
 
 export const AssetLeaderboardCard = ({ mint }: AssetLeaderboardCardProps) => {
+  const { isMedium: isSmallScreen } = useMedia() // <1024px
+  const numUsersShowing = isSmallScreen ? 6 : 8
   const { data: leaderboardUsers, isPending: isLeaderboardPending } =
-    useArtistCoinMembers({ mint })
+    useArtistCoinMembers(
+      { mint },
+      {
+        select: (data) => {
+          return data.pages.flat().slice(0, numUsersShowing)
+        }
+      }
+    )
   const { data: users, isPending: isUsersPending } = useUsers(
     leaderboardUsers?.map((user) => user.userId)
   )
+  const coinInsights = useArtistCoinInsights({ mint })
   const dispatch = useDispatch()
   const isPending = isLeaderboardPending || isUsersPending
-  const { isMedium: isSmallScreen } = useMedia() // <1024px
 
   const handleViewLeaderboard = () => {
     dispatch(
@@ -100,7 +113,7 @@ export const AssetLeaderboardCard = ({ mint }: AssetLeaderboardCardProps) => {
           >
             <UserProfilePictureList
               users={users ?? []}
-              totalUserCount={leaderboardUsers?.length ?? 0}
+              totalUserCount={coinInsights?.data?.members}
               limit={isSmallScreen ? 6 : 8}
               disableProfileClick={true}
               disablePopover={true}


### PR DESCRIPTION
### Description

- Fixed the issue where the members leaderboard card would show a load state as you scrolled through the leaderboard modal
- Fixed the issue where it was showing the total user count from whatever we loaded in the first page, now it shows the total number based on the insights endpoint. (this is audio on prod)
<img width="402" height="165" alt="image" src="https://github.com/user-attachments/assets/7bea112a-f30b-4c62-af35-e62787dd6c27" />

- One thing I did run into with this was that the insights endpoint still is kind of slow sometimes, and previously the userlist component assumed you would always have the total count whenever you have data. Instead of halting all rendering I just made the "+xyz" count not show if undefined/null

![2025-08-22 18 03 13](https://github.com/user-attachments/assets/3dfd2cb7-c277-45dd-8c8a-5c174b0db22b)

### How Has This Been Tested?

web:prod
