### PR TITLE
[PE-6764] Reset leaderboard query key after buy tokens

### DIFF
--- a/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
+++ b/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
@@ -118,6 +118,10 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.userCoins]
       })
+      // Invalidate artist coin members queries (leaderboard)
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.artistCoinMembers]
+      })
 
       // Invalidate track queries to provide track access if the user has traded the artist coin
       if (baseUserTracks?.length) {


### PR DESCRIPTION
### Description
So that the leaderboard is always up to date

### How Has This Been Tested?

right after first buy of $WEEB i am on the leaderboard:
<img width="979" height="156" alt="Screenshot 2025-09-22 at 1 36 01 PM" src="https://github.com/user-attachments/assets/49acbcfa-ce5f-4f20-85f6-68c8ffc22fa1" />

