### PR TITLE
[PE-6706] Fix userbadge gap

### DIFF
--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -113,7 +113,7 @@ const SignedInView = ({
       <Avatar userId={userId} h={48} w={48} />
       <AccountInfo>
         <Flex alignItems='center' justifyContent='space-between' gap='s' h={20}>
-          <Flex css={{ maxWidth: '85%' }}>
+          <Flex css={{ maxWidth: '85%', overflow: 'hidden' }}>
             <UserLink
               popover
               textVariant='title'

--- a/packages/web/src/components/user-badges/UserBadges.module.css
+++ b/packages/web/src/components/user-badges/UserBadges.module.css
@@ -2,11 +2,11 @@
   display: flex;
   overflow: visible;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
 }
 
 .inlineContainer {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
 }


### PR DESCRIPTION
### Description
- Decrease gap between userbadges to 2px
- Add overflow: hidden to account details in left nav

Ideally we'd like to ellipsize the username but always show the badges. Couldn't figure out a quick fix for that atm, this is at least an improvement.

### How Has This Been Tested?

<img width="277" height="120" alt="Screenshot 2025-08-25 at 4 28 17 PM" src="https://github.com/user-attachments/assets/862a2c4f-e0b4-4f82-a4fc-afc5a1cd18e8" />
<img width="399" height="94" alt="Screenshot 2025-08-25 at 4 30 37 PM" src="https://github.com/user-attachments/assets/669c3bf8-428d-4599-8607-499ac957bdfb" />
