### PR TITLE
[PE-6866] Artist coin blast UI on sender side

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -591,7 +591,8 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
           message,
           reactions: [],
           created_at: dayjs().toISOString(),
-          is_plaintext: !!chat?.is_blast
+          is_plaintext: !!chat?.is_blast,
+          audience: chat?.audience
         },
         status: Status.LOADING,
         isSelfMessage: true

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -465,6 +465,7 @@ const slice = createSlice({
       action: PayloadAction<{
         chatId: string
         message: string
+        audience?: ChatBlastAudience
         resendMessageId?: string
       }>
     ) => {

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useRef, useState } from 'react'
 
+import { useProxySelector } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
-import { chatActions } from '@audius/common/store'
+import { chatActions, chatSelectors } from '@audius/common/store'
 import type { Nullable } from '@audius/common/utils'
 import { OptionalHashId } from '@audius/sdk'
 import type { TextInput as RNTextInput } from 'react-native'
@@ -15,6 +16,7 @@ import { spacing } from 'app/styles/spacing'
 import { ComposerCollectionInfo, ComposerTrackInfo } from './ComposePreviewInfo'
 
 const { sendMessage } = chatActions
+const { getChat } = chatSelectors
 
 const messages = {
   startNewMessage: ' Start typing...'
@@ -34,6 +36,7 @@ export const ChatTextInput = ({
   onMessageSent
 }: ChatTextInputProps) => {
   const dispatch = useDispatch()
+  const chat = useProxySelector((state) => getChat(state, chatId), [chatId])
   const [messageId, setMessageId] = useState(0)
   // The track and collection ids used to render the composer preview
   const [trackId, setTrackId] = useState<Nullable<ID>>(null)
@@ -61,13 +64,15 @@ export const ChatTextInput = ({
   const handleSubmit = useCallback(
     async (value: string) => {
       if (chatId && value) {
-        dispatch(sendMessage({ chatId, message: value }))
+        dispatch(
+          sendMessage({ chatId, message: value, audience: chat?.audience })
+        )
         onMessageSent()
         setMessageId((id) => ++id)
         setTimeout(() => ref.current?.blur())
       }
     },
-    [chatId, dispatch, onMessageSent]
+    [chatId, dispatch, onMessageSent, chat?.audience]
   )
 
   // For iOS: default padding + extra padding

--- a/packages/web/src/pages/chat-page/components/ChatComposer.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatComposer.tsx
@@ -2,17 +2,19 @@ import { ComponentPropsWithoutRef, useCallback, useState } from 'react'
 
 import { LinkEntity } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
-import { chatActions } from '@audius/common/store'
+import { chatActions, chatSelectors } from '@audius/common/store'
 import { Nullable } from '@audius/common/utils'
 import { Box } from '@audius/harmony'
 import { HashId } from '@audius/sdk'
 import { useDispatch } from 'react-redux'
 
+import { useSelector } from 'common/hooks/useSelector'
 import { ComposerInput } from 'components/composer-input/ComposerInput'
 
 import { ComposerCollectionInfo, ComposerTrackInfo } from './ComposePreviewInfo'
 
 const { sendMessage } = chatActions
+const { getChat } = chatSelectors
 
 const messages = {
   sendMessagePlaceholder: 'Start typing...'
@@ -29,6 +31,7 @@ const MAX_MESSAGE_LENGTH = 10000
 export const ChatComposer = (props: ChatComposerProps) => {
   const { chatId, presetMessage, onMessageSent } = props
   const dispatch = useDispatch()
+  const chat = useSelector((state) => getChat(state, chatId ?? ''))
   const [value, setValue] = useState(presetMessage ?? '')
   const [messageId, setMessageId] = useState(0)
   // The track and collection ids used to render the composer preview
@@ -50,11 +53,13 @@ export const ChatComposer = (props: ChatComposerProps) => {
 
   const handleSubmit = useCallback(async () => {
     if (chatId && value) {
-      dispatch(sendMessage({ chatId, message: value }))
+      dispatch(
+        sendMessage({ chatId, message: value, audience: chat?.audience })
+      )
       setMessageId((id) => ++id)
       onMessageSent()
     }
-  }, [chatId, dispatch, onMessageSent, value])
+  }, [chatId, dispatch, onMessageSent, value, chat?.audience])
 
   return (
     <Box backgroundColor='white' className={props.className}>


### PR DESCRIPTION
### Description
When an artist sends an artist coin message blast, include the artist coin header UI.

### How Has This Been Tested?

<img width="1049" height="857" alt="Screenshot 2025-09-25 at 6 55 53 PM" src="https://github.com/user-attachments/assets/aa682d36-0076-4f8d-87bf-c6e5c1ec54ef" />
