### PR TITLE
archiver: skip parent track if not downloadable

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/workers/createStemsArchive/createStemsArchive.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/workers/createStemsArchive/createStemsArchive.ts
@@ -120,12 +120,13 @@ export const createStemsArchiveWorker = (services: WorkerServices) => {
         throw new Error('No stems found for track')
       }
 
-      const filesToDownload = includeParentTrack
-        ? [
-            ...stems,
-            { ...track, origFilename: track.origFilename ?? track.title }
-          ]
-        : stems
+      const filesToDownload =
+        includeParentTrack && track.isDownloadable
+          ? [
+              ...stems,
+              { ...track, origFilename: track.origFilename ?? track.title }
+            ]
+          : stems
 
       logger.debug({ files: filesToDownload }, 'Getting file sizes')
 


### PR DESCRIPTION
### Description
If you pass `?include_parent_track`, we will dutifully attempt to download it. That download will fail if the parent track isn't actually downloadable and kill the whole job. We already have the track metadata and know this, so we should skip trying to download the parent if it's not available.

### How Has This Been Tested?
Tried downloading archive for a track that has stems but doesn't allow download of the parent. Verified that I still received a zip with all the stems and no parent. Also tried against a track that _does_ have the parent available just to make sure that's not broken.
