### PR TITLE
Fix bug in asset details navigation

### DIFF
--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -15,7 +15,7 @@ export const AssetDetailPage = () => {
     isPending,
     isSuccess,
     error: coinError
-  } = useArtistCoinByTicker({ ticker: ticker })
+  } = useArtistCoinByTicker({ ticker })
 
   if (!ticker) {
     return <Redirect to='/wallet' />
@@ -37,7 +37,12 @@ export const AssetDetailPage = () => {
     return <Redirect to='/wallet' />
   }
 
-  return <AssetDetailPageContent mint={coin?.mint} title={coin?.ticker} />
+  return (
+    <AssetDetailPageContent
+      mint={coin?.mint ?? ''}
+      title={coin?.ticker ?? ''}
+    />
+  )
 }
 
 type AssetDetailPageContentProps = {

--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -12,15 +12,16 @@ export const AssetDetailPage = () => {
 
   const {
     data: coin,
-    isLoading: coinLoading,
+    isPending,
+    isSuccess,
     error: coinError
-  } = useArtistCoinByTicker({ ticker: ticker ?? '' })
+  } = useArtistCoinByTicker({ ticker: ticker })
 
   if (!ticker) {
     return <Redirect to='/wallet' />
   }
 
-  if (coinLoading) {
+  if (isPending) {
     return (
       <Flex
         justifyContent='center'
@@ -32,7 +33,7 @@ export const AssetDetailPage = () => {
     )
   }
 
-  if (coinError || !coin) {
+  if (coinError || (isSuccess && !coin)) {
     return <Redirect to='/wallet' />
   }
 

--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -37,7 +37,7 @@ export const AssetDetailPage = () => {
     return <Redirect to='/wallet' />
   }
 
-  return <AssetDetailPageContent mint={coin.mint} title={coin.ticker ?? ''} />
+  return <AssetDetailPageContent mint={coin?.mint} title={coin?.ticker} />
 }
 
 type AssetDetailPageContentProps = {


### PR DESCRIPTION
### Description
Bug: we were getting to the final `if (coinError || !coin)` check without waiting for the coin to load in, so we were redirecting to wallet sometimes if the coin wasn't fetched.

### How Has This Been Tested?
tested on local web stage
