### PR TITLE
[PROTO-2029] Unified validators page

### DIFF
--- a/packages/protocol-dashboard/src/App.tsx
+++ b/packages/protocol-dashboard/src/App.tsx
@@ -32,6 +32,7 @@ import ServiceUsers from 'containers/ServiceUsers'
 import Services from 'containers/Services'
 import UnregisteredNode from 'containers/UnregisteredNode'
 import User from 'containers/User'
+import Validators from 'containers/Validators'
 import { getDidGraphError } from 'store/api/hooks'
 import { createStyles } from 'utils/mobile'
 import * as routes from 'utils/routes'
@@ -147,6 +148,10 @@ const App = () => {
                     element={<ContentNodes />}
                   />
                   <Route path={routes.NODES_CONTENT_NODE} element={<Node />} />
+                  <Route
+                    path={routes.NODES_VALIDATORS}
+                    element={<Validators />}
+                  />
                   <Route
                     path={routes.SERVICES_CONTENT_NODE}
                     element={

--- a/packages/protocol-dashboard/src/components/NodeTable/NodeTable.tsx
+++ b/packages/protocol-dashboard/src/components/NodeTable/NodeTable.tsx
@@ -5,7 +5,11 @@ import { useContentNodes } from 'store/cache/contentNode/hooks'
 import { useDiscoveryProviders } from 'store/cache/discoveryProvider/hooks'
 import { Address, NodeService, ServiceType, Status } from 'types'
 import { usePushRoute } from 'utils/effects'
-import { NODES_CONTENT, contentNodePage, discoveryNodePage } from 'utils/routes'
+import {
+  NODES_VALIDATORS,
+  contentNodePage,
+  discoveryNodePage
+} from 'utils/routes'
 
 const messages = {
   title: 'Nodes',
@@ -32,7 +36,7 @@ const ContentTable: React.FC<NodeTableProps> = ({
   const allNodes = [...cnNodes, ...dpNodes]
 
   const onClickMore = useCallback(() => {
-    pushRoute(NODES_CONTENT)
+    pushRoute(NODES_VALIDATORS)
   }, [pushRoute])
 
   const onRowClick = useCallback(

--- a/packages/protocol-dashboard/src/components/NodeTable/NodeTable.tsx
+++ b/packages/protocol-dashboard/src/components/NodeTable/NodeTable.tsx
@@ -24,7 +24,7 @@ type OwnProps = {
 }
 
 type NodeTableProps = OwnProps
-const ContentTable: React.FC<NodeTableProps> = ({
+const NodeTable: React.FC<NodeTableProps> = ({
   className,
   limit,
   owner,
@@ -66,4 +66,4 @@ const ContentTable: React.FC<NodeTableProps> = ({
   )
 }
 
-export default ContentTable
+export default NodeTable

--- a/packages/protocol-dashboard/src/containers/Validators/Validators.tsx
+++ b/packages/protocol-dashboard/src/containers/Validators/Validators.tsx
@@ -1,0 +1,18 @@
+import NodeTable from 'components/NodeTable'
+import Page from 'components/Page'
+
+import styles from './Validators.module.css'
+
+const messages = {
+  title: 'VALIDATORS'
+}
+
+const Validators = () => {
+  return (
+    <Page title={messages.title} className={styles.container}>
+      <NodeTable className={styles.serviceTable} />
+    </Page>
+  )
+}
+
+export default Validators

--- a/packages/protocol-dashboard/src/containers/Validators/index.tsx
+++ b/packages/protocol-dashboard/src/containers/Validators/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Validators'

--- a/packages/protocol-dashboard/src/utils/routes.ts
+++ b/packages/protocol-dashboard/src/utils/routes.ts
@@ -21,6 +21,9 @@ export const NODES = '/nodes'
 export const SERVICES = '/services' // deprecated
 export const SERVICES_TITLE = 'Services Overview'
 
+export const NODES_VALIDATORS = '/nodes/validators'
+export const NODES_VALIDATORS_TITLE = 'Validators'
+
 export const NODES_DISCOVERY = '/nodes/discovery-node'
 export const SERVICES_DISCOVERY_PROVIDER = '/services/discovery-node' // deprecated
 export const SERVICES_DISCOVERY_PROVIDER_TITLE = 'Discovery Nodes'
@@ -137,6 +140,7 @@ const routeTitles = {
   [NODES_CONTENT_NODE]: SERVICES_CONTENT_NODE_TITLE,
   [NODES_CONTENT]: SERVICES_CONTENT_TITLE,
   [NODES_DISCOVERY_NODE]: SERVICES_DISCOVERY_PROVIDER_NODE_TITLE,
+  [NODES_VALIDATORS]: NODES_VALIDATORS_TITLE,
   [API]: API_TITLE,
   [API_LEADERBOARD]: API_LEADERBOARD_TITLE
 }


### PR DESCRIPTION
### Description

Completes the nodes -> view more workflow to show a unified list of all validators instead of just a single node type.

Existing dedicated content and dp node pages are preserved for backwards compatibility.

### How Has This Been Tested?

Verified correct behavior when clicking on "view all nodes" from nodes top-level page.

<img width="851" height="650" alt="image" src="https://github.com/user-attachments/assets/cc7dd44b-e471-4b3c-97b0-52963f891338" />

