### PR TITLE
Pass includeExternalWallets to useAudioBalance in AudioHoverCard

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useTokenBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useTokenBalance.ts
@@ -49,7 +49,10 @@ export const useTokenBalance = ({
   const isAudio = mint === env.WAUDIO_MINT_ADDRESS
 
   // For AUDIO, we need to use the useAudioBalance hook since it includes ETH audio. useUserCoin is only SOL AUDIO
-  const audioTokenQuery = useAudioBalance({ userId }, { enabled: isAudio })
+  const audioTokenQuery = useAudioBalance(
+    { userId, includeConnectedWallets: includeExternalWallets },
+    { enabled: isAudio }
+  )
 
   // Artist coins query
   const userCoinQuery = useUserCoin(

--- a/packages/web/src/components/hover-card/AudioHoverCard.tsx
+++ b/packages/web/src/components/hover-card/AudioHoverCard.tsx
@@ -82,7 +82,8 @@ export const AudioHoverCard = ({
   const { data: tokenBalance } = useTokenBalance({
     mint: env.WAUDIO_MINT_ADDRESS,
     userId,
-    enabled: isHovered
+    enabled: isHovered,
+    includeExternalWallets: true
   })
 
   const formattedBalance = tokenBalance


### PR DESCRIPTION
### Description

### How Has This Been Tested?

badge includes external balance, but buy/sell does not
<img width="730" height="522" alt="Screenshot 2025-09-25 at 1 54 13 PM" src="https://github.com/user-attachments/assets/0265818a-74a8-45c3-a8b1-65717fc712d8" />
<img width="348" height="178" alt="Screenshot 2025-09-25 at 1 54 17 PM" src="https://github.com/user-attachments/assets/b91baa18-a853-4c1a-8688-bff93cbe0a79" />

