### PR TITLE
[PE-6768] Hide tip button until artist coins load

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -230,9 +230,9 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
         {/* For artist coin owners, replace the tip CTA with their coin */}
         {showArtistCoinCTA ? (
           <BuyArtistCoinCard mint={ownedCoin.mint} />
-        ) : (
+        ) : !isArtistCoinLoading ? (
           <TipAudioButton />
-        )}
+        ) : null}
         {isRecentCommentsEnabled ? <RecentComments userId={userId} /> : null}
         <SupportingList />
         <TopSupporters />


### PR DESCRIPTION
### Description

Not a perfect solution, but mitigates the weird UI misdirection where tipping button loads and is immediately replace

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local stack v prod