### PR TITLE
[PE-6860] Fix token amount showing in members leaderboard

### DIFF
--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
@@ -78,6 +78,7 @@ export const useArtistCoinMembers = <TResult = CoinMember[]>(
     },
     queryFn: async ({ pageParam }) => {
       if (!mint) return []
+      if (!artistCoin) return []
 
       const sdk = await audiusSdk()
 
@@ -91,7 +92,7 @@ export const useArtistCoinMembers = <TResult = CoinMember[]>(
       const response = await sdk.coins.getCoinMembers(params)
 
       const members = (response.data ?? []).map((member) => {
-        const decimals = artistCoin?.decimals
+        const decimals = artistCoin.decimals
         const balanceFD = new FixedDecimal(
           BigInt(member.balance.toString()),
           decimals
@@ -111,6 +112,6 @@ export const useArtistCoinMembers = <TResult = CoinMember[]>(
       return members
     },
     select: options?.select ?? ((data) => data.pages.flat() as TResult),
-    enabled: options?.enabled !== false && !!mint
+    enabled: options?.enabled !== false && !!mint && !!artistCoin
   })
 }


### PR DESCRIPTION
### Description

The actual issue "Members leaderboard row should all be clickable" feels a bit unnecessary. It was weird to click on b/c the token amount was so huge before, but now this will show up given proper decimals. The only part you can click that doesn't take you to their profile is the number itself, that seems fine to me.

<img width="704" height="460" alt="image" src="https://github.com/user-attachments/assets/95b380e1-49db-43db-a696-a3aa50886013" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

local web