### PR TITLE
[PE-6552] Fix buy/sell modal close issue

### DIFF
--- a/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
@@ -43,6 +43,7 @@ type BuySellFlowProps = {
   onScreenChange: (screen: Screen) => void
   onLoadingStateChange?: (isLoading: boolean) => void
   initialTicker?: string
+  setResetState: (resetState: () => void) => void
 }
 
 export const BuySellFlow = (props: BuySellFlowProps) => {
@@ -51,7 +52,8 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
     openAddCashModal,
     onScreenChange,
     onLoadingStateChange,
-    initialTicker
+    initialTicker,
+    setResetState
   } = props
   const { toast } = useContext(ToastContext)
   const { isEnabled: isArtistCoinsEnabled } = useFlag(FeatureFlags.ARTIST_COINS)
@@ -383,6 +385,22 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
     setHasAttemptedSubmit(false)
   }, [activeTab])
 
+  useEffect(() => {
+    setResetState(() => {
+      resetTransactionData()
+      resetSuccessDisplayData()
+      setCurrentScreen('input')
+      // Clear all tab input values on completion
+      setTabInputValues({ buy: '', sell: '', convert: '' })
+    })
+  }, [
+    setResetState,
+    resetTransactionData,
+    resetSuccessDisplayData,
+    setCurrentScreen,
+    setTabInputValues
+  ])
+
   const isTransactionInvalid = !transactionData?.isValid
 
   const displayErrorMessage = useMemo(() => {
@@ -534,17 +552,7 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
         style={{ display: currentScreen === 'success' ? 'flex' : 'none' }}
       >
         {currentScreen === 'success' && successDisplayData ? (
-          <TransactionSuccessScreen
-            {...successDisplayData}
-            onDone={() => {
-              onClose()
-              resetTransactionData()
-              resetSuccessDisplayData()
-              setCurrentScreen('input')
-              // Clear all tab input values on completion
-              setTabInputValues({ buy: '', sell: '', convert: '' })
-            }}
-          />
+          <TransactionSuccessScreen {...successDisplayData} onDone={onClose} />
         ) : null}
       </Flex>
     </>

--- a/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
@@ -25,6 +25,7 @@ export const BuySellModal = () => {
   const { isOpen, onClose, data } = useBuySellModal()
   const { ticker } = data
   const { onOpen: openAddCashModal } = useAddCashModal()
+  const [resetState, setResetState] = useState<(() => void) | null>(null)
 
   const [modalScreen, setModalScreen] = useState<Screen>('input')
   const [isFlowLoading, setIsFlowLoading] = useState(false)
@@ -48,8 +49,10 @@ export const BuySellModal = () => {
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      onClosed={resetState ?? undefined}
       size='medium'
       zIndex={zIndex.BUY_SELL_MODAL}
+      dismissOnClickOutside={modalScreen !== 'confirm'}
     >
       <ModalHeader
         onClose={onClose}
@@ -79,6 +82,7 @@ export const BuySellModal = () => {
           onScreenChange={setModalScreen}
           onLoadingStateChange={setIsFlowLoading}
           initialTicker={ticker}
+          setResetState={setResetState}
         />
       </ModalContent>
       {modalScreen !== 'success' && !isFlowLoading && (


### PR DESCRIPTION
### Description

When you close the modal after a success purchase, it flashes the initial state before close. Modal has a prop for onClosed, so pass a prop a reset fn setter to the inner component and use that on onClosed instead of on success alone.

Also prevents dismissing the modal w/ a click outside when you are on the confirm screen.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Purchased, bailed out of flow, clicked outside of flow to bail out, etc.