### PR TITLE
[PE-6930] Use bonding curve price in swap flow pricePerBaseToken

### DIFF
--- a/packages/mobile/src/components/buy-sell/CryptoBalanceSection.tsx
+++ b/packages/mobile/src/components/buy-sell/CryptoBalanceSection.tsx
@@ -1,13 +1,7 @@
-import React from 'react'
-
 import { type TokenInfo } from '@audius/common/store'
 import { Image } from 'react-native'
 
 import { Flex, Text, useTheme, HexagonalIcon } from '@audius/harmony-native'
-
-const messages = {
-  symbol: (symbol: string) => `$${symbol}`
-}
 
 type CryptoBalanceSectionProps = {
   title: string
@@ -23,36 +17,44 @@ export const CryptoBalanceSection = ({
   priceLabel
 }: CryptoBalanceSectionProps) => {
   const { logoURI } = tokenInfo
-  const { iconSizes } = useTheme()
+  const { iconSizes, spacing } = useTheme()
   const iconSize = iconSizes['4xl']
 
   return (
-    <Flex direction='column' gap='m'>
+    <Flex gap='m'>
       {/* Header */}
       <Text variant='heading' size='s' color='subdued'>
         {title}
       </Text>
 
       {/* Amount and token info */}
-      <Flex direction='row' alignItems='center' gap='s'>
+      <Flex row alignItems='center' gap='s'>
         <HexagonalIcon size={iconSize}>
           <Image
             source={{ uri: logoURI }}
             style={{ width: iconSize, height: iconSize }}
           />
         </HexagonalIcon>
-        <Flex direction='column'>
-          <Flex direction='row' gap='xs' alignItems='center'>
+        <Flex>
+          <Flex row gap='xs' alignItems='center'>
             <Text variant='heading' size='l'>
               {amount}
             </Text>
             <Text variant='heading' size='m' color='subdued'>
-              {messages.symbol(tokenInfo.symbol)}
+              {tokenInfo.symbol}
             </Text>
           </Flex>
-          <Flex direction='row' gap='xs'>
+          <Flex row gap='xs'>
             {priceLabel && (
-              <Text variant='heading' size='s' color='subdued'>
+              <Text
+                variant='heading'
+                size='s'
+                color='subdued'
+                style={{
+                  lineHeight: spacing.unit7,
+                  transform: [{ translateY: -spacing.unitHalf }]
+                }}
+              >
                 {priceLabel}
               </Text>
             )}

--- a/packages/mobile/src/components/buy-sell/SwapBalanceSection.tsx
+++ b/packages/mobile/src/components/buy-sell/SwapBalanceSection.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import type { TokenInfo } from '@audius/common/store'
 
 import { CryptoBalanceSection } from './CryptoBalanceSection'

--- a/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/BuySellFlow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { useTokenPair, useTokens } from '@audius/common/api'
+import { useArtistCoin, useTokenPair, useTokens } from '@audius/common/api'
 import { useBuySellAnalytics, useOwnedTokens } from '@audius/common/hooks'
 import { buySellMessages as messages } from '@audius/common/messages'
 import type { BuySellTab, TokenInfo } from '@audius/common/store'
@@ -213,6 +213,15 @@ export const BuySellFlow = ({
     selectedPair: safeSelectedPair
   })
 
+  const { data: outputCoin } = useArtistCoin(
+    swapTokens.outputTokenInfo?.address
+  )
+  const pricePerBaseToken = useMemo(() => {
+    return outputCoin?.price !== 0
+      ? (outputCoin?.price ?? 0)
+      : (outputCoin?.dynamicBondingCurve.priceUSD ?? 0)
+  }, [outputCoin])
+
   // Use shared tabs array logic
   const tabs = useBuySellTabsArray()
 
@@ -235,7 +244,8 @@ export const BuySellFlow = ({
         navigation.navigate('ConfirmSwapScreen', {
           confirmationData: confirmationScreenData,
           activeTab,
-          selectedPair: safeSelectedPair
+          selectedPair: safeSelectedPair,
+          pricePerBaseToken
         })
       }
     }

--- a/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/ConfirmSwapScreen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { formatUSDCValue, SLIPPAGE_BPS } from '@audius/common/api'
+import { SLIPPAGE_BPS } from '@audius/common/api'
 import { useBuySellAnalytics } from '@audius/common/hooks'
 import { buySellMessages as baseMessages } from '@audius/common/messages'
 import type { TokenInfo, TokenPair } from '@audius/common/store'
@@ -11,6 +11,7 @@ import {
   useSwapDisplayData,
   useTokenAmountFormatting
 } from '@audius/common/store'
+import { formatCurrencyWithSubscript } from '@audius/common/utils'
 
 import {
   Button,
@@ -35,7 +36,7 @@ import { PoweredByJupiter } from './components/PoweredByJupiter'
 const messages = {
   ...baseMessages,
   priceEach: (price: number) => {
-    const formatted = formatUSDCValue(price, { includeDollarSign: true })
+    const formatted = formatCurrencyWithSubscript(price)
     return `(${formatted} ea.)`
   },
   loadingTitle: 'Transaction in Progress',
@@ -164,10 +165,10 @@ export const ConfirmSwapScreen = ({ route }: ConfirmSwapScreenProps) => {
         activeTab,
         inputToken: swapTokens.inputToken,
         outputToken: swapTokens.outputToken,
-        inputAmount: swapResult?.inputAmount || payAmount,
-        outputAmount: swapResult?.outputAmount || receiveAmount,
+        inputAmount: swapResult?.inputAmount ?? payAmount,
+        outputAmount: swapResult?.outputAmount ?? receiveAmount,
         exchangeRate,
-        signature: swapResult?.signature || ''
+        signature: swapResult?.signature ?? ''
       })
 
       navigation.navigate('TransactionResultScreen', {

--- a/packages/mobile/src/screens/buy-sell-screen/TransactionResultScreen.tsx
+++ b/packages/mobile/src/screens/buy-sell-screen/TransactionResultScreen.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { formatUSDCValue } from '@audius/common/api'
 import { buySellMessages as baseMessages } from '@audius/common/messages'
 import type { SuccessDisplayData } from '@audius/common/store'
 import { useTokenAmountFormatting } from '@audius/common/store'
@@ -21,11 +20,12 @@ import {
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import { SwapBalanceSection } from '../../components/buy-sell'
+import { formatCurrencyWithSubscript } from '@audius/common/utils'
 
 const messages = {
   ...baseMessages,
   priceEach: (price: number) => {
-    const formatted = formatUSDCValue(price, { includeDollarSign: true })
+    const formatted = formatCurrencyWithSubscript(price)
     return `(${formatted} ea.)`
   }
 }

--- a/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
@@ -4,7 +4,8 @@ import {
   useCurrentAccountUser,
   useUserCoins,
   useTokens,
-  useTokenPair
+  useTokenPair,
+  useArtistCoin
 } from '@audius/common/api'
 import { useBuySellAnalytics } from '@audius/common/hooks'
 import { buySellMessages as messages } from '@audius/common/messages'
@@ -360,6 +361,16 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
     setTabInputValues
   ])
 
+  const { data: outputCoin } = useArtistCoin(
+    swapTokens.outputTokenInfo?.address
+  )
+  const pricePerBaseToken = useMemo(() => {
+    return outputCoin?.price !== 0
+      ? (outputCoin?.price ?? 0)
+      : (outputCoin?.dynamicBondingCurve.priceUSD ?? 0)
+  }, [outputCoin])
+  console.log('pricePerBaseToken', pricePerBaseToken)
+
   const isTransactionInvalid = !transactionData?.isValid
 
   const displayErrorMessage = useMemo(() => {
@@ -502,6 +513,7 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
             isConfirming={isConfirmButtonLoading}
             activeTab={activeTab}
             selectedPair={safeSelectedPair}
+            pricePerBaseToken={pricePerBaseToken}
           />
         ) : null}
       </Flex>

--- a/packages/web/src/components/buy-sell-modal/ConfirmSwapScreen.tsx
+++ b/packages/web/src/components/buy-sell-modal/ConfirmSwapScreen.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { formatUSDCValue, SLIPPAGE_BPS } from '@audius/common/api'
+import { SLIPPAGE_BPS } from '@audius/common/api'
 import { useBuySellAnalytics } from '@audius/common/hooks'
 import { buySellMessages as baseMessages } from '@audius/common/messages'
 import {
@@ -12,11 +12,12 @@ import {
 import { Button, Flex, Text } from '@audius/harmony'
 
 import { SwapBalanceSection } from './SwapBalanceSection'
+import { formatCurrencyWithSubscript } from '@audius/common/utils'
 
 const messages = {
   ...baseMessages,
   priceEach: (price: number) => {
-    const formatted = formatUSDCValue(price, { includeDollarSign: true })
+    const formatted = formatCurrencyWithSubscript(price)
     return `(${formatted} ea.)`
   }
 }
@@ -96,11 +97,11 @@ export const ConfirmSwapScreen = (props: ConfirmSwapScreenProps) => {
   }
 
   return (
-    <Flex direction='column' gap='l'>
-      <Text variant='body' size='m' textAlign='center'>
+    <Flex column gap='l'>
+      <Text variant='body' size='m'>
         {messages.confirmReview}
       </Text>
-      <Flex direction='column' gap='xl'>
+      <Flex column gap='xl'>
         <SwapBalanceSection
           title={messages.youPay}
           tokenInfo={payTokenInfo}

--- a/packages/web/src/components/buy-sell-modal/TransactionSuccessScreen.tsx
+++ b/packages/web/src/components/buy-sell-modal/TransactionSuccessScreen.tsx
@@ -1,14 +1,14 @@
-import { formatUSDCValue } from '@audius/common/api'
 import { buySellMessages as baseMessages } from '@audius/common/messages'
 import { useTokenAmountFormatting, TokenInfo } from '@audius/common/store'
 import { Button, CompletionCheck, Flex, Text } from '@audius/harmony'
 
 import { SwapBalanceSection } from './SwapBalanceSection'
+import { formatCurrencyWithSubscript } from '@audius/common/utils'
 
 const messages = {
   ...baseMessages,
   priceEach: (price: number) => {
-    const formatted = formatUSDCValue(price, { includeDollarSign: true })
+    const formatted = formatCurrencyWithSubscript(price)
     return `(${formatted} ea.)`
   }
 }


### PR DESCRIPTION
### Description
Fallback to bonding curve price if birdeye price is 0, and use subscript notation.

Need to revisit subscript text getting clipped. Included a temp fix for now using lineHeight + translate.

### How Has This Been Tested?

<img width="728" height="520" alt="Screenshot 2025-09-24 at 9 58 57 PM" src="https://github.com/user-attachments/assets/013611df-a73d-481f-8a5c-e5aa15f8d06b" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-24 at 22 27 00" src="https://github.com/user-attachments/assets/e437d9c9-ebbc-426f-80ec-8225c2ab61a9" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-24 at 23 23 31" src="https://github.com/user-attachments/assets/d29dfa32-735f-4eb9-b36b-7b70e4eec600" />
<img width="739" height="470" alt="Screenshot 2025-09-24 at 11 23 43 PM" src="https://github.com/user-attachments/assets/5ba800f1-9ba1-4011-afed-f50af67fe432" />
