### PR TITLE
Add error logic

### DIFF
--- a/packages/common/src/models/ErrorReporting.ts
+++ b/packages/common/src/models/ErrorReporting.ts
@@ -47,7 +47,8 @@ export enum Feature {
   Events = 'events',
   Remixes = 'remixes',
   TanQuery = 'tan-query',
-  SendTokens = 'send-tokens'
+  SendTokens = 'send-tokens',
+  ArtistCoins = 'artist-coins'
 }
 
 export type ReportToSentryArgs = {

--- a/packages/web/src/pages/artist-coins-launchpad-page/pages/BuyCoinPage.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/pages/BuyCoinPage.tsx
@@ -50,7 +50,8 @@ const messages = {
   errors: {
     quoteError: 'Failed to get a quote. Please try again.',
     valueTooHigh: 'Value is too high. Please enter a lower value.',
-    insufficientBalance: 'Insufficient $AUDIO balance.'
+    insufficientBalance: 'Insufficient $AUDIO balance.',
+    transactionFailed: 'Transaction failed. Please try again.'
   },
   createCoin: 'Create Coin',
   max: 'MAX',
@@ -64,7 +65,11 @@ const FORM_INPUT_DECIMALS = 8
 
 const INPUT_DEBOUNCE_TIME = 400
 
-export const BuyCoinPage = ({ onContinue, onBack }: PhasePageProps) => {
+export const BuyCoinPage = ({
+  onContinue,
+  onBack,
+  submitError
+}: PhasePageProps & { submitError: boolean }) => {
   // Use Formik context to manage form state, including payAmount and receiveAmount
   const { values, setFieldValue, errors, validateForm } =
     useFormikContext<SetupFormValues>()
@@ -195,6 +200,16 @@ export const BuyCoinPage = ({ onContinue, onBack }: PhasePageProps) => {
     },
     [setFieldValue, debouncedReceiveAmountChange]
   )
+
+  const submitFooterErrorText = useMemo(() => {
+    if (firstBuyQuoteError) {
+      return messages.errors.quoteError
+    }
+    if (submitError) {
+      return messages.errors.transactionFailed
+    }
+  }, [firstBuyQuoteError, submitError])
+
   return (
     <>
       {isBuyModalOpen ? (
@@ -326,7 +341,7 @@ export const BuyCoinPage = ({ onContinue, onBack }: PhasePageProps) => {
         onBack={handleBack}
         submit
         continueText={messages.createCoin}
-        errorText={firstBuyQuoteError ? messages.errors.quoteError : undefined}
+        errorText={submitFooterErrorText}
       />
     </>
   )


### PR DESCRIPTION
### Description

- Adds new UI error states based on how far into the flow the user is
- Adds much more robust sentry logging (removes console logs)

- Any handled error before the pool is created
![2025-09-22 17 54 51](https://github.com/user-attachments/assets/cdd29915-bd8c-4060-b67b-6ae56bbd2b3f)

- SDK call failed
<img width="522" height="340" alt="image" src="https://github.com/user-attachments/assets/8ee16bbc-5864-4975-99f5-23c11536b20d" />


- Uncaught error after pool is created
<img width="506" height="286" alt="image" src="https://github.com/user-attachments/assets/2cd0870f-f17c-458d-870b-cce8765e6631" />


TODO: Last failure point is just if the first buy fails - product & design requested the ability to retry the first buy back on the same form but I haven't wired this up to do a new buy swap yet

### How Has This Been Tested?

web:prod - manually triggering errors (not actually spending any $$)
