### PR TITLE
[PROTO-2030] Remove discovery node option from register node modal

### DIFF
--- a/packages/protocol-dashboard/.eslintignore
+++ b/packages/protocol-dashboard/.eslintignore
@@ -1,0 +1,7 @@
+.env.local
+.env.development.local
+.env.dev.local
+.env.test.local
+.env.production.local
+.env.stage.local
+.env.prod.local

--- a/packages/protocol-dashboard/package.json
+++ b/packages/protocol-dashboard/package.json
@@ -20,7 +20,7 @@
     "deploy:prod": "wrangler deploy --env production",
     "lint": "eslint --cache --ext=js,jsx,ts,tsx src",
     "lint:fix": "eslint --cache --fix --ext=js,jsx,ts,tsx src",
-    "lint:env": "dotenv-linter",
+    "lint:env": "dotenv-linter --exclude .env.prod.local",
     "pull-dev-accounts": "node ./scripts/pullDevAccounts.js",
     "typecheck": "tsc",
     "advance-blocks": "node ./scripts/advanceBlocks.js",

--- a/packages/protocol-dashboard/src/components/ConfirmTransactionModal/ConfirmTransactionModal.tsx
+++ b/packages/protocol-dashboard/src/components/ConfirmTransactionModal/ConfirmTransactionModal.tsx
@@ -12,7 +12,7 @@ import Loading from 'components/Loading'
 import Modal from 'components/Modal'
 import UserImage from 'components/UserImage'
 import AudiusClient from 'services/Audius'
-import { Address, BigNumber, ServiceType, Status } from 'types'
+import { Address, BigNumber, Status } from 'types'
 import { TICKER } from 'utils/consts'
 import { sharedMessages } from 'utils/sharedMessages'
 
@@ -71,7 +71,6 @@ export const OperatorStaking: React.FC<OperatorStakingProps> = (props) => {
 
 type NewServiceProps = {
   className?: string
-  serviceType: ServiceType
   delegateOwnerWallet: string
 }
 export const NewService: React.FC<NewServiceProps> = (props) => {
@@ -82,11 +81,6 @@ export const NewService: React.FC<NewServiceProps> = (props) => {
       })}
     >
       <div className={styles.newServiceTitle}>{messages.newService}</div>
-      <div className={styles.newServiceType}>
-        {props.serviceType === ServiceType.DiscoveryProvider
-          ? messages.discoveryProvider
-          : messages.contentNode}
-      </div>
       <div className={styles.newServiceDelegateWallet}>
         {messages.delegateOwnerWallet}
       </div>

--- a/packages/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
+++ b/packages/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
@@ -343,7 +343,6 @@ const NodeOverview = ({
                     delegateOwnerWallet || health?.delegateOwnerWallet || ''
                   }
                   defaultEndpoint={endpoint}
-                  defaultServiceType={serviceType}
                 />
               </Box>
             )}


### PR DESCRIPTION
### Description

Discovery node type is being deprecated, this removes the discovery node option from the register node UI.

### How Has This Been Tested?

Verified correctness of modal appearance

<img width="609" height="439" alt="image" src="https://github.com/user-attachments/assets/ad7cde1c-609c-4816-ab2e-aab2cf9c9b86" />
