### PR TITLE
More borders for AssetDetailPage

### DIFF
--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -41,24 +41,20 @@ const AssetInfoSectionSkeleton = () => {
     <Paper
       borderRadius='l'
       shadow='far'
-      direction='column'
+      column
       alignItems='flex-start'
+      border='default'
     >
       {/* Banner skeleton */}
       <Flex
-        direction='column'
+        column
         alignItems='flex-start'
         alignSelf='stretch'
+        border='default'
         h={BANNER_HEIGHT}
         css={{ backgroundColor: theme.color.neutral.n100 }}
       >
-        <Flex
-          direction='column'
-          alignItems='flex-start'
-          alignSelf='stretch'
-          p='l'
-          gap='s'
-        >
+        <Flex column alignItems='flex-start' alignSelf='stretch' p='l' gap='s'>
           <Skeleton width='80px' height='16px' />
           <Flex
             alignItems='center'
@@ -75,15 +71,9 @@ const AssetInfoSectionSkeleton = () => {
       </Flex>
 
       {/* Content skeleton */}
-      <Flex
-        direction='column'
-        alignItems='flex-start'
-        alignSelf='stretch'
-        p='xl'
-        gap='l'
-      >
+      <Flex column alignItems='flex-start' alignSelf='stretch' p='xl' gap='l'>
         <Skeleton width='200px' height='24px' />
-        <Flex direction='column' gap='m'>
+        <Flex column gap='m'>
           <Skeleton width='100%' height='20px' />
           <Skeleton width='90%' height='20px' />
           <Skeleton width='100%' height='20px' />
@@ -130,19 +120,13 @@ const BannerSection = ({ mint }: BannerSectionProps) => {
   if (isLoading || !coin || !owner) {
     return (
       <Flex
-        direction='column'
+        column
         alignItems='flex-start'
         alignSelf='stretch'
         h={BANNER_HEIGHT}
         css={{ backgroundColor: theme.color.neutral.n100 }}
       >
-        <Flex
-          direction='column'
-          alignItems='flex-start'
-          alignSelf='stretch'
-          p='l'
-          gap='s'
-        >
+        <Flex column alignItems='flex-start' alignSelf='stretch' p='l' gap='s'>
           <Skeleton width='80px' height='16px' />
           <Flex
             alignItems='center'
@@ -162,7 +146,7 @@ const BannerSection = ({ mint }: BannerSectionProps) => {
 
   return (
     <Flex
-      direction='column'
+      column
       alignItems='flex-start'
       alignSelf='stretch'
       h={BANNER_HEIGHT}
@@ -174,13 +158,7 @@ const BannerSection = ({ mint }: BannerSectionProps) => {
         position: 'relative'
       }}
     >
-      <Flex
-        direction='column'
-        alignItems='flex-start'
-        alignSelf='stretch'
-        p='l'
-        gap='s'
-      >
+      <Flex column alignItems='flex-start' alignSelf='stretch' p='l' gap='s'>
         <Text variant='label' size='m' color='staticWhite' shadow='emphasis'>
           {messages.createdBy}
         </Text>
@@ -238,20 +216,15 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
     <Paper
       borderRadius='l'
       shadow='far'
-      direction='column'
+      column
       alignItems='flex-start'
+      border='default'
     >
       <BannerSection mint={mint} />
 
       {coin.description ? (
-        <Flex
-          direction='column'
-          alignItems='flex-start'
-          alignSelf='stretch'
-          p='xl'
-          gap='l'
-        >
-          <Flex direction='column' gap='m'>
+        <Flex column alignItems='flex-start' alignSelf='stretch' p='xl' gap='l'>
+          <Flex column gap='m'>
             {descriptionParagraphs.map((paragraph) => {
               if (paragraph.trim() === '') {
                 return null

--- a/packages/web/src/pages/asset-detail-page/components/AssetLeaderboardCard.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetLeaderboardCard.tsx
@@ -90,8 +90,9 @@ export const AssetLeaderboardCard = ({ mint }: AssetLeaderboardCardProps) => {
     <Paper
       borderRadius='l'
       shadow='far'
-      direction='column'
+      column
       alignItems='flex-start'
+      border='default'
     >
       <Flex alignItems='center' gap='xs' pv='l' ph='xl'>
         <Text variant='heading' size='s' color='heading'>

--- a/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/BalanceSection.tsx
@@ -283,7 +283,7 @@ const BalanceSectionContent = ({ mint }: AssetDetailProps) => {
   const logoURI = coin.logoUri
 
   return (
-    <Paper ph='xl' pv='l'>
+    <Paper ph='xl' pv='l' border='default'>
       <Flex column gap='l' w='100%'>
         {!tokenBalance?.balance ||
         Number(tokenBalance.balance.toString()) === 0 ? (
@@ -340,7 +340,7 @@ export const BalanceSection = componentWithErrorBoundary(
   {
     name: 'BalanceSection',
     fallback: (
-      <Paper ph='xl' pv='l'>
+      <Paper ph='xl' pv='l' border='default'>
         <Flex column gap='l' w='100%'>
           <Text variant='body' size='m' color='subdued'>
             {walletMessages.errors.unableToLoadBalance}


### PR DESCRIPTION
### Description
so they don't float in matrix mode

### How Has This Been Tested?

<img width="1920" height="1080" alt="Screenshot 2025-09-25 at 2 02 27 PM" src="https://github.com/user-attachments/assets/00ebabd0-dfed-4fa0-b721-501a6764da7f" />
