### PR TITLE
Fix download all when track download not available

### DIFF
--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -143,16 +143,19 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
       return
     }
 
+    // Only include parent track in count if it's downloadable
+    const parentTrackCount = track?.access?.download ? 1 : 0
     openDownloadTrackArchiveModal({
       trackId,
-      fileCount: stemTracks.length + 1
+      fileCount: stemTracks.length + parentTrackCount
     })
   }, [
     openDownloadTrackArchiveModal,
     shouldDisplayDownloadFollowGated,
     stemTracks.length,
     toast,
-    trackId
+    trackId,
+    track?.access?.download
   ])
 
   const hasStems = stemTracks.length > 0

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -180,12 +180,19 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
   const handleDownloadAll = useRequiresAccountCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
+      // Only include parent track in count if it's downloadable
+      const parentTrackCount = access?.download ? 1 : 0
       openDownloadTrackArchiveModal({
         trackId,
-        fileCount: stemTracks.length + 1
+        fileCount: stemTracks.length + parentTrackCount
       })
     },
-    [openDownloadTrackArchiveModal, trackId, stemTracks.length]
+    [
+      openDownloadTrackArchiveModal,
+      trackId,
+      stemTracks.length,
+      access?.download
+    ]
   )
 
   const hasStems = stemTracks.length > 0 || isUploadingStems

--- a/packages/web/src/pages/track-page/components/mobile/DownloadSection.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/DownloadSection.tsx
@@ -163,9 +163,11 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
         dispatch(toast({ content: messages.followToDownload }))
         return
       }
+      // Only include parent track in count if it's downloadable
+      const parentTrackCount = partialTrack?.access?.download ? 1 : 0
       openDownloadTrackArchiveModal({
         trackId,
-        fileCount: stemTracks.length + 1
+        fileCount: stemTracks.length + parentTrackCount
       })
     },
     [
@@ -174,7 +176,8 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
       openDownloadTrackArchiveModal,
       trackId,
       stemTracks.length,
-      dispatch
+      dispatch,
+      partialTrack?.access?.download
     ]
   )
 


### PR DESCRIPTION
### Description

Fixes issue where frontend was requesting original track download alongside stem download, which fails in the case where the original track is not downloadable.