### PR TITLE
Use subscript notation in artist coin table

### DIFF
--- a/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
@@ -4,6 +4,7 @@ import { useArtistCoins } from '@audius/common/api'
 import { walletMessages } from '@audius/common/messages'
 import { ASSET_DETAIL_PAGE } from '@audius/common/src/utils/route'
 import { useBuySellModal } from '@audius/common/store'
+import { formatCurrencyWithSubscript } from '@audius/common/utils'
 import {
   Button,
   Flex,
@@ -102,9 +103,8 @@ const renderTokenNameCell = (cellInfo: CoinCell) => {
 const renderPriceCell = (cellInfo: CoinCell) => {
   const coin = cellInfo.row.original
   return (
-    <Text variant='body' size='m' color='default'>
-      {walletMessages.dollarSign}
-      {coin.price.toFixed(4)}
+    <Text variant='body' size='m'>
+      {formatCurrencyWithSubscript(coin.price)}
     </Text>
   )
 }


### PR DESCRIPTION
### Description

### How Has This Been Tested?

<img width="851" height="574" alt="Screenshot 2025-09-19 at 1 54 00 PM" src="https://github.com/user-attachments/assets/6777c3eb-3570-465e-83c1-bdd8e94b2f67" />
