### PR TITLE
[QA-2255] Fix mobile lineup & playback bugs (continues playing same track after playing a new lineup page)

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -641,6 +641,7 @@ export const AudioPlayer = () => {
 
     // Due to a dependency waterfall (queue from redux -> useTracks -> useUsers),
     // we need to wait for all 3 things to be loaded before loading anything into RNTP - queue + tracks + users
+    // Original bug: https://linear.app/audius/issue/QA-2255/keeps-playing-the-same-track-when-clicking-new-tracks-in-the-same
     if (
       !queueTracks.every(
         ({ track }) =>
@@ -755,6 +756,7 @@ export const AudioPlayer = () => {
     queueTrackUids,
     didOfflineToggleChange,
     didPlayerBehaviorChange,
+    queueTrackOwnersMap,
     makeTrackData
   ])
 

--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -189,7 +189,19 @@ export const AudioPlayer = () => {
     () => queueOrder.map((trackData) => trackData.id as ID),
     [queueOrder]
   )
-  const { byId: tracksById } = useTracks(uniq(queueTrackIds))
+
+  useEffect(() => {
+    console.log('queueOrder', queueOrder, ' length ', queueOrder.length)
+  }, [queueOrder])
+  useEffect(() => {
+    console.log(
+      'queueTrackIds',
+      uniq(queueTrackIds),
+      ' length ',
+      uniq(queueTrackIds).length
+    )
+  }, [queueTrackIds])
+  const { byId: tracksById, data: tracks } = useTracks(uniq(queueTrackIds))
   const queueTracks = useMemo(
     () =>
       queueOrder.map(({ id, playerBehavior }) => ({
@@ -198,6 +210,10 @@ export const AudioPlayer = () => {
       })),
     [queueOrder, tracksById]
   )
+  useEffect(() => {
+    console.log('track count', tracks?.length)
+    console.log('tracksById count', Object.keys(tracksById).length)
+  }, [tracks, tracksById])
   const queueTrackOwnerIds = useMemo(
     () =>
       queueTracks.map(({ track }) => track?.owner_id).filter(removeNullable),
@@ -543,6 +559,7 @@ export const AudioPlayer = () => {
 
     const playCounterTimeout = setTimeout(() => {
       if (isReachable) {
+        console.log('recordListen', trackId)
         dispatch(recordListen(trackId))
       } else {
         dispatch(

--- a/packages/web/src/common/store/lineup/sagas.ts
+++ b/packages/web/src/common/store/lineup/sagas.ts
@@ -417,7 +417,6 @@ function* play<T extends Track | Collection>(
   prefix: string,
   action: ReturnType<LineupBaseActions['play']>
 ) {
-  console.log('lineup play saga')
   const lineup = yield* select(lineupSelector)
   const requestedPlayTrack = yield* queryTrackByUid(action.uid)
   const isPreview = !!action.isPreview

--- a/packages/web/src/common/store/lineup/sagas.ts
+++ b/packages/web/src/common/store/lineup/sagas.ts
@@ -44,6 +44,7 @@ import {
   race
 } from 'typed-redux-saga'
 
+import { make } from 'common/store/analytics/actions'
 import { getToQueue } from 'common/store/queue/sagas'
 import { isPreview } from 'common/utils/isPreview'
 import { AppState } from 'store/types'
@@ -416,6 +417,7 @@ function* play<T extends Track | Collection>(
   prefix: string,
   action: ReturnType<LineupBaseActions['play']>
 ) {
+  console.log('lineup play saga')
   const lineup = yield* select(lineupSelector)
   const requestedPlayTrack = yield* queryTrackByUid(action.uid)
   const isPreview = !!action.isPreview
@@ -426,10 +428,9 @@ function* play<T extends Track | Collection>(
     const currentPlayerBehavior = yield* select(getPlayerBehavior)
     const newPlayerBehavior = isPreview
       ? PlayerBehavior.PREVIEW_OR_FULL
-      : undefined
+      : PlayerBehavior.FULL_OR_PREVIEW
     if (
       !currentPlayerTrackUid ||
-      action.uid !== currentPlayerTrackUid ||
       source !== lineup.prefix ||
       currentPlayerBehavior !== newPlayerBehavior
     ) {
@@ -444,6 +445,7 @@ function* play<T extends Track | Collection>(
           return queueable
         })
       )
+
       const flattenedQueue = flatten(toQueue).filter((e) => Boolean(e))
       yield* put(queueActions.clear({}))
       yield* put(queueActions.add({ entries: flattenedQueue }))
@@ -477,11 +479,12 @@ function* togglePlay<T extends Track | Collection>(
 
   if (!isPlayingUid || !isPlaying) {
     yield* put(lineupActions.play(action.uid))
-    analytics.track({
-      eventName: Name.PLAYBACK_PLAY,
-      id: `${action.id}`,
-      source: action.source
-    })
+    yield* put(
+      make(Name.PLAYBACK_PLAY, {
+        id: `${action.id}`,
+        source: action.source
+      })
+    )
   } else {
     yield* put(lineupActions.pause())
     analytics.track({

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -273,6 +273,7 @@ function* watchPlay() {
         )
         if (!lineup) return
         if (lineup.entries.length > 0) {
+          console.log('queue play saga clear')
           yield* put(clear({}))
           const toQueue = yield* all(
             lineup.entries.map((e) => call(getToQueue, lineup.prefix, e))

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -273,7 +273,6 @@ function* watchPlay() {
         )
         if (!lineup) return
         if (lineup.entries.length > 0) {
-          console.log('queue play saga clear')
           yield* put(clear({}))
           const toQueue = yield* all(
             lineup.entries.map((e) => call(getToQueue, lineup.prefix, e))


### PR DESCRIPTION
### Description

Several key fixes for some hard to find bugs in here:
- Lineup saga is clearing the queue even when on a queue append, this was one way we were causing our bug but not the root cause. Removing
- Tweak the `handleQueueChange` to properly wait for tanQuery data before attempting to queue anything into RNTP; this was the root cause of the bugs
- Add try/catch to `makeTrackData` - this was a very nasty side effect of our bug where there was an error thrown inside this detached `async` fn but never gets thrown anywhere so it just silently fails. The issue with it silently failing is that the `await enqueueJobsRef` is stuck infinitely
- Also fixed the issue where analytics was showing `Playback: Play undefined` (unrelated to the playback bugs but fixed lol)

### How Has This Been Tested?

ios:stage simulator
