### PR TITLE
Remove erroneous signer

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/coreRelay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/coreRelay.ts
@@ -118,7 +118,6 @@ export const coreRelay = async (
       encodedABI as `0x${string}`
     )
 
-    const signer = request.senderAddress
     const signature = ethers.utils.hexlify(subjectSig)
     const nonce = ethers.utils.hexlify(nonceBytes)
 
@@ -129,7 +128,6 @@ export const coreRelay = async (
       action,
       metadata,
       signature,
-      signer,
       nonce
     })
 
@@ -181,8 +179,8 @@ export const coreRelay = async (
       transactionIndex: 0,
       blockHash: blockHash,
       blockNumber: Number(blockHeight),
-      from: signer || '',
-      to: signer || '',
+      from: request.senderAddress || '',
+      to: request.senderAddress || '',
       cumulativeGasUsed: 10,
       gasUsed: 10,
       effectiveGasPrice: 420


### PR DESCRIPTION
### Description

From/to are probably fine in the receipt, that actually makes sense as the `senderAddress`. It's just not the `Signer`