### PR TITLE
[PE-6950], [PE-6949] Fix mobile balance formatting

### DIFF
--- a/packages/common/src/hooks/useFormattedTokenBalance.ts
+++ b/packages/common/src/hooks/useFormattedTokenBalance.ts
@@ -7,7 +7,8 @@ import {
   getTokenDecimalPlaces,
   formatCurrencyWithSubscript,
   isNullOrUndefined,
-  formatCount
+  formatCount,
+  formatNumberCommas
 } from '../utils'
 
 type UseFormattedTokenBalanceReturn = {
@@ -54,10 +55,13 @@ export const useFormattedTokenBalance = (
     // FixedDecimal can't format with more decimals than it was constructed with
     const maxFractionDigits = Math.min(decimalPlaces, tokenBalance?.decimals)
 
-    return balance.toLocaleString(locale, {
-      maximumFractionDigits: maxFractionDigits,
-      roundingMode: 'trunc'
-    })
+    // Need formatNumberCommas for mobile :(
+    return formatNumberCommas(
+      balance.toLocaleString(locale, {
+        maximumFractionDigits: maxFractionDigits,
+        roundingMode: 'trunc'
+      })
+    )
   }, [balance, hasFetchedTokenBalance, locale, tokenBalance?.decimals])
 
   // Calculate dollar value of user's mint balance

--- a/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
+++ b/packages/mobile/src/screens/coin-details-screen/components/BalanceCard.tsx
@@ -9,7 +9,7 @@ import {
 } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
 
-import { Paper, Flex, Text, Button } from '@audius/harmony-native'
+import { Paper, Flex, Text, Button, spacing } from '@audius/harmony-native'
 import { TokenIcon } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 
@@ -93,7 +93,15 @@ const HasBalanceState = ({
               {title}
             </Text>
           </Flex>
-          <Text variant='heading' size='s' color='subdued'>
+          <Text
+            variant='heading'
+            size='s'
+            color='subdued'
+            style={{
+              lineHeight: spacing.unit7,
+              transform: [{ translateY: -spacing.unitHalf }]
+            }}
+          >
             {tokenDollarValue}
           </Text>
         </Flex>


### PR DESCRIPTION
### Description
2 annoying things:
- there's probably a better way to fix harmony `Text` to handle subscripts but that's a rabbit hole i'm not tryna go down right now.
- For some reason `toLocaleString` formats numbers with commas on web but not mobile. fml. so gotta do it manually.

### How Has This Been Tested?

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-25 at 14 32 06" src="https://github.com/user-attachments/assets/fd49917e-045a-43aa-aa6f-669777477f9d" />
