### PR TITLE
Remove US, MX from is_country_eur

### DIFF
--- a/packages/discovery-provider/ddl/functions/is_country_eur.sql
+++ b/packages/discovery-provider/ddl/functions/is_country_eur.sql
@@ -346,7 +346,6 @@ BEGIN
         country = 'MU' OR
         country = 'MV' OR
         country = 'MW' OR
-        country = 'MX' OR
         country = 'MY' OR
         country = 'MZ' OR
         country = 'NA' OR


### PR DESCRIPTION
### Description

This sql hook is used for reporting and was initially determined by MRI to be as such in https://github.com/AudiusProject/audius-protocol/commit/89f2d1aba7c442282507d8c4040f481a63c2942f, now it is no longer so due to various reporting parties (SACEM, ICE, etc.)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

n/a