### PR TITLE
Update Wallet screen loading states on mobile

### DIFF
--- a/packages/mobile/src/screens/wallet-screen/components/CoinCard.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/CoinCard.tsx
@@ -5,25 +5,38 @@ import { useFeatureFlag, useFormattedTokenBalance } from '@audius/common/hooks'
 import { FeatureFlags } from '@audius/common/services'
 import { Image, TouchableOpacity } from 'react-native'
 
-import { Flex, HexagonalIcon, Skeleton, Text } from '@audius/harmony-native'
+import {
+  Box,
+  Flex,
+  HexagonalIcon,
+  Skeleton,
+  Text
+} from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
-
-// TODO: Fix loading states
-// Skeletons are not working as expected
 
 const ICON_SIZE = 64
 
 const CoinCardSkeleton = () => {
   return (
     <Flex column gap='xs'>
-      <Skeleton w='240px' h='36px' />
-      <Skeleton w='140px' h='24px' />
+      <Box w={240} h={36}>
+        <Skeleton />
+      </Box>
+      <Box w={140} h={24}>
+        <Skeleton />
+      </Box>
     </Flex>
   )
 }
 
-const IconSkeleteon = () => {
-  return <Skeleton w={ICON_SIZE} h={ICON_SIZE} />
+const HexagonalSkeleton = () => {
+  return (
+    <HexagonalIcon size={ICON_SIZE}>
+      <Box w={ICON_SIZE} h={ICON_SIZE}>
+        <Skeleton />
+      </Box>
+    </HexagonalIcon>
+  )
 }
 
 export type CoinCardProps = {
@@ -87,7 +100,7 @@ export const CoinCard = ({ mint, showUserBalance = true }: CoinCardProps) => {
         alignItems='center'
       >
         <Flex row alignItems='center' gap='l'>
-          {isLoading ? <IconSkeleteon /> : renderIcon()}
+          {isLoading ? <HexagonalSkeleton /> : renderIcon()}
           <Flex column gap='xs'>
             {isLoading ? (
               <CoinCardSkeleton />

--- a/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
@@ -11,13 +11,41 @@ import { FeatureFlags } from '@audius/common/services'
 import { AUDIO_TICKER } from '@audius/common/store'
 import { ownedCoinsFilter } from '@audius/common/utils'
 
-import { Box, Button, Divider, Flex, Paper, Text } from '@audius/harmony-native'
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Paper,
+  Skeleton,
+  Text
+} from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import { CoinCard } from './CoinCard'
 
 const messages = {
   ...buySellMessages
+}
+
+const YourCoinsSkeleton = () => {
+  return (
+    <Flex column>
+      <Flex p='l' pl='xl' row alignItems='center' gap='l'>
+        <Box w={64} h={64}>
+          <Skeleton />
+        </Box>
+        <Flex column gap='xs'>
+          <Box w={240} h={36}>
+            <Skeleton />
+          </Box>
+          <Box w={140} h={24}>
+            <Skeleton />
+          </Box>
+        </Flex>
+      </Flex>
+    </Flex>
+  )
 }
 
 const TokensHeader = () => {
@@ -48,7 +76,7 @@ export const YourCoins = () => {
     FeatureFlags.ARTIST_COINS
   )
 
-  const { data: artistCoins } = useUserCoins({
+  const { data: artistCoins, isPending: isLoadingCoins } = useUserCoins({
     userId: currentUserId
   })
 
@@ -72,16 +100,20 @@ export const YourCoins = () => {
     <Paper>
       <TokensHeader />
       <Flex column>
-        {cards.map((item) => (
-          <Box key={typeof item === 'string' ? item : item.mint}>
-            {item === 'audio-coin' ? (
-              <CoinCard mint={env.WAUDIO_MINT_ADDRESS} />
-            ) : (
-              <CoinCard mint={item.mint} />
-            )}
-            <Divider />
-          </Box>
-        ))}
+        {isLoadingCoins || !currentUserId ? (
+          <YourCoinsSkeleton />
+        ) : (
+          cards.map((item) => (
+            <Box key={typeof item === 'string' ? item : item.mint}>
+              {item === 'audio-coin' ? (
+                <CoinCard mint={env.WAUDIO_MINT_ADDRESS} />
+              ) : (
+                <CoinCard mint={item.mint} />
+              )}
+              <Divider />
+            </Box>
+          ))
+        )}
       </Flex>
       {isWalletUIBuySellEnabled ? (
         <Flex p='l'>


### PR DESCRIPTION
### Description
The loading states in the "Your Coins" section were borked. Updated to match web's loading states 

### How Has This Been Tested?

`npm run ios:prod` and navigate to "Wallet" screen 
