### PR TITLE
[PE-6746] Fix scroll pos when unfurl happens

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -38,6 +38,7 @@ import { InboxUnavailableMessage } from './InboxUnavailableMessage'
 import { SendMessagePrompt } from './SendMessagePrompt'
 import { StickyScrollList } from './StickyScrollList'
 
+export const CONTENT_EXPANDED_LISTENER_KEY = 'audius:chat:content-expanded'
 const SPINNER_HEIGHT = 48
 
 const { fetchMoreMessages, markChatAsRead, setActiveChat } = chatActions
@@ -107,12 +108,16 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       }
     }, [chat, chatId])
 
+    const wasNearBottomRef = useRef<boolean>(true)
+
     const scrollHandler = useCallback(
       (e: UIEvent<HTMLDivElement>) => {
         if (!chatId) return
 
         // Handle case where scrolled to bottom
-        if (isScrolledNearBottom(e.target as HTMLDivElement)) {
+        const nearBottom = isScrolledNearBottom(e.target as HTMLDivElement)
+        wasNearBottomRef.current = nearBottom
+        if (nearBottom) {
           // Mark chat as read when the user reaches the bottom (saga handles no-op if already read)
           dispatch(markChatAsRead({ chatId }))
           dispatch(setActiveChat({ chatId }))
@@ -155,6 +160,28 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     useEffect(() => () => {
       throttledScrollHandler.cancel()
     })
+
+    // Respond to async unfurl expansions explicitly signaled by list items
+    useEffect(() => {
+      const el = ref.current
+      if (!el) return
+
+      const handleExpanded = (e: Event) => {
+        // If user was near bottom before expansion, schedule a microtask scroll
+        if (!wasNearBottomRef.current) return
+        // Wait for the layout to settle this tick
+        queueMicrotask(() => {
+          el.scrollTo({ top: el.scrollHeight })
+        })
+      }
+      window.addEventListener(CONTENT_EXPANDED_LISTENER_KEY, handleExpanded)
+      return () => {
+        window.removeEventListener(
+          CONTENT_EXPANDED_LISTENER_KEY,
+          handleExpanded
+        )
+      }
+    }, [])
 
     const scrollIntoViewOnMount = useCallback((el: HTMLDivElement) => {
       if (el) {
@@ -217,7 +244,7 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         onScroll={throttledScrollHandler}
         className={cn(styles.root, classNameProp)}
         resetKey={chatId}
-        updateKey={chatMessages}
+        updateKey={messageListHeight}
         stickToBottom
         scrollBottomThreshold={SCROLL_BOTTOM_THRESHOLD}
         {...other}

--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
@@ -23,6 +23,7 @@ import { UserGeneratedTextV2 } from 'components/user-generated-text/UserGenerate
 import ChatTail from '../../../assets/img/ChatTail.svg'
 
 import { ArtistCoinHeader } from './ArtistCoinHeader'
+import { CONTENT_EXPANDED_LISTENER_KEY } from './ChatMessageList'
 import styles from './ChatMessageListItem.module.css'
 import { ChatMessagePlaylist } from './ChatMessagePlaylist'
 import { ChatMessageTrack } from './ChatMessageTrack'
@@ -122,8 +123,16 @@ export const ChatMessageListItem = (props: ChatMessageListItemProps) => {
   const onUnfurlSuccess = useCallback(() => {
     if (linkValue) {
       setEmptyUnfurl(false)
+      // Notify the message list that content expanded so it can adjust scroll
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent(CONTENT_EXPANDED_LISTENER_KEY, {
+            detail: { chatId }
+          })
+        )
+      }
     }
-  }, [linkValue])
+  }, [linkValue, chatId])
 
   // Only render reactions if user has message permissions
   const { canSendMessage } = useCanSendMessage(chatId)


### PR DESCRIPTION
### Description

When DMs with embedded tracks unfurl, we don't stay scrolled to the bottom. Add a window event to notify the message list of it and scroll down.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Loads and I stay on the bottom. Not jitter really.

![2025-09-24 18 18 05](https://github.com/user-attachments/assets/482a5422-5a6b-47e0-8030-994616203178)

