### PR TITLE
[PE-6963] Artist coin table text body variant subscripts

### DIFF
--- a/packages/harmony/src/components/text/Text.tsx
+++ b/packages/harmony/src/components/text/Text.tsx
@@ -149,7 +149,7 @@ export const Text = forwardRef(
     // @ts-ignore
     const variantTag = variant && variantTagMap[variant]?.[size]
 
-    const Tag: ElementType = asChild ? Slot : tag ?? variantTag ?? 'span'
+    const Tag: ElementType = asChild ? Slot : (tag ?? variantTag ?? 'span')
 
     // Only convert Unicode subscripts to <sub> tags for body variants with default strength.
     // Other variants/strengths render Unicode subscripts correctly without this conversion.


### PR DESCRIPTION
### Description
This is weird and i don't like it, but it works.

Bug: `<Text variant='body' strength='default'>` was not rendering subscripts correctly. Other variants, and every body variant with other strength actually rendered them correctly.
Fix: Use the `<sub>` html tag.

However, all the other text variants look fine without the `<sub>` tag, so I guess let's just use it for that specific condition.

### How Has This Been Tested?

<img width="895" height="393" alt="Screenshot 2025-09-25 at 5 54 03 PM" src="https://github.com/user-attachments/assets/8f965f21-1832-41f6-9570-7c576154feff" />
<img width="594" height="346" alt="Screenshot 2025-09-25 at 5 54 00 PM" src="https://github.com/user-attachments/assets/6b716aec-c188-4734-b98d-134abf8e41ad" />
