### PR TITLE
Update api Go module import

### DIFF
--- a/packages/discovery-provider/ddl/run_migrations.go
+++ b/packages/discovery-provider/ddl/run_migrations.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	"bridgerton.audius.co/config"
+	"api.audius.co/config"
 )
 
 func RunMigrations() error {


### PR DESCRIPTION
### Description
We renamed this module to `api`, so updating this local dev tool to reference the correct module.
