### PR TITLE
[PE-6716] Fix AssetDetailsPage wrong bottom padding

### DIFF
--- a/packages/web/src/components/user-list/lists/CoinLeaderboardUserList.tsx
+++ b/packages/web/src/components/user-list/lists/CoinLeaderboardUserList.tsx
@@ -9,7 +9,7 @@ export const CoinLeaderboardUserList = () => {
   const mint = useSelector(coinLeaderboardUserListSelectors.getMint)
 
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, isPending } =
-    useArtistCoinMembers({ mint: mint || '' })
+    useArtistCoinMembers({ mint: mint ?? '' })
 
   if (!mint) return null
 

--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -15,7 +15,7 @@ export const AssetDetailPage = () => {
     data: coin,
     isLoading: coinLoading,
     error: coinError
-  } = useArtistCoin({ mint: mint || '' })
+  } = useArtistCoin({ mint: mint ?? '' })
 
   if (!mint) {
     return <Redirect to='/wallet' />

--- a/packages/web/src/pages/asset-detail-page/components/AssetInsights.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInsights.tsx
@@ -31,15 +31,15 @@ const AssetInsightsSkeleton = () => {
           alignItems='flex-start'
           justifyContent='space-between'
           borderTop='default'
-          pv='m'
+          pv='l'
           ph='l'
           w='100%'
         >
-          <Flex direction='column' alignItems='flex-start' gap='xs' flex={1}>
+          <Flex column alignItems='flex-start' gap='l' flex={1}>
             <Skeleton width='80px' height='32px' />
             <Skeleton width='120px' height='20px' />
           </Flex>
-          <Flex direction='row' alignItems='center' gap='xs'>
+          <Flex row alignItems='center' gap='xs'>
             <Skeleton width='60px' height='16px' />
             <Skeleton width='16px' height='16px' />
           </Flex>


### PR DESCRIPTION
### Description
Found it was due to skeleton heights not matching real content, once data loaded in it increased the height of the whole page.

### How Has This Been Tested?

I'd gotten consistent repro by:
- Refresh
- starting at wallet page (http://localhost:3001/wallet)
- Clicking on $AUDIO

Tried a bunch of times, no repro of the bug after this fix.