### PR TITLE
[PE-6908] Show buy coins for own profile

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -1,4 +1,4 @@
-import { useCurrentUserId, useUserCreatedCoins } from '@audius/common/api'
+import { useUserCreatedCoins } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
@@ -92,7 +92,6 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
     isOwner
   } = props
 
-  const { data: accountUserId } = useCurrentUserId()
   const { data: ownedCoins, isPending: isArtistCoinLoading } =
     useUserCreatedCoins({ userId, limit: 1 })
   const ownedCoin = ownedCoins?.[0]
@@ -102,10 +101,7 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
     recentCommentsFlag.isLoaded && recentCommentsFlag.isEnabled
   const isArtistCoinsEnabled = useFeatureFlag(FeatureFlags.ARTIST_COINS)
   const showArtistCoinCTA =
-    accountUserId !== userId &&
-    !isArtistCoinLoading &&
-    isArtistCoinsEnabled &&
-    !!ownedCoin
+    !isArtistCoinLoading && isArtistCoinsEnabled && !!ownedCoin
 
   if (editMode) {
     return (
@@ -230,7 +226,7 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
         {/* For artist coin owners, replace the tip CTA with their coin */}
         {showArtistCoinCTA ? (
           <BuyArtistCoinCard mint={ownedCoin.mint} />
-        ) : !isArtistCoinLoading ? (
+        ) : !isArtistCoinLoading && !isOwner ? (
           <TipAudioButton />
         ) : null}
         {isRecentCommentsEnabled ? <RecentComments userId={userId} /> : null}


### PR DESCRIPTION
### Description
Show artist coin buy button even if it's your own coin.
Show tip button only if it's not your own profile, and there isn't an artist coin for that profile.

### How Has This Been Tested?

(hardcoded ownedCoin as $MEMEY)
<img width="1728" height="1117" alt="Screenshot 2025-09-23 at 10 06 44 PM" src="https://github.com/user-attachments/assets/e694e168-970d-4328-b216-fbc14ef543e8" />
