### PR TITLE
[PE-6919] Fix launchpad audio purchase modal not updating

### DIFF
--- a/packages/web/src/hooks/useExternalWalletSwap.ts
+++ b/packages/web/src/hooks/useExternalWalletSwap.ts
@@ -122,6 +122,8 @@ export const useExternalWalletSwap = () => {
       }
     },
     onSuccess: (result, params) => {
+      // NOTE: due to how we are catching errors in the function, this onSuccess will still run on a handled error
+      // (since we're still returning a result no matter what)
       if (!result.isError) {
         // Update external wallet balances optimistically
         // NOTE: invalidate queries does not work here, need to manually update the balances


### PR DESCRIPTION
### Description

- Previously I was just invalidating the audio balance query, which seems to work some of the time but not all the time =/
- Instead I optimistically update balances here


![2025-09-25 12 59 05](https://github.com/user-attachments/assets/e3b04702-6e9d-4bac-a078-17c2d35924cc)

### How Has This Been Tested?

web:prod - tested with USDC and SOL swaps