### PR TITLE
Fix anchor tag warning

### DIFF
--- a/packages/web/src/components/avatar/Avatar.tsx
+++ b/packages/web/src/components/avatar/Avatar.tsx
@@ -26,6 +26,7 @@ export type AvatarProps = Omit<HarmonyAvatarProps, 'src'> & {
   onClick?: () => void
   imageSize?: SquareSizes
   popover?: boolean
+  disableLink?: boolean // Prevents Avatar from wrapping with UserLink when already inside a link
 }
 
 export const AvatarContent = (props: AvatarProps) => {
@@ -35,6 +36,7 @@ export const AvatarContent = (props: AvatarProps) => {
     'aria-hidden': ariaHidden,
     imageSize = SquareSizes.SIZE_150_BY_150,
     popover,
+    disableLink,
     ...other
   } = props
 
@@ -92,7 +94,7 @@ export const AvatarContent = (props: AvatarProps) => {
     )
   }
 
-  if (userId) {
+  if (userId && !disableLink) {
     return (
       <UserLink
         userId={userId}

--- a/packages/web/src/components/user-token-badge/UserTokenBadge.tsx
+++ b/packages/web/src/components/user-token-badge/UserTokenBadge.tsx
@@ -44,7 +44,7 @@ export const UserTokenBadge = ({ userId }: UserTokenBadgeProps) => {
           }
         }}
       >
-        <Avatar userId={userId} w={spacing.xl} h={spacing.xl} />
+        <Avatar userId={userId} w={spacing.xl} h={spacing.xl} disableLink />
         <Flex alignItems='center' gap='xs'>
           <Text variant='body' size='l'>
             {name}


### PR DESCRIPTION
### Description

React was throwing a warning about `<a>` elements appearing as descendants of other `<a>` elements, which is invalid HTML. This occurred when `UserTokenBadge` wrapped content with a `UserLink`, and the `Avatar` component inside also rendered its own `UserLink`, creating nested links.

## Solution

Added a `disableLink` prop to the `Avatar` component that prevents it from rendering its own `UserLink` when already wrapped in another link. This maintains functionality while fixing the HTML validity issue.

### How Has This Been Tested?

`npm run web:prod` and checked console 

The fix maintains the same user interaction behavior (clicking the avatar/badge navigates to the user profile) while eliminating the React warning about nested anchor tags.
