### PR TITLE
[PE-6922] Shorten SPL address if necessary

### DIFF
--- a/packages/mobile/src/components/core/AddressTile.tsx
+++ b/packages/mobile/src/components/core/AddressTile.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import Clipboard from '@react-native-clipboard/clipboard'
 
+import { shortenSPLAddress } from '@audius/common/utils'
 import { Text, IconCopy, Flex, IconButton } from '@audius/harmony-native'
 import { useToast } from 'app/hooks/useToast'
 import { make, track as trackEvent } from 'app/services/analytics'
@@ -30,8 +31,8 @@ export const AddressTile = ({ address, analytics }: AddressTileProps) => {
   return (
     <Flex row border='default' borderRadius='s' backgroundColor='surface1'>
       <Flex pv='l' ph='xl' flex={1}>
-        <Text variant='body' numberOfLines={1} ellipsizeMode='middle'>
-          {address}
+        <Text variant='body'>
+          {address ? shortenSPLAddress(address, 8) : ''}
         </Text>
       </Flex>
       <Flex

--- a/packages/web/src/components/address-tile/AddressTile.tsx
+++ b/packages/web/src/components/address-tile/AddressTile.tsx
@@ -21,11 +21,13 @@ const messages = {
 type AddressTileProps = {
   address?: string
   iconRight?: IconComponent
+  shorten?: boolean
 }
 
 export const AddressTile = ({
   address,
-  iconRight: IconRight
+  iconRight: IconRight,
+  shorten = false
 }: AddressTileProps) => {
   const { toast } = useContext(ToastContext)
   const isMobile = useIsMobile()
@@ -69,7 +71,7 @@ export const AddressTile = ({
             }}
             variant='body'
           >
-            {isMobile ? shortenSPLAddress(address, 12) : address}
+            {isMobile || shorten ? shortenSPLAddress(address, 12) : address}
           </Text>
         </Box>
         <Flex alignItems='center' borderLeft='default' ph='l'>

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadModals.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/LaunchpadModals.tsx
@@ -93,7 +93,7 @@ const CoinNotInAudiusState = ({
           <Text variant='label' size='l' color='subdued'>
             {messages.addressTitle}
           </Text>
-          <AddressTile address={mintAddress} />
+          <AddressTile address={mintAddress} shorten />
         </Flex>
       </Flex>
     </ModalContent>
@@ -129,7 +129,7 @@ const UnknownErrorState = ({
               <Text variant='label' size='l' color='subdued'>
                 {messages.addressTitle}
               </Text>
-              <AddressTile address={mintAddress} />
+              <AddressTile address={mintAddress} shorten />
             </Flex>
           ) : null}
         </Flex>


### PR DESCRIPTION
### Description

Adds prop to AddressTile to shorted spl address, which is needed for some of the smaller desktop modals. Also updates shortening logic on mobile