### PR TITLE
[PE-6964] Calculate 24h vol change manually

### DIFF
--- a/packages/common/src/utils/coinMetrics.ts
+++ b/packages/common/src/utils/coinMetrics.ts
@@ -68,8 +68,7 @@ export const createCoinMetrics = (coin: Coin): MetricData[] => {
     createMetric(
       formatCount(coin.holder),
       messages.uniqueHolders,
-      ((coin.holder - coin.uniqueWalletHistory24h) /
-        coin.uniqueWalletHistory24h) *
+      (coin.uniqueWallet24h / Math.max(coin.holder - coin.uniqueWallet24h, 1)) *
         100
     ),
     createMetric(

--- a/packages/common/src/utils/coinMetrics.ts
+++ b/packages/common/src/utils/coinMetrics.ts
@@ -76,7 +76,7 @@ export const createCoinMetrics = (coin: Coin): MetricData[] => {
       messages.graduationProgress
     ),
     createMetric(
-      formatCount(coin.v24hUSD, 2),
+      `$${formatCount(coin.v24hUSD, 2)}`,
       messages.volume24hr,
       coin.v24hChangePercent
     ),

--- a/packages/common/src/utils/coinMetrics.ts
+++ b/packages/common/src/utils/coinMetrics.ts
@@ -68,7 +68,9 @@ export const createCoinMetrics = (coin: Coin): MetricData[] => {
     createMetric(
       formatCount(coin.holder),
       messages.uniqueHolders,
-      coin.uniqueWallet24hChangePercent
+      ((coin.holder - coin.uniqueWalletHistory24h) /
+        coin.uniqueWalletHistory24h) *
+        100
     ),
     createMetric(
       `${Math.round((coin.dynamicBondingCurve?.curveProgress ?? 0) * 100)}%`,


### PR DESCRIPTION
### Description
uniqueWallet24h seems to be unique new wallets in the last period according to their docs, see how much larger the 5m is than the 1m:
```
   "uniqueWallet1m": 7188,
    "uniqueWalletHistory1m": 7299,
    "uniqueWallet1mChangePercent": -1.5207562679819153,
    "uniqueWallet5m": 23670,
    "uniqueWalletHistory5m": 32416,
    "uniqueWallet5mChangePercent": -26.98050345508391,
```
So we calculate the 24hour change we want manually.

### How Has This Been Tested?

<img width="1683" height="846" alt="Screenshot 2025-09-25 at 7 50 10 PM" src="https://github.com/user-attachments/assets/bd65ce5e-d852-449b-aaca-cc678e461622" />
