### PR TITLE
[QA-2308] Fix stuck index_payment_router

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0157_fix_stuck_payment_router.sql
+++ b/packages/discovery-provider/ddl/migrations/0157_fix_stuck_payment_router.sql
@@ -1,0 +1,5 @@
+begin;
+
+update users set wallet = '0xFc010EB1bfc922D931801a310CF36B58Fde83021' where user_id = 343362;
+
+commit;


### PR DESCRIPTION
### Description
This user has two rows in `user` with the same wallet:
```
select * from users where wallet = '0xfe5f7a324b1fb58afeb8392e09aa72370d6d08ab';
```

### How Has This Been Tested?

Ran this on write db DN1 to confirm:

```
update users set wallet = 'test' where user_id = 343362;
update users set wallet = '0xFc010EB1bfc922D931801a310CF36B58Fde83021' where user_id = 343362;
```