### PR TITLE
[API-100] Add error handling for rewards claiming

### DIFF
--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -257,7 +257,10 @@ async function claimRewardsForChallenge({
             }
           })
         )
-        .then(() =>
+        .then((res) => {
+          if (res?.data?.[0]?.error) {
+            throw new Error(res.data[0].error)
+          }
           track(
             make({
               eventName: Name.REWARDS_CLAIM_SUCCESS,
@@ -266,7 +269,8 @@ async function claimRewardsForChallenge({
               amount: specifierWithAmount.amount
             })
           )
-        )
+          return res
+        })
         .then(() => {
           return specifierWithAmount
         })


### PR DESCRIPTION
Since we only claim 1 reward at a time in this flow, use the error for the first result.

Tested: Claimed all my rewards on prod