### PR TITLE
Fix coin blasts sending to all chats

### DIFF
--- a/packages/discovery-provider/ddl/functions/chat_blast_audience.sql
+++ b/packages/discovery-provider/ddl/functions/chat_blast_audience.sql
@@ -61,29 +61,16 @@ BEGIN
   UNION
 
   -- coin_holder_audience
-  -- Case 1: userbank ie. sol_claimable_accounts
-  SELECT chat_blast.blast_id, u.user_id AS to_user_id
-  FROM artist_coins ac
-  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
+  SELECT chat_blast.blast_id, sol_user_balances.user_id AS to_user_id
+  FROM chat_blast
+  JOIN artist_coins 
+    ON artist_coins.user_id = chat_blast.from_user_id
+  JOIN sol_user_balances 
+    ON sol_user_balances.mint = artist_coins.mint
+    AND sol_user_balances.balance > 0
+  WHERE chat_blast.blast_id = blast_id_param
     AND chat_blast.audience = 'coin_holder_audience'
-    AND ac.user_id = chat_blast.from_user_id
-  JOIN sol_claimable_accounts sca ON sca.mint = ac.mint
-  JOIN sol_token_account_balances stab ON stab.account = sca.account
-  JOIN users u ON u.wallet = sca.ethereum_address
-  WHERE stab.balance > 0
-
-  UNION
-
-  -- Case 2: associated_wallets
-  SELECT chat_blast.blast_id, u.user_id AS to_user_id
-  FROM artist_coins ac
-  JOIN chat_blast ON chat_blast.blast_id = blast_id_param
-    AND chat_blast.audience = 'coin_holder_audience'
-    AND ac.user_id = chat_blast.from_user_id
-  JOIN sol_token_account_balances stab ON stab.mint = ac.mint
-  JOIN associated_wallets aw ON aw.wallet = stab.owner
-  JOIN users u ON u.user_id = aw.user_id
-  WHERE stab.balance > 0;
+    AND sol_user_balances.user_id != chat_blast.from_user_id;
 
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Fixes a bug where:

- Artist owns their own artist coin
- Artist has many existing chats
- Artist sends blast to coin holders
- Results in that message getting sent to all existing chats

Root cause was:
In audience calculation, since the artist themselves were a coin holder, they were getting included in the audience.
This led to some sql wonkiness in `chat_blast.go` blast fan-out logic where there would be many dup rows with that user_id and all their existing chats, eg:

```
"blast_id"|"from_user_id"|"to_user_id"|"chat_id"|"handle"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|128006|"PX52wR:lzl4w"|"dharit"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:ZOpkv5E"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:Wem1e"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:g493y2p"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:lzl4w"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"E2AMEVN:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:eJ57D"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:Pdxw5"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"0MMZ6:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"7eP5n:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"J5ZOp:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PWY7x2X:PX52wR"|"fariddiraf"
```

Unfortunately it seems we don't have infra to test this flow, as it would require
- Send blast (write path)
- Run through fan-out logic
- Confirm `chat_message` reads do not include the blast
OR some way to test `chat_blast_audience.sql` function.

See also https://github.com/AudiusProject/api/pull/391