### PR TITLE
[PE-6641|PE-6642] Artist coin popover fixes

### DIFF
--- a/packages/harmony/src/components/hover-card/HoverCard.tsx
+++ b/packages/harmony/src/components/hover-card/HoverCard.tsx
@@ -81,7 +81,7 @@ const HoverCardComponent = ({
       {children}
 
       <Popup
-        shadow='near'
+        shadow='far'
         anchorRef={anchorRef}
         isVisible={isVisible}
         onClose={handleClose}
@@ -92,10 +92,12 @@ const HoverCardComponent = ({
       >
         <Paper
           className={className}
+          border='strong'
           borderRadius='m'
           backgroundColor='white'
           direction='column'
           onClick={onClick}
+          shadow='far'
         >
           {content}
         </Paper>

--- a/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
@@ -440,7 +440,8 @@ export const TokenAmountSection = ({
     title,
     tab,
     tokenInfo,
-    tooltipPlacement
+    tooltipPlacement,
+    onChangeSwapDirection
   ])
 
   return (

--- a/packages/web/src/components/hover-card/ArtistCoinHoverCard.tsx
+++ b/packages/web/src/components/hover-card/ArtistCoinHoverCard.tsx
@@ -12,7 +12,8 @@ import {
   IconArrowRight,
   useTheme
 } from '@audius/harmony'
-import { useNavigate } from 'react-router-dom-v5-compat'
+
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 
 import { HoverCardBody } from './HoverCardBody'
 
@@ -49,7 +50,7 @@ export const ArtistCoinHoverCard = ({
   onClick,
   triggeredBy
 }: ArtistCoinHoverCardProps) => {
-  const navigate = useNavigate()
+  const navigate = useNavigateToPage()
   const { cornerRadius, spacing } = useTheme()
 
   const { data: coin } = useArtistCoin({ mint })
@@ -58,9 +59,10 @@ export const ArtistCoinHoverCard = ({
     userId
   })
 
-  const handleNavigateToTokenPage = useCallback(() => {
+  const handleClick = useCallback(() => {
+    onClick?.()
     navigate(`${WALLET_PAGE}/${mint}`)
-  }, [navigate, mint])
+  }, [navigate, mint, onClick])
 
   if (!tokenBalance || !coin) return null
 
@@ -85,7 +87,7 @@ export const ArtistCoinHoverCard = ({
               ) : null
             }
             title={coinName}
-            onClick={handleNavigateToTokenPage}
+            onClick={handleClick}
             onClose={onClose}
             iconRight={IconArrowRight}
           />
@@ -109,7 +111,7 @@ export const ArtistCoinHoverCard = ({
       }
       anchorOrigin={anchorOrigin}
       transformOrigin={transformOrigin}
-      onClick={onClick}
+      onClick={handleClick}
       triggeredBy={triggeredBy}
     >
       {children}

--- a/packages/web/src/components/hover-card/AudioHoverCard.tsx
+++ b/packages/web/src/components/hover-card/AudioHoverCard.tsx
@@ -87,9 +87,10 @@ export const AudioHoverCard = ({
     ? formatBalance(currentUserBalance)
     : userBalance
 
-  const handleNavigateToAudioPage = useCallback(() => {
+  const handleClick = useCallback(() => {
+    onClick?.()
     navigate(AUDIO_PAGE)
-  }, [navigate])
+  }, [navigate, onClick])
 
   return (
     <HoverCard
@@ -98,7 +99,7 @@ export const AudioHoverCard = ({
           <HoverCardHeader
             iconLeft={audioTierBadgeMap[tier]}
             title={getBadgeName(tier)}
-            onClick={handleNavigateToAudioPage}
+            onClick={handleClick}
             onClose={onClose}
             iconRight={IconArrowRight}
           />
@@ -116,7 +117,7 @@ export const AudioHoverCard = ({
       }
       anchorOrigin={anchorOrigin}
       transformOrigin={transformOrigin}
-      onClick={onClick}
+      onClick={handleClick}
       triggeredBy={triggeredBy}
     >
       {children}


### PR DESCRIPTION
### Description

- Fixes popovers not having a border (and the wrong shadow)
- Make entire coin popover a CTA (per design's request)

### How Has This Been Tested?

web:prod
