### PR TITLE
Limit appkit modal to Solana on Launchpad flow 

### DIFF
--- a/packages/web/src/pages/artist-coins-launchpad-page/LaunchpadPage.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/LaunchpadPage.tsx
@@ -167,8 +167,11 @@ const LaunchpadPageContent = ({ submitError }: { submitError: boolean }) => {
 
   const handleSplashContinue = useCallback(async () => {
     // Switch to Solana network to prioritize SOL wallets
-    await appkitModal.switchNetwork(solana)
     appkitModal.removeAdapter('eip155')
+    appkitModal.removeAdapter('bip122')
+    appkitModal.removeAdapter('polkadot')
+    await appkitModal.switchNetwork(solana)
+  
     openAppKitModal()
   }, [openAppKitModal])
 


### PR DESCRIPTION
### Description
Only show solana based wallets in the `appKitModal` for Launchpad

### How Has This Been Tested?

<img width="389" height="407" alt="image" src="https://github.com/user-attachments/assets/bc19668d-f6d8-41e3-8096-dbcea1f185ea" />
