### PR TITLE
[PE-6759] Update error stages in swap hook

### DIFF
--- a/packages/common/src/api/tan-query/jupiter/directSwap.ts
+++ b/packages/common/src/api/tan-query/jupiter/directSwap.ts
@@ -12,7 +12,8 @@ import {
   SwapDependencies,
   SwapTokensParams,
   SwapTokensResult,
-  SwapStatus
+  SwapStatus,
+  SwapErrorType
 } from './types'
 import {
   addTransferFromUserBankInstructions,
@@ -28,121 +29,148 @@ export const executeDirectSwap = async (
   dependencies: SwapDependencies,
   tokens: Record<string, TokenInfo>
 ): Promise<SwapTokensResult> => {
-  const {
-    inputMint: inputMintUiAddress,
-    outputMint: outputMintUiAddress,
-    amountUi
-  } = params
-  const wrapUnwrapSol = params.wrapUnwrapSol ?? true
+  let errorStage = 'DIRECT_SWAP_UNKNOWN'
 
-  const {
-    sdk,
-    keypair,
-    userPublicKey,
-    feePayer,
-    ethAddress,
-    queryClient,
-    user
-  } = dependencies
+  try {
+    const {
+      inputMint: inputMintUiAddress,
+      outputMint: outputMintUiAddress,
+      amountUi
+    } = params
+    const wrapUnwrapSol = params.wrapUnwrapSol ?? true
 
-  const instructions: TransactionInstruction[] = []
-
-  // Validate tokens and create configs
-  const tokenConfigsResult = validateAndCreateTokenConfigs(
-    inputMintUiAddress,
-    outputMintUiAddress,
-    tokens
-  )
-
-  if ('error' in tokenConfigsResult) {
-    return tokenConfigsResult.error
-  }
-
-  const { inputTokenConfig, outputTokenConfig } = tokenConfigsResult
-
-  // Get quote
-  const { quoteResult: quote } = await getJupiterQuoteByMintWithRetry({
-    inputMint: inputMintUiAddress,
-    outputMint: outputMintUiAddress,
-    inputDecimals: inputTokenConfig.decimals,
-    outputDecimals: outputTokenConfig.decimals,
-    amountUi,
-    swapMode: 'ExactIn',
-    onlyDirectRoutes: false
-  })
-
-  // Prepare input token
-  const sourceAtaForJupiter = await addTransferFromUserBankInstructions({
-    tokenInfo: inputTokenConfig,
-    userPublicKey,
-    ethAddress: ethAddress!,
-    amountLamports: BigInt(quote.inputAmount.amount),
-    sdk,
-    feePayer,
-    instructions
-  })
-  // Prepare output destination
-  const preferredJupiterDestination = await prepareOutputUserBank(
-    sdk,
-    ethAddress!,
-    outputTokenConfig
-  )
-
-  // Get swap instructions
-  const swapRequestParams: SwapRequest = {
-    quoteResponse: quote.quote,
-    userPublicKey: userPublicKey.toBase58(),
-    destinationTokenAccount: preferredJupiterDestination,
-    wrapAndUnwrapSol: wrapUnwrapSol,
-    dynamicSlippage: true
-  }
-
-  const { swapInstructionsResult, outputAtaForJupiter } =
-    await getJupiterSwapInstructions(
-      swapRequestParams,
-      outputTokenConfig,
+    const {
+      sdk,
+      keypair,
       userPublicKey,
       feePayer,
+      ethAddress,
+      queryClient,
+      user
+    } = dependencies
+
+    const instructions: TransactionInstruction[] = []
+
+    // Validate tokens and create configs
+    errorStage = 'DIRECT_SWAP_TOKEN_VALIDATION'
+    const tokenConfigsResult = validateAndCreateTokenConfigs(
+      inputMintUiAddress,
+      outputMintUiAddress,
+      tokens
+    )
+
+    if ('error' in tokenConfigsResult) {
+      return {
+        ...tokenConfigsResult.error,
+        errorStage
+      }
+    }
+
+    const { inputTokenConfig, outputTokenConfig } = tokenConfigsResult
+
+    // Get quote
+    errorStage = 'DIRECT_SWAP_GET_QUOTE'
+    const { quoteResult: quote } = await getJupiterQuoteByMintWithRetry({
+      inputMint: inputMintUiAddress,
+      outputMint: outputMintUiAddress,
+      inputDecimals: inputTokenConfig.decimals,
+      outputDecimals: outputTokenConfig.decimals,
+      amountUi,
+      swapMode: 'ExactIn',
+      onlyDirectRoutes: false
+    })
+
+    // Prepare input token
+    errorStage = 'DIRECT_SWAP_PREPARE_INPUT'
+    const sourceAtaForJupiter = await addTransferFromUserBankInstructions({
+      tokenInfo: inputTokenConfig,
+      userPublicKey,
+      ethAddress: ethAddress!,
+      amountLamports: BigInt(quote.inputAmount.amount),
+      sdk,
+      feePayer,
       instructions
+    })
+
+    // Prepare output destination
+    errorStage = 'DIRECT_SWAP_PREPARE_OUTPUT'
+    const preferredJupiterDestination = await prepareOutputUserBank(
+      sdk,
+      ethAddress!,
+      outputTokenConfig
     )
-  const { swapInstruction, addressLookupTableAddresses } =
-    swapInstructionsResult
 
-  const jupiterInstructions = convertJupiterInstructions([swapInstruction])
+    // Get swap instructions
+    errorStage = 'DIRECT_SWAP_GET_INSTRUCTIONS'
+    const swapRequestParams: SwapRequest = {
+      quoteResponse: quote.quote,
+      userPublicKey: userPublicKey.toBase58(),
+      destinationTokenAccount: preferredJupiterDestination,
+      wrapAndUnwrapSol: wrapUnwrapSol,
+      dynamicSlippage: true
+    }
 
-  instructions.push(...jupiterInstructions)
+    const { swapInstructionsResult, outputAtaForJupiter } =
+      await getJupiterSwapInstructions(
+        swapRequestParams,
+        outputTokenConfig,
+        userPublicKey,
+        feePayer,
+        instructions
+      )
+    const { swapInstruction, addressLookupTableAddresses } =
+      swapInstructionsResult
 
-  // Cleanup
-  const atasToClose: PublicKey[] = []
-  if (sourceAtaForJupiter) {
-    atasToClose.push(sourceAtaForJupiter)
-  }
-  if (outputAtaForJupiter) {
-    atasToClose.push(outputAtaForJupiter)
-  }
+    const jupiterInstructions = convertJupiterInstructions([swapInstruction])
 
-  for (const ataToClose of atasToClose) {
-    instructions.push(
-      createCloseAccountInstruction(ataToClose, feePayer, userPublicKey)
+    instructions.push(...jupiterInstructions)
+
+    // Cleanup
+    errorStage = 'DIRECT_SWAP_CLEANUP'
+    const atasToClose: PublicKey[] = []
+    if (sourceAtaForJupiter) {
+      atasToClose.push(sourceAtaForJupiter)
+    }
+    if (outputAtaForJupiter) {
+      atasToClose.push(outputAtaForJupiter)
+    }
+
+    for (const ataToClose of atasToClose) {
+      instructions.push(
+        createCloseAccountInstruction(ataToClose, feePayer, userPublicKey)
+      )
+    }
+
+    // Build and send transaction
+    errorStage = 'DIRECT_SWAP_BUILD_TRANSACTION'
+    const signature = await buildAndSendTransaction(
+      sdk,
+      keypair,
+      feePayer,
+      instructions,
+      addressLookupTableAddresses
     )
-  }
 
-  // Build and send transaction
-  const signature = await buildAndSendTransaction(
-    sdk,
-    keypair,
-    feePayer,
-    instructions,
-    addressLookupTableAddresses
-  )
+    // Invalidate queries
+    errorStage = 'DIRECT_SWAP_INVALIDATE_QUERIES'
+    await invalidateSwapQueries(queryClient, user)
 
-  // Invalidate queries
-  await invalidateSwapQueries(queryClient, user)
-
-  return {
-    status: SwapStatus.SUCCESS,
-    signature,
-    inputAmount: quote.inputAmount,
-    outputAmount: quote.outputAmount
+    return {
+      status: SwapStatus.SUCCESS,
+      signature,
+      inputAmount: quote.inputAmount,
+      outputAmount: quote.outputAmount
+    }
+  } catch (error: unknown) {
+    return {
+      status: SwapStatus.ERROR,
+      errorStage,
+      error: {
+        type: SwapErrorType.UNKNOWN,
+        message: `Direct swap failed at stage ${errorStage}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      },
+      inputAmount: undefined,
+      outputAmount: undefined
+    }
   }
 }

--- a/packages/common/src/api/tan-query/jupiter/indirectSwapViaAudio.ts
+++ b/packages/common/src/api/tan-query/jupiter/indirectSwapViaAudio.ts
@@ -18,7 +18,8 @@ import {
   SwapDependencies,
   SwapTokensParams,
   SwapTokensResult,
-  SwapStatus
+  SwapStatus,
+  SwapErrorType
 } from './types'
 import {
   addTransferFromUserBankInstructions,
@@ -41,215 +42,256 @@ export const executeIndirectSwap = async (
   dependencies: SwapDependencies,
   tokens: Record<string, TokenInfo>
 ): Promise<SwapTokensResult> => {
-  const {
-    inputMint: inputMintUiAddress,
-    outputMint: outputMintUiAddress,
-    amountUi
-  } = params
-  const wrapUnwrapSol = params.wrapUnwrapSol ?? true
+  let errorStage = 'INDIRECT_SWAP_UNKNOWN'
 
-  const {
-    sdk,
-    keypair,
-    userPublicKey,
-    feePayer,
-    ethAddress,
-    queryClient,
-    user
-  } = dependencies
-
-  const firstInstructions: TransactionInstruction[] = []
-  const secondInstructions: TransactionInstruction[] = []
-
-  // Validate tokens and create configs
-  const tokenConfigsResult = validateAndCreateTokenConfigs(
-    inputMintUiAddress,
-    outputMintUiAddress,
-    tokens
-  )
-
-  if ('error' in tokenConfigsResult) {
-    return tokenConfigsResult.error
-  }
-
-  const { inputTokenConfig, outputTokenConfig } = tokenConfigsResult
-
-  // Create AUDIO token config for transfers
-  const audioTokenInfo = createTokenConfig(
-    findTokenByAddress(tokens, AUDIO_MINT)!
-  )
-
-  // Get first quote: InputToken -> AUDIO
-  const { quoteResult: firstQuote } = await getJupiterQuoteByMintWithRetry({
-    inputMint: inputMintUiAddress,
-    outputMint: AUDIO_MINT,
-    inputDecimals: inputTokenConfig.decimals,
-    outputDecimals: AUDIO_DECIMALS,
-    amountUi,
-    swapMode: 'ExactIn',
-    onlyDirectRoutes: false
-  })
-
-  // Get second quote: AUDIO -> OutputToken
-  const { quoteResult: secondQuote } = await getJupiterQuoteByMintWithRetry({
-    inputMint: AUDIO_MINT,
-    outputMint: outputMintUiAddress,
-    inputDecimals: AUDIO_DECIMALS,
-    outputDecimals: outputTokenConfig.decimals,
-    amountUi: firstQuote.outputAmount.uiAmount,
-    swapMode: 'ExactIn',
-    onlyDirectRoutes: false
-  })
-
-  // Prepare input token for first swap
-  const sourceAtaForJupiter = await addTransferFromUserBankInstructions({
-    tokenInfo: inputTokenConfig,
-    userPublicKey,
-    ethAddress: ethAddress!,
-    amountLamports: BigInt(firstQuote.inputAmount.amount),
-    sdk,
-    feePayer,
-    instructions: firstInstructions
-  })
-
-  // Create intermediate AUDIO ATA
-  const audioMint = new PublicKey(AUDIO_MINT)
-  const intermediateAudioAta = getAssociatedTokenAddressSync(
-    audioMint,
-    userPublicKey,
-    true
-  )
-
-  // Create ATA if it doesn't exist
   try {
-    await getAccount(sdk.services.solanaClient.connection, intermediateAudioAta)
-  } catch (e) {
-    firstInstructions.push(
-      createAssociatedTokenAccountIdempotentInstruction(
-        feePayer,
-        intermediateAudioAta,
-        userPublicKey,
-        audioMint
-      )
-    )
-  }
+    const {
+      inputMint: inputMintUiAddress,
+      outputMint: outputMintUiAddress,
+      amountUi
+    } = params
+    const wrapUnwrapSol = params.wrapUnwrapSol ?? true
 
-  // Get first swap instructions (InputToken -> AUDIO)
-  const firstSwapRequestParams: SwapRequest = {
-    quoteResponse: firstQuote.quote,
-    userPublicKey: userPublicKey.toBase58(),
-    destinationTokenAccount: intermediateAudioAta.toBase58(),
-    wrapAndUnwrapSol: wrapUnwrapSol,
-    dynamicSlippage: true
-  }
-
-  const { swapInstructionsResult: firstSwapResponse } =
-    await getJupiterSwapInstructions(firstSwapRequestParams)
-
-  const firstSwapInstructions = convertJupiterInstructions([
-    firstSwapResponse.swapInstruction
-  ])
-
-  firstInstructions.push(...firstSwapInstructions)
-
-  // Transfer AUDIO back to user bank after first swap
-  await addTransferToUserBankInstructions({
-    tokenInfo: audioTokenInfo,
-    userPublicKey,
-    ethAddress: ethAddress!,
-    amountLamports: BigInt(firstQuote.outputAmount.amount),
-    sourceAta: intermediateAudioAta,
-    sdk,
-    feePayer,
-    instructions: firstInstructions
-  })
-
-  // Cleanup source ATA after first swap
-  firstInstructions.push(
-    createCloseAccountInstruction(sourceAtaForJupiter, feePayer, userPublicKey)
-  )
-
-  // Build and send first transaction
-  const firstTransactionSignature = await buildAndSendTransaction(
-    sdk,
-    keypair,
-    feePayer,
-    firstInstructions,
-    firstSwapResponse.addressLookupTableAddresses,
-    'confirmed'
-  )
-
-  // Transfer AUDIO from user bank to ATA for second swap
-  const audioSourceAtaForJupiter = await addTransferFromUserBankInstructions({
-    tokenInfo: audioTokenInfo,
-    userPublicKey,
-    ethAddress: ethAddress!,
-    amountLamports: BigInt(secondQuote.inputAmount.amount),
-    sdk,
-    feePayer,
-    instructions: secondInstructions
-  })
-
-  // Prepare output destination
-  const preferredJupiterDestination = await prepareOutputUserBank(
-    sdk,
-    ethAddress!,
-    outputTokenConfig
-  )
-
-  // Get second swap instructions (AUDIO -> OutputToken)
-  const secondSwapRequestParams: SwapRequest = {
-    quoteResponse: secondQuote.quote,
-    userPublicKey: userPublicKey.toBase58(),
-    destinationTokenAccount: preferredJupiterDestination,
-    wrapAndUnwrapSol: wrapUnwrapSol,
-    dynamicSlippage: true
-  }
-
-  const { swapInstructionsResult: secondSwapResponse, outputAtaForJupiter } =
-    await getJupiterSwapInstructions(
-      secondSwapRequestParams,
-      outputTokenConfig,
+    const {
+      sdk,
+      keypair,
       userPublicKey,
       feePayer,
-      secondInstructions
+      ethAddress,
+      queryClient,
+      user
+    } = dependencies
+
+    const firstInstructions: TransactionInstruction[] = []
+    const secondInstructions: TransactionInstruction[] = []
+
+    // Validate tokens and create configs
+    errorStage = 'INDIRECT_SWAP_TOKEN_VALIDATION'
+    const tokenConfigsResult = validateAndCreateTokenConfigs(
+      inputMintUiAddress,
+      outputMintUiAddress,
+      tokens
     )
 
-  const secondSwapInstructions = convertJupiterInstructions([
-    secondSwapResponse.swapInstruction
-  ])
+    if ('error' in tokenConfigsResult) {
+      return {
+        ...tokenConfigsResult.error,
+        errorStage
+      }
+    }
 
-  secondInstructions.push(...secondSwapInstructions)
+    const { inputTokenConfig, outputTokenConfig } = tokenConfigsResult
 
-  // Cleanup
-  const atasToClose: PublicKey[] = [audioSourceAtaForJupiter]
-  if (outputAtaForJupiter) {
-    atasToClose.push(outputAtaForJupiter)
-  }
-
-  for (const ataToClose of atasToClose) {
-    secondInstructions.push(
-      createCloseAccountInstruction(ataToClose, feePayer, userPublicKey)
+    // Create AUDIO token config for transfers
+    errorStage = 'INDIRECT_SWAP_AUDIO_CONFIG'
+    const audioTokenInfo = createTokenConfig(
+      findTokenByAddress(tokens, AUDIO_MINT)!
     )
-  }
 
-  // Build and send second transaction
-  const signature = await buildAndSendTransaction(
-    sdk,
-    keypair,
-    feePayer,
-    secondInstructions,
-    secondSwapResponse.addressLookupTableAddresses
-  )
+    // Get first quote: InputToken -> AUDIO
+    errorStage = 'INDIRECT_SWAP_FIRST_QUOTE'
+    const { quoteResult: firstQuote } = await getJupiterQuoteByMintWithRetry({
+      inputMint: inputMintUiAddress,
+      outputMint: AUDIO_MINT,
+      inputDecimals: inputTokenConfig.decimals,
+      outputDecimals: AUDIO_DECIMALS,
+      amountUi,
+      swapMode: 'ExactIn',
+      onlyDirectRoutes: false
+    })
 
-  // Invalidate queries
-  await invalidateSwapQueries(queryClient, user)
+    // Get second quote: AUDIO -> OutputToken
+    errorStage = 'INDIRECT_SWAP_SECOND_QUOTE'
+    const { quoteResult: secondQuote } = await getJupiterQuoteByMintWithRetry({
+      inputMint: AUDIO_MINT,
+      outputMint: outputMintUiAddress,
+      inputDecimals: AUDIO_DECIMALS,
+      outputDecimals: outputTokenConfig.decimals,
+      amountUi: firstQuote.outputAmount.uiAmount,
+      swapMode: 'ExactIn',
+      onlyDirectRoutes: false
+    })
 
-  return {
-    status: SwapStatus.SUCCESS,
-    signature,
-    inputAmount: firstQuote.inputAmount,
-    outputAmount: secondQuote.outputAmount,
-    firstTransactionSignature
+    // Prepare input token for first swap
+    errorStage = 'INDIRECT_SWAP_PREPARE_FIRST_INPUT'
+    const sourceAtaForJupiter = await addTransferFromUserBankInstructions({
+      tokenInfo: inputTokenConfig,
+      userPublicKey,
+      ethAddress: ethAddress!,
+      amountLamports: BigInt(firstQuote.inputAmount.amount),
+      sdk,
+      feePayer,
+      instructions: firstInstructions
+    })
+
+    // Create intermediate AUDIO ATA
+    errorStage = 'INDIRECT_SWAP_CREATE_AUDIO_ATA'
+    const audioMint = new PublicKey(AUDIO_MINT)
+    const intermediateAudioAta = getAssociatedTokenAddressSync(
+      audioMint,
+      userPublicKey,
+      true
+    )
+
+    // Create ATA if it doesn't exist
+    try {
+      await getAccount(
+        sdk.services.solanaClient.connection,
+        intermediateAudioAta
+      )
+    } catch (e) {
+      firstInstructions.push(
+        createAssociatedTokenAccountIdempotentInstruction(
+          feePayer,
+          intermediateAudioAta,
+          userPublicKey,
+          audioMint
+        )
+      )
+    }
+
+    // Get first swap instructions (InputToken -> AUDIO)
+    errorStage = 'INDIRECT_SWAP_FIRST_SWAP_INSTRUCTIONS'
+    const firstSwapRequestParams: SwapRequest = {
+      quoteResponse: firstQuote.quote,
+      userPublicKey: userPublicKey.toBase58(),
+      destinationTokenAccount: intermediateAudioAta.toBase58(),
+      wrapAndUnwrapSol: wrapUnwrapSol,
+      dynamicSlippage: true
+    }
+
+    const { swapInstructionsResult: firstSwapResponse } =
+      await getJupiterSwapInstructions(firstSwapRequestParams)
+
+    const firstSwapInstructions = convertJupiterInstructions([
+      firstSwapResponse.swapInstruction
+    ])
+
+    firstInstructions.push(...firstSwapInstructions)
+
+    // Transfer AUDIO back to user bank after first swap
+    errorStage = 'INDIRECT_SWAP_TRANSFER_AUDIO_TO_BANK'
+    await addTransferToUserBankInstructions({
+      tokenInfo: audioTokenInfo,
+      userPublicKey,
+      ethAddress: ethAddress!,
+      amountLamports: BigInt(firstQuote.outputAmount.amount),
+      sourceAta: intermediateAudioAta,
+      sdk,
+      feePayer,
+      instructions: firstInstructions
+    })
+
+    // Cleanup source ATA after first swap
+    errorStage = 'INDIRECT_SWAP_FIRST_CLEANUP'
+    firstInstructions.push(
+      createCloseAccountInstruction(
+        sourceAtaForJupiter,
+        feePayer,
+        userPublicKey
+      )
+    )
+
+    // Build and send first transaction
+    errorStage = 'INDIRECT_SWAP_FIRST_TRANSACTION'
+    const firstTransactionSignature = await buildAndSendTransaction(
+      sdk,
+      keypair,
+      feePayer,
+      firstInstructions,
+      firstSwapResponse.addressLookupTableAddresses,
+      'confirmed'
+    )
+
+    // Transfer AUDIO from user bank to ATA for second swap
+    errorStage = 'INDIRECT_SWAP_PREPARE_SECOND_INPUT'
+    const audioSourceAtaForJupiter = await addTransferFromUserBankInstructions({
+      tokenInfo: audioTokenInfo,
+      userPublicKey,
+      ethAddress: ethAddress!,
+      amountLamports: BigInt(secondQuote.inputAmount.amount),
+      sdk,
+      feePayer,
+      instructions: secondInstructions
+    })
+
+    // Prepare output destination
+    errorStage = 'INDIRECT_SWAP_PREPARE_SECOND_OUTPUT'
+    const preferredJupiterDestination = await prepareOutputUserBank(
+      sdk,
+      ethAddress!,
+      outputTokenConfig
+    )
+
+    // Get second swap instructions (AUDIO -> OutputToken)
+    errorStage = 'INDIRECT_SWAP_SECOND_SWAP_INSTRUCTIONS'
+    const secondSwapRequestParams: SwapRequest = {
+      quoteResponse: secondQuote.quote,
+      userPublicKey: userPublicKey.toBase58(),
+      destinationTokenAccount: preferredJupiterDestination,
+      wrapAndUnwrapSol: wrapUnwrapSol,
+      dynamicSlippage: true
+    }
+
+    const { swapInstructionsResult: secondSwapResponse, outputAtaForJupiter } =
+      await getJupiterSwapInstructions(
+        secondSwapRequestParams,
+        outputTokenConfig,
+        userPublicKey,
+        feePayer,
+        secondInstructions
+      )
+
+    const secondSwapInstructions = convertJupiterInstructions([
+      secondSwapResponse.swapInstruction
+    ])
+
+    secondInstructions.push(...secondSwapInstructions)
+
+    // Cleanup
+    errorStage = 'INDIRECT_SWAP_SECOND_CLEANUP'
+    const atasToClose: PublicKey[] = [audioSourceAtaForJupiter]
+    if (outputAtaForJupiter) {
+      atasToClose.push(outputAtaForJupiter)
+    }
+
+    for (const ataToClose of atasToClose) {
+      secondInstructions.push(
+        createCloseAccountInstruction(ataToClose, feePayer, userPublicKey)
+      )
+    }
+
+    // Build and send second transaction
+    errorStage = 'INDIRECT_SWAP_SECOND_TRANSACTION'
+    const signature = await buildAndSendTransaction(
+      sdk,
+      keypair,
+      feePayer,
+      secondInstructions,
+      secondSwapResponse.addressLookupTableAddresses
+    )
+
+    // Invalidate queries
+    errorStage = 'INDIRECT_SWAP_INVALIDATE_QUERIES'
+    await invalidateSwapQueries(queryClient, user)
+
+    return {
+      status: SwapStatus.SUCCESS,
+      signature,
+      inputAmount: firstQuote.inputAmount,
+      outputAmount: secondQuote.outputAmount,
+      firstTransactionSignature
+    }
+  } catch (error: unknown) {
+    return {
+      status: SwapStatus.ERROR,
+      errorStage,
+      error: {
+        type: SwapErrorType.UNKNOWN,
+        message: `Indirect swap failed at stage ${errorStage}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      },
+      inputAmount: undefined,
+      outputAmount: undefined
+    }
   }
 }

--- a/packages/common/src/api/tan-query/jupiter/types.ts
+++ b/packages/common/src/api/tan-query/jupiter/types.ts
@@ -46,6 +46,7 @@ export type SwapTokensResult = {
   status: SwapStatus
   signature?: string
   firstTransactionSignature?: string
+  errorStage?: string
   error?: {
     type: SwapErrorType
     message: string


### PR DESCRIPTION
### Description

[This PR](https://github.com/AudiusProject/audius-protocol/pull/12786/files#diff-76020105f32c742cac8d29b02d5935606a18672c1a859eddad035d0a1dba535a) messed up how we track `errorStage` in the swap hook which is useful for debugging. Updated to work as it previously did

### How Has This Been Tested?

`npm run web:prod` and force an error in `directSwap` and see that it logs properly
