### PR TITLE
[PE-6710] Fix optimistic updates after token swaps

### DIFF
--- a/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
+++ b/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
@@ -78,10 +78,15 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
 
   const invalidateBalances = () => {
     if (user?.wallet) {
-      // Invalidate balances for all token types that could be involved
+      // Invalidate USDC balance queries
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.usdcBalance, user.wallet]
       })
+      // Invalidate individual user coin queries (for artist coins and $AUDIO)
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.userCoin]
+      })
+      // Invalidate general user coins queries
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.userCoins]
       })
@@ -147,7 +152,8 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
 
     if (swapStatus === 'success' && swapData) {
       if (swapData.status === SwapStatus.SUCCESS) {
-        // Success - navigate to success screen
+        // Success - invalidate balances and navigate to success screen
+        invalidateBalances()
         setSwapResult({
           inputAmount:
             swapData.inputAmount?.uiAmount ??


### PR DESCRIPTION
### Description
Missing a call to invalidate queries, and also needed to invalidate individual coin query keys

### How Has This Been Tested?

Ignore the "you receive $0" i think that's due to diff issue (jup says no routes found)

https://github.com/user-attachments/assets/5079878c-3aac-4fa1-8421-2ef9063e136c

note - 2 $BONK discrepancy bc i have 2 bonk in a connected wallet
https://github.com/user-attachments/assets/6699a601-50bb-4e1f-8207-9d33bd41dbb8


