### PR TITLE
Fix mobile follow button flickering

### DIFF
--- a/packages/common/src/api/tan-query/utils/primeCollectionData.ts
+++ b/packages/common/src/api/tan-query/utils/primeCollectionData.ts
@@ -66,8 +66,7 @@ export const primeCollectionData = ({
     if ('user' in collection) {
       primeUserData({
         users: [collection.user],
-        queryClient,
-        forceReplace
+        queryClient
       })
     }
 

--- a/packages/common/src/api/tan-query/utils/primeTrackData.ts
+++ b/packages/common/src/api/tan-query/utils/primeTrackData.ts
@@ -156,8 +156,7 @@ export const primeTrackDataInternal = ({
       const user = (track as { user: User }).user
       primeUserData({
         users: [user],
-        queryClient,
-        forceReplace
+        queryClient
       })
     }
   })


### PR DESCRIPTION
### Description
On mobile, bug was:
- Go to profile that has follow-gated tracks
- Hit follow button

Follow button would first show "follow" state, then switch back to "unfollow" state, then finally land on correct state.

Guessing this is bc `useTracks` would retrigger due to follow state changing, which then had a `forceReplace: true` in its own `primeUserData`. Don't think we ever want to `forceReplace` a user from a track or collection update.. but lmk if this is wrong @DejayJD 

### How Has This Been Tested?


https://github.com/user-attachments/assets/6e658508-c86f-4d09-ab77-821a317c6a27

