### PR TITLE
[QA-2325] Fix audio balance user badges

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useAudioBalance.ts
@@ -14,19 +14,17 @@ import {
   useQueryContext,
   type QueryContextType
 } from '~/api/tan-query/utils/QueryContext'
-import { Chain } from '~/models'
+import { Chain, ID } from '~/models'
 import { Feature } from '~/models/ErrorReporting'
 import { toErrorWithMessage } from '~/utils/error'
 
 import { QUERY_KEYS } from '../queryKeys'
 import { queryCurrentUserId, queryUser } from '../saga-utils'
+import { QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { useUser } from '../users/useUser'
 
-import {
-  getConnectedWalletsQueryOptions,
-  useConnectedWallets
-} from './useConnectedWallets'
+import { getConnectedWalletsQueryOptions } from './useConnectedWallets'
 
 type UseWalletAudioBalanceParams = {
   /** Ethereum or Solana wallet address */
@@ -165,21 +163,30 @@ export const useWalletAudioBalances = (
   })
 }
 
-type UseAudioBalanceOptions = {
+type UseAudioBalanceParams = {
   /** Whether to include connected/linked wallets in the balance calculation. Defaults to true. */
   includeConnectedWallets?: boolean
   includeStaked?: boolean
+  userId?: ID
 }
 
 /**
  * Hook for getting the AUDIO balance of the current user, optionally including connected wallets.
  */
-export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
-  const { includeConnectedWallets = true, includeStaked = false } = options
+export const useAudioBalance = (
+  params: UseAudioBalanceParams = {},
+  options?: QueryOptions
+) => {
+  const {
+    includeConnectedWallets = true,
+    includeStaked = false,
+    userId: userIdParam
+  } = params
 
   // Get account balances
   const { data: currentUserId } = useCurrentUserId()
-  const { data, isSuccess: isUserFetched } = useUser(currentUserId)
+  const userId = userIdParam ?? currentUserId
+  const { data, isSuccess: isUserFetched } = useUser(userId)
   const accountBalances = useWalletAudioBalances(
     {
       wallets: [
@@ -204,17 +211,28 @@ export const useAudioBalance = (options: UseAudioBalanceOptions = {}) => {
   }
 
   // Get linked/connected wallets balances
+  const context = useQueryContext()
+  const connectedWalletsQuery = useQuery({
+    ...getConnectedWalletsQueryOptions(context, { userId }),
+    enabled: !!userId && includeConnectedWallets
+  })
   const {
     data: connectedWallets = [],
     isFetched: isConnectedWalletsFetched,
     isError: isConnectedWalletsError
-  } = useConnectedWallets()
+  } = connectedWalletsQuery
   const connectedWalletsBalances = useWalletAudioBalances(
     {
       wallets: connectedWallets,
       includeStaked
     },
-    { enabled: isConnectedWalletsFetched && includeConnectedWallets }
+    {
+      ...options,
+      enabled:
+        isConnectedWalletsFetched &&
+        includeConnectedWallets &&
+        options?.enabled !== false
+    }
   )
   let connectedWalletsBalance = AUDIO(0).value
   const isConnectedWalletsBalanceLoading = includeConnectedWallets

--- a/packages/common/src/api/tan-query/wallets/useTokenBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useTokenBalance.ts
@@ -1,4 +1,4 @@
-import { FixedDecimal } from '@audius/fixed-decimal'
+import { AUDIO, FixedDecimal } from '@audius/fixed-decimal'
 
 import {
   useAudioBalance,
@@ -112,17 +112,16 @@ export const useTokenBalance = ({
 
   if (isUsdc) return usdcQuery
   if (isAudio) {
-    const balanceFD = new FixedDecimal(
-      audioTokenQuery.totalBalance,
-      WEI_DECIMALS // AUDIO has 18 decimals
-    )
     return {
       data: {
-        balance: balanceFD,
-        balanceLocaleString: balanceFD.toLocaleString(),
+        balance: AUDIO(audioTokenQuery.totalBalance),
+        balanceLocaleString: AUDIO(
+          audioTokenQuery.totalBalance
+        ).toLocaleString(),
         decimals: WEI_DECIMALS
       },
       isLoading: audioTokenQuery.isLoading,
+      isPending: audioTokenQuery.isLoading,
       isError: audioTokenQuery.isError
     }
   }

--- a/packages/common/src/hooks/useFormattedTokenBalance.ts
+++ b/packages/common/src/hooks/useFormattedTokenBalance.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react'
 import { FixedDecimal } from '@audius/fixed-decimal'
 
 import { useTokenBalance, useArtistCoins } from '../api'
-import { Status } from '../models/Status'
 import {
   getTokenDecimalPlaces,
   formatCurrency,

--- a/packages/common/src/hooks/useFormattedTokenBalance.ts
+++ b/packages/common/src/hooks/useFormattedTokenBalance.ts
@@ -29,11 +29,11 @@ export const useFormattedTokenBalance = (
   mint: string,
   locale: string = 'en-US'
 ): UseFormattedTokenBalanceReturn => {
-  const { data: tokenBalance, status: balanceStatus } = useTokenBalance({
-    mint
-  })
+  const { data: tokenBalance, isPending: isTokenBalanceLoading } =
+    useTokenBalance({
+      mint
+    })
 
-  const isTokenBalanceLoading = balanceStatus === Status.LOADING
   const { data: tokenPriceData, isPending: isTokenPriceLoading } =
     useArtistCoins({ mint: [mint] })
 


### PR DESCRIPTION
### Description

- Add branching path for useAudioBalance in useTokenBalance hook instead of using `useUserCoin` (which only works for SOL audio). useAudioBalance accounts for ETH audio and connected wallets 

### How Has This Been Tested?

Using Randy as a guinea pig - confirmed w/ him that this value is correct
my branch:
<img width="340" height="103" alt="image" src="https://github.com/user-attachments/assets/7bdb3e76-ae9b-4cdc-8398-0b1d12358857" />
prod:
<img width="392" height="144" alt="image" src="https://github.com/user-attachments/assets/8b5023e8-ac22-438f-bf42-bb050b2d1bea" />

