### PR TITLE
Make swaps work for new artist coins

### DIFF
--- a/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
+++ b/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
@@ -21,7 +21,7 @@ import {
   SwapTokensParams,
   SwapTokensResult
 } from './types'
-import { getSwapErrorResponse, isDirectRouteAvailable } from './utils'
+import { getSwapErrorResponse } from './utils'
 
 const initializeSwapDependencies = async (
   solanaWalletService: QueryContextType['solanaWalletService'],
@@ -91,7 +91,8 @@ const initializeSwapDependencies = async (
  */
 export const useSwapTokens = () => {
   const queryClient = useQueryClient()
-  const { solanaWalletService, reportToSentry, audiusSdk } = useQueryContext()
+  const { solanaWalletService, reportToSentry, audiusSdk, env } =
+    useQueryContext()
   const { data: user } = useCurrentAccountUser()
   const { tokens } = useTokens()
 
@@ -122,14 +123,11 @@ export const useSwapTokens = () => {
         const dependencies = dependenciesResult
 
         errorStage = 'DIRECT_QUOTE_CHECK'
-        const hasDirectPath = await isDirectRouteAvailable(
-          inputMintUiAddress,
-          outputMintUiAddress,
-          params.amountUi,
-          tokens
-        )
+        const isAudioPairedSwap =
+          inputMintUiAddress === env.WAUDIO_MINT_ADDRESS ||
+          outputMintUiAddress === env.WAUDIO_MINT_ADDRESS
 
-        if (hasDirectPath) {
+        if (isAudioPairedSwap) {
           const result = await executeDirectSwap(params, dependencies, tokens)
           if (result.status === SwapStatus.ERROR && result.errorStage) {
             errorStage = result.errorStage


### PR DESCRIPTION
### Description

This PR updates the Jupiter swap logic to handle intermediate accounts properly when `useSharedAccounts: false`.

### Changes

**indirectSwapViaAudio.ts**

- Modified `executeIndirectSwap` to properly close intermediate ATAs created during the first swap step
- Added logic to collect and close both source and output ATAs from the first swap when necessary

**useSwapTokens.ts**

- Simplified direct route detection logic to check if either input or output token is AUDIO instead of querying Jupiter for direct routes
- Removed unused `isDirectRouteAvailable` utility import

### Technical Details

The key improvement is in handling ATA (Associated Token Account) cleanup for indirect swaps. When `useSharedAccounts: false`, Jupiter may create intermediate accounts that need to be closed to reclaim SOL. The updated logic ensures all temporary ATAs are properly cleaned up after the first swap transaction.

### How Has This Been Tested?

`npm run web:prod` and swap for $MEME
