### PR TITLE
[PE-6978] Fix scroll top issue

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -244,7 +244,7 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         onScroll={throttledScrollHandler}
         className={cn(styles.root, classNameProp)}
         resetKey={chatId}
-        updateKey={messageListHeight}
+        updateKey={chatMessages}
         stickToBottom
         scrollBottomThreshold={SCROLL_BOTTOM_THRESHOLD}
         {...other}


### PR DESCRIPTION
### Description


Prevent chat from jumping to the top when there are no unfurls by scoping StickyScrollList updates to message changes only.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Opened DMs with and without unfurlable links; sent messages; verified the view remains at the bottom without jitter.
