### PR TITLE
[API-349] Upstream non-plugins/comms DN requests to API

### DIFF
--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -33,7 +33,7 @@ server {
     location /health_check {
         resolver 127.0.0.11 valid=30s;
         set $upstream audius-protocol-discovery-provider-1:5000;
-        proxy_pass http://$upstream/health_check;
+        proxy_pass http://$upstream;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -149,6 +149,16 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        # allow DN to be health-checked for now
+        location /health_check {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:5000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # Upstream unhandled requests to new API server
         location / {
             resolver 1.1.1.1 valid=30s;
             proxy_pass $upstream_uri$request_uri;


### PR DESCRIPTION
⚠️ Do not merge until https://github.com/AudiusProject/api/pull/415 is merged and deployed

### Description
Adds two nginx configs:
1. The one in dev-tools runs local dev. This will upstream all `/` requests that are not otherwise handled to `http://audius-protocol-api:1323`.
2. The one in packages/discovery-provider is the openresty container used in audius-docker-compose layouts. This one is a little more complicated
  a. Our upstreams here will be https, so we need more config to make sure we do TLS correctly
  b. Our upstream needs to be mapped based on environment. I left out the dev case here because I don't think 'devnet' audius-docker-compose deployments are really used and it would only complicate things.

Note: Left health check for now since a few things still talk to it (healthz for one). Will remove it as a last step when we shut down the server container.

### How Has This Been Tested?
* Run local stack and attempt to curl `http://audius-protocol-discovery-provider1/v1/coins`. It should return a valid response (note this endpoint doesn't exist in discprov, only the new API server).
* I also swapped the config from the Discovery nginx stack into the local dev stack and hard-coded it to api.audius.co to make sure that the http->https upstream works correctly.