### PR TITLE
Fix nginx config for comms websockets in bridge server

### DIFF
--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -333,4 +333,15 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    location ~ ^/comms/chats/ws(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://audius-protocol-api:1323;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # for websockets:
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
 }


### PR DESCRIPTION
### Description
Since local dev uses nginx and it doesn't forward the websocket headers by default, we need this block (adapted from a similar entry for the DN comms server) in order for websocket connection upgrades to succeed.

### How Has This Been Tested?
Run a bridge server that has comms ws support locally and make sure that socket connections from local client succeed with a 101 status code and not a 426.
