### PR TITLE
round up on buy sell modal

### DIFF
--- a/packages/common/src/store/ui/buy-sell/utils/validationHelpers.ts
+++ b/packages/common/src/store/ui/buy-sell/utils/validationHelpers.ts
@@ -54,7 +54,8 @@ export const validateMinimumAmount = (
 
   try {
     const amount = new FixedDecimal(value, decimals)
-    const minAmount = new FixedDecimal(min, decimals)
+    // The UI displays this value up to 2 decimal places. To prevent confusion we round this number up
+    const minAmount = new FixedDecimal(min, decimals).round(2)
 
     if (amount.value < minAmount.value) {
       return messages.minAmount(min, tokenSymbol)


### PR DESCRIPTION
### Description

- Round the min transaction amount so that the UI doesnt look confusing

<img width="730" height="333" alt="image" src="https://github.com/user-attachments/assets/3dbb9c57-dccd-4f08-a21b-ebe316dd1df5" />

digging in this was the issue
<img width="236" height="197" alt="image" src="https://github.com/user-attachments/assets/2dae2a69-3463-4371-b32b-d24d651beb38" />


### How Has This Been Tested?

BEAR on prod - also did a swap
