### PR TITLE
[PE-6942] Add copy address button to asset page

### DIFF
--- a/packages/mobile/src/screens/coin-details-screen/components/CoinInfoCard.tsx
+++ b/packages/mobile/src/screens/coin-details-screen/components/CoinInfoCard.tsx
@@ -3,8 +3,10 @@ import { useCallback } from 'react'
 import { useArtistCoin } from '@audius/common/api'
 import { coinDetailsMessages } from '@audius/common/messages'
 import { WidthSizes } from '@audius/common/models'
+import { shortenSPLAddress } from '@audius/common/utils'
 import type { Coin } from '@audius/sdk'
 import { decodeHashId } from '@audius/sdk'
+import Clipboard from '@react-native-clipboard/clipboard'
 import { Image, Linking } from 'react-native'
 
 import {
@@ -12,6 +14,7 @@ import {
   Divider,
   Flex,
   HexagonalIcon,
+  IconCopy,
   IconExternalLink,
   IconGift,
   Paper,
@@ -20,9 +23,11 @@ import {
 } from '@audius/harmony-native'
 import { useCoverPhoto } from 'app/components/image/CoverPhoto'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { useToast } from 'app/hooks/useToast'
 import { env } from 'app/services/env'
 
 const messages = coinDetailsMessages.coinInfo
+const overflowMessages = coinDetailsMessages.overflowMenu
 
 const BannerSection = ({ mint }: { mint: string }) => {
   const { data: coin, isLoading } = useArtistCoin(mint)
@@ -151,6 +156,7 @@ const CoinDescriptionSection = ({ coin }: { coin: Coin }) => {
 export const CoinInfoCard = ({ mint }: { mint: string }) => {
   const { data: coin, isLoading } = useArtistCoin(mint)
   const navigation = useNavigation()
+  const { toast } = useToast()
 
   const handleLearnMore = useCallback(() => {
     // Open the coin website in browser
@@ -162,6 +168,11 @@ export const CoinInfoCard = ({ mint }: { mint: string }) => {
   const handleBrowseRewards = useCallback(() => {
     navigation.navigate('RewardsScreen')
   }, [navigation])
+
+  const handleCopyAddress = useCallback(() => {
+    Clipboard.setString(mint)
+    toast({ content: overflowMessages.copiedToClipboard, type: 'info' })
+  }, [mint, toast])
 
   if (isLoading || !coin) {
     return null
@@ -190,6 +201,22 @@ export const CoinInfoCard = ({ mint }: { mint: string }) => {
         >
           {isWAudio ? messages.browseRewards : messages.learnMore}
         </PlainButton>
+      </Flex>
+      <Divider style={{ width: '100%' }} />
+      <Flex
+        direction='row'
+        w='100%'
+        ph='xl'
+        pv='l'
+        justifyContent='space-between'
+        alignItems='center'
+      >
+        <PlainButton onPress={handleCopyAddress} iconLeft={IconCopy}>
+          {overflowMessages.copyCoinAddress}
+        </PlainButton>
+        <Text variant='body' size='m' color='subdued'>
+          {shortenSPLAddress(mint)}
+        </Text>
       </Flex>
     </Paper>
   )

--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 
 import {
   useArtistCoin,
@@ -9,9 +9,10 @@ import {
 import { useDiscordOAuthLink } from '@audius/common/hooks'
 import { coinDetailsMessages } from '@audius/common/messages'
 import { WidthSizes } from '@audius/common/models'
-import { route } from '@audius/common/utils'
+import { route, shortenSPLAddress } from '@audius/common/utils'
 import {
   Flex,
+  IconCopy,
   IconDiscord,
   IconExternalLink,
   IconGift,
@@ -24,13 +25,16 @@ import { decodeHashId } from '@audius/sdk'
 import { useDispatch } from 'react-redux'
 
 import Skeleton from 'components/skeleton/Skeleton'
+import { ToastContext } from 'components/toast/ToastContext'
 import Tooltip from 'components/tooltip/Tooltip'
 import { UserTokenBadge } from 'components/user-token-badge/UserTokenBadge'
 import { useCoverPhoto } from 'hooks/useCoverPhoto'
 import { env } from 'services/env'
+import { copyToClipboard } from 'utils/clipboardUtil'
 import { push } from 'utils/navigation'
 
 const messages = coinDetailsMessages.coinInfo
+const overflowMessages = coinDetailsMessages.overflowMenu
 
 const BANNER_HEIGHT = 120
 
@@ -199,6 +203,7 @@ const { REWARDS_PAGE } = route
 
 export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
   const dispatch = useDispatch()
+  const { toast } = useContext(ToastContext)
 
   const { data: coin, isLoading } = useArtistCoin(mint)
   const { data: currentUserId } = useCurrentUserId()
@@ -223,6 +228,11 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
   const handleBrowseRewards = useCallback(() => {
     dispatch(push(REWARDS_PAGE))
   }, [dispatch])
+
+  const handleCopyAddress = useCallback(() => {
+    copyToClipboard(mint)
+    toast(overflowMessages.copiedToClipboard)
+  }, [mint, toast])
 
   if (isLoading || !coin) {
     return <AssetInfoSectionSkeleton />
@@ -331,6 +341,25 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
           </Flex>
         </Flex>
       ) : null}
+
+      <Flex
+        alignItems='center'
+        justifyContent='space-between'
+        alignSelf='stretch'
+        p='l'
+        borderTop='default'
+      >
+        <PlainButton
+          onClick={handleCopyAddress}
+          iconLeft={IconCopy}
+          variant='default'
+        >
+          {overflowMessages.copyCoinAddress}
+        </PlainButton>
+        <Text variant='body' size='m' color='subdued'>
+          {shortenSPLAddress(mint)}
+        </Text>
+      </Flex>
     </Paper>
   )
 }

--- a/packages/web/src/pages/asset-detail-page/components/AssetInsights.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInsights.tsx
@@ -121,7 +121,7 @@ const GraduationProgressMetricRowComponent = ({
         <Text variant='title' size='m' color='subdued'>
           {metric.label}
         </Text>
-        <Tooltip text={tooltipContent}>
+        <Tooltip text={tooltipContent} mount='body'>
           <IconInfo size='s' color='subdued' />
         </Tooltip>
       </Flex>


### PR DESCRIPTION
### Description
<img width="720" height="70" alt="image" src="https://github.com/user-attachments/assets/0bcaa7c3-6cc7-44df-807e-04b3cc8f381c" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
