### PR TITLE
[PE-6948] Format number commas on mobile leaderboard

### DIFF
--- a/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
+++ b/packages/common/src/api/tan-query/coins/useArtistCoinMembers.ts
@@ -13,6 +13,7 @@ import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey } from '../types'
 
 import { useArtistCoin } from './useArtistCoin'
+import { formatNumberCommas } from '~/utils'
 
 const DEFAULT_PAGE_SIZE = 20
 
@@ -96,11 +97,13 @@ export const useArtistCoinMembers = <TResult = CoinMember[]>(
         return {
           userId: HashId.parse(member.userId),
           balance: member.balance,
-          // TODO: ideally this is a selector using logic from useTokenAmountFormatting
-          balanceLocaleString: balanceFD.toLocaleString('en-US', {
-            maximumFractionDigits: 0,
-            roundingMode: 'trunc'
-          })
+          // Need formatNumberCommas for mobile :(
+          balanceLocaleString: formatNumberCommas(
+            balanceFD.toLocaleString('en-US', {
+              maximumFractionDigits: 0,
+              roundingMode: 'trunc'
+            })
+          )
         }
       })
 


### PR DESCRIPTION
### Description
Lack of comma formatting on mobile toLocaleString is killing me

### How Has This Been Tested?

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-25 at 14 40 11" src="https://github.com/user-attachments/assets/bb6614ec-bf68-4f75-9496-6fbc10bc06ba" />
