### PR TITLE
[PE-6540] Fix artist coin blast logos

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ArtistCoinHeader.tsx
+++ b/packages/mobile/src/screens/chat-screen/ArtistCoinHeader.tsx
@@ -25,18 +25,6 @@ export const ArtistCoinHeader = ({
 
   if (!artistCoinSymbol) return null
 
-  const ArtistCoinIcon = !isLoading ? (
-    <HexagonalIcon size={spacing.m}>
-      <Image
-        source={{ uri: tokens[artistCoinSymbol]?.logoURI }}
-        style={{
-          width: spacing.m,
-          height: spacing.m
-        }}
-      />
-    </HexagonalIcon>
-  ) : undefined
-
   return (
     <Flex
       row
@@ -49,7 +37,17 @@ export const ArtistCoinHeader = ({
       borderBottom='default'
     >
       <Flex row gap='xs' alignItems='center'>
-        {ArtistCoinIcon}
+        {!isLoading ? (
+          <HexagonalIcon size={spacing.m}>
+            <Image
+              source={{ uri: tokens[artistCoinSymbol]?.logoURI }}
+              style={{
+                width: spacing.m,
+                height: spacing.m
+              }}
+            />
+          </HexagonalIcon>
+        ) : undefined}
         {/* Alignment bug for label text variant on iOS */}
         <Flex mt={Platform.OS === 'ios' ? '2xs' : 'none'}>
           <Text variant='label' size='s'>

--- a/packages/web/src/pages/chat-page/components/ArtistCoinHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ArtistCoinHeader.tsx
@@ -24,16 +24,6 @@ export const ArtistCoinHeader = ({
 
   if (!artistCoinSymbol) return null
 
-  const artistCoinLogo = !isLoading ? (
-    <Artwork
-      src={tokens[artistCoinSymbol]?.logoURI}
-      hex
-      w={spacing.m}
-      h={spacing.m}
-      borderWidth={0}
-    />
-  ) : undefined
-
   return (
     <Flex
       ph='l'
@@ -45,7 +35,15 @@ export const ArtistCoinHeader = ({
       borderBottom='default'
     >
       <Flex gap='xs' alignItems='center'>
-        {artistCoinLogo}
+        {!isLoading ? (
+          <Artwork
+            src={tokens[artistCoinSymbol]?.logoURI}
+            hex
+            w={spacing.m}
+            h={spacing.m}
+            borderWidth={0}
+          />
+        ) : undefined}
         <Text variant='label' size='s'>
           {artistCoinSymbol}
         </Text>


### PR DESCRIPTION
### Description
Fixed these logos, were not showing before.

Should we centralize the logo/image function somewhere?

### How Has This Been Tested?

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-25 at 15 21 34" src="https://github.com/user-attachments/assets/2b707d65-bbb7-4829-832d-6b16c775a4f0" />
<img width="369" height="731" alt="Screenshot 2025-08-25 at 3 21 39 PM" src="https://github.com/user-attachments/assets/68504d0c-854c-4e75-8802-bc35f141b869" />
