### PR TITLE
Don't highlight coin pages

### DIFF
--- a/packages/web/src/components/nav/desktop/nav-items/ArtistCoinsNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/nav-items/ArtistCoinsNavItem.tsx
@@ -24,6 +24,7 @@ export const ArtistCoinsNavItem = () => {
     <LeftNavLink
       leftIcon={IconArtistCoin}
       to={COINS_EXPLORE_PAGE}
+      exact
       restriction='none'
     >
       {messages.title}


### PR DESCRIPTION
### Description
We decided to do this to avoid the jarring feeling of jumping from the coins tab in nav bar to wallet tab

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
