### PR TITLE
Fix your coins table on resizing

### DIFF
--- a/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
@@ -4,6 +4,7 @@ import {
   UserCoin,
   useArtistCoins,
   useCurrentUserId,
+  useQueryContext,
   useUserCoins
 } from '@audius/common/api'
 import {
@@ -14,7 +15,7 @@ import {
 import { buySellMessages } from '@audius/common/messages'
 import { FeatureFlags } from '@audius/common/services'
 import { ASSET_DETAIL_PAGE } from '@audius/common/src/utils/route'
-import { useBuySellModal, useGroupCoinPairs } from '@audius/common/store'
+import { useBuySellModal } from '@audius/common/store'
 import {
   Box,
   Button,
@@ -25,6 +26,7 @@ import {
   useMedia,
   useTheme
 } from '@audius/harmony'
+import type { CSSObject } from '@emotion/react'
 import { useDispatch } from 'react-redux'
 import { push } from 'redux-first-history'
 import { roundedHexClipPath } from '~harmony/icons/SVGDefs'
@@ -36,6 +38,45 @@ import Tooltip from 'components/tooltip/Tooltip'
 
 import { AudioCoinCard } from './AudioCoinCard'
 import { CoinCard } from './CoinCard'
+
+// Helper function to determine if an item should have a right border
+const shouldShowRightBorder = (
+  index: number,
+  isSingleColumn: boolean,
+  shouldSpanFullWidth: boolean,
+  isOddCount: boolean,
+  totalItems: number
+): boolean => {
+  if (isSingleColumn || shouldSpanFullWidth) {
+    return false
+  }
+
+  const isEvenIndex = index % 2 === 0
+  const isItemBeforeFullWidth = isOddCount && index === totalItems - 2
+
+  return isEvenIndex && !isItemBeforeFullWidth
+}
+
+// Helper function to build CSS styles for a coin item
+const getCoinItemStyles = (
+  shouldSpanFullWidth: boolean,
+  shouldHaveRightBorder: boolean,
+  borderColor: string
+): CSSObject => {
+  const baseStyles: CSSObject = {
+    position: 'relative',
+    padding: '0'
+  }
+
+  if (shouldSpanFullWidth) {
+    baseStyles.gridColumn = '1 / -1'
+  } else if (shouldHaveRightBorder) {
+    baseStyles.borderRight = `1px solid ${borderColor}`
+    baseStyles.paddingRight = '0'
+  }
+
+  return baseStyles
+}
 
 const YourCoinsSkeleton = () => {
   const { spacing } = useTheme()
@@ -172,43 +213,94 @@ const CoinCardWithBalance = ({ coin }: { coin: UserCoin }) => {
 
 export const YourCoins = () => {
   const { data: currentUserId } = useCurrentUserId()
+  const { env } = useQueryContext()
+  const { isEnabled: isArtistCoinsEnabled } = useFeatureFlag(
+    FeatureFlags.ARTIST_COINS
+  )
+  const { color } = useTheme()
 
   const { data: artistCoins, isPending: isLoadingCoins } = useUserCoins({
     userId: currentUserId
   })
 
-  const { isMobile, isTablet } = useMedia()
+  const { isLarge } = useMedia()
 
-  const coinPairs = useGroupCoinPairs(artistCoins, isMobile || isTablet)
+  // Filter coins using the same logic as useGroupCoinPairs
+  const filteredCoins =
+    artistCoins?.filter((coin) => {
+      if (!isArtistCoinsEnabled) {
+        return coin.mint === env.WAUDIO_MINT_ADDRESS
+      }
+      return (
+        coin.ticker !== 'USDC' &&
+        (coin.balance > 0 || coin.mint === env.WAUDIO_MINT_ADDRESS)
+      )
+    }) || []
+
+  // Show audio coin card when no coins are available
+  const showAudioCoin = filteredCoins.length === 0
+  const allCoins = showAudioCoin ? ['audio-coin' as const] : filteredCoins
+
+  const isSingleColumn = isLarge
 
   return (
     <Paper column shadow='far' borderRadius='l' css={{ overflow: 'hidden' }}>
       <YourCoinsHeader isLoading={isLoadingCoins} />
       <Flex column>
         {isLoadingCoins || !currentUserId ? <YourCoinsSkeleton /> : null}
-        {coinPairs.map((pair, rowIndex) => (
-          <Fragment key={`row-${rowIndex}`}>
-            <Flex alignItems='stretch'>
-              {pair.map((item, colIndex) => {
-                const key = typeof item === 'string' ? item : item.mint
+        <Box
+          css={{
+            display: 'grid',
+            gridTemplateColumns: isSingleColumn ? '1fr' : '1fr 1fr',
+            gap: '0'
+          }}
+        >
+          {allCoins.map((item, index) => {
+            const key = typeof item === 'string' ? item : item.mint
+            const isLastItem = index === allCoins.length - 1
+            const isOddCount = !isSingleColumn && allCoins.length % 2 === 1
+            const shouldSpanFullWidth = isOddCount && isLastItem
+            const isLastInRow = isSingleColumn ? true : index % 2 === 1
+            const isLastRow =
+              index >= allCoins.length - (isSingleColumn ? 1 : 2)
 
-                return (
-                  <Fragment key={key}>
-                    {colIndex > 0 && <Divider orientation='vertical' />}
-                    <Box flex={1}>
-                      {item === 'audio-coin' ? (
-                        <AudioCoinCard />
-                      ) : (
-                        <CoinCardWithBalance coin={item as UserCoin} />
-                      )}
-                    </Box>
-                  </Fragment>
-                )
-              })}
-            </Flex>
-            {rowIndex < coinPairs.length - 1 && <Divider />}
-          </Fragment>
-        ))}
+            // Use helper functions for cleaner logic
+            const shouldHaveRightBorder = shouldShowRightBorder(
+              index,
+              isSingleColumn,
+              shouldSpanFullWidth,
+              isOddCount,
+              allCoins.length
+            )
+
+            const itemStyles = getCoinItemStyles(
+              shouldSpanFullWidth,
+              shouldHaveRightBorder,
+              color.border.default
+            )
+
+            return (
+              <Fragment key={key}>
+                <Box css={itemStyles}>
+                  {item === 'audio-coin' ? (
+                    <AudioCoinCard />
+                  ) : (
+                    <CoinCardWithBalance coin={item as UserCoin} />
+                  )}
+                </Box>
+                {/* Horizontal divider after each row except the last */}
+                {!isLastRow && isLastInRow && (
+                  <Box
+                    css={{
+                      gridColumn: '1 / -1',
+                      borderBottom: `1px solid ${color.border.default}`
+                    }}
+                  />
+                )}
+              </Fragment>
+            )
+          })}
+        </Box>
       </Flex>
     </Paper>
   )


### PR DESCRIPTION
### Description

Refactors the YourCoins component to use CSS Grid layout instead of Flexbox for improved responsive design and cleaner code structure. This change was done because resizing the table broke it a lot (borders were misaligned and text was jank)

## Changes

- **Layout System**: Migrated from Flexbox to CSS Grid with responsive single/two-column layout
- **Responsive Design**: Added logic for single column on large screens and two columns on smaller screens
- **Coin Filtering**: Replaced `useGroupCoinPairs` hook with explicit filtering logic using feature flags
- **Border Management**: Implemented helper functions to handle right borders and full-width spanning for odd count items
- **Divider Logic**: Added horizontal dividers between rows using grid positioning
- **Code Organization**: Extracted layout logic into reusable helper functions for better maintainability

## Technical Details

- Uses CSS Grid with `grid-template-columns` for responsive layout
- Implements proper handling of odd-numbered coin lists by spanning the last item full width
- Maintains existing functionality while improving code readability and performance
- Removes dependency on `useGroupCoinPairs` hook in favor of explicit filtering

## Files Modified

- `packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx`


### How Has This Been Tested?

`npm run web:prod` and play with "Your Coins" section on wallet page
