### PR TITLE
[PE-6984] Hide artist coin badge on coin explore

### DIFF
--- a/packages/mobile/src/components/user-badges/UserBadges.tsx
+++ b/packages/mobile/src/components/user-badges/UserBadges.tsx
@@ -16,10 +16,11 @@ type UserBadgesProps = {
   userId: ID
   badgeSize?: IconSize
   mint?: string
+  hideArtistCoinBadge?: boolean
 }
 
 export const UserBadges = (props: UserBadgesProps) => {
-  const { userId, badgeSize = 's', mint } = props
+  const { userId, badgeSize = 's', mint, hideArtistCoinBadge } = props
   const { isEnabled: isArtistCoinEnabled } = useFeatureFlag(
     FeatureFlags.ARTIST_COINS
   )
@@ -44,7 +45,8 @@ export const UserBadges = (props: UserBadgesProps) => {
   const shouldShowArtistCoinBadge =
     isArtistCoinEnabled &&
     !!displayMint &&
-    displayMint !== env.WAUDIO_MINT_ADDRESS
+    displayMint !== env.WAUDIO_MINT_ADDRESS &&
+    !hideArtistCoinBadge
 
   return (
     <Flex row gap='xs' alignItems='center'>

--- a/packages/mobile/src/components/user-link/UserLink.tsx
+++ b/packages/mobile/src/components/user-link/UserLink.tsx
@@ -24,6 +24,7 @@ type UserLinkProps = Omit<TextLinkProps<ParamList>, 'to' | 'children'> & {
   badgeSize?: IconSize
   textLinkStyle?: StyleProp<TextStyle>
   disabled?: boolean
+  hideArtistCoinBadge?: boolean
 }
 
 export const UserLink = (props: UserLinkProps) => {
@@ -33,6 +34,7 @@ export const UserLink = (props: UserLinkProps) => {
     style,
     textLinkStyle,
     disabled,
+    hideArtistCoinBadge,
     ...other
   } = props
   const { data: userName } = useUser(userId, {
@@ -79,7 +81,11 @@ export const UserLink = (props: UserLinkProps) => {
         >
           {userName}
         </TextLink>
-        <UserBadges userId={userId} badgeSize={badgeSize} />
+        <UserBadges
+          userId={userId}
+          badgeSize={badgeSize}
+          hideArtistCoinBadge={hideArtistCoinBadge}
+        />
       </AnimatedFlex>
     </Pressable>
   )

--- a/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
+++ b/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
@@ -55,7 +55,12 @@ const CoinRow = ({ coin, onPress }: CoinRowProps) => {
             </Text>
           </Flex>
 
-          <UserLink userId={ownerId} size='xs' badgeSize='2xs' />
+          <UserLink
+            userId={ownerId}
+            size='xs'
+            badgeSize='2xs'
+            hideArtistCoinBadge
+          />
         </Flex>
       </Flex>
     </TouchableOpacity>

--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -65,7 +65,7 @@ export const UserLink = (props: UserLinkProps) => {
         display: 'inline-flex',
         verticalAlign: 'middle'
       }}
-      hideArtistCoinBadge
+      hideArtistCoinBadge={hideArtistCoinBadge}
     />
   )
 

--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -24,6 +24,7 @@ type UserLinkProps = Omit<TextLinkProps, 'to'> & {
   noOverflow?: boolean
   center?: boolean
   fullWidth?: boolean
+  hideArtistCoinBadge?: boolean
 }
 
 export const UserLink = (props: UserLinkProps) => {
@@ -38,6 +39,7 @@ export const UserLink = (props: UserLinkProps) => {
     noOverflow,
     center,
     fullWidth,
+    hideArtistCoinBadge,
     ...other
   } = props
   const { spacing } = useTheme()
@@ -63,6 +65,7 @@ export const UserLink = (props: UserLinkProps) => {
         display: 'inline-flex',
         verticalAlign: 'middle'
       }}
+      hideArtistCoinBadge
     />
   )
 

--- a/packages/web/src/components/user-badges/UserBadges.tsx
+++ b/packages/web/src/components/user-badges/UserBadges.tsx
@@ -67,6 +67,9 @@ type UserBadgesProps = {
   // Optional mint address for displaying specific artist coin
   // If provided, shows the artist coin badge for that token
   mint?: string
+
+  // Optional flag to hide the artist coin badge
+  hideArtistCoinBadge?: boolean
 }
 
 /**
@@ -81,7 +84,8 @@ const UserBadges = ({
   transformOrigin,
   isVerifiedOverride,
   overrideTier,
-  mint
+  mint,
+  hideArtistCoinBadge = false
 }: UserBadgesProps) => {
   const { tier: currentTier, isVerified } = useTierAndVerifiedForUser(userId)
   const { isEnabled: isArtistCoinEnabled } = useFeatureFlag(
@@ -170,6 +174,7 @@ const UserBadges = ({
   }, [tier, userId, anchorOrigin, transformOrigin, size])
 
   const shouldShowArtistCoinBadge =
+    !hideArtistCoinBadge &&
     isArtistCoinEnabled &&
     !!displayMint &&
     displayMint !== env.WAUDIO_MINT_ADDRESS

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
@@ -120,6 +120,7 @@ const renderTokenNameCell = (cellInfo: CoinCell) => {
             badgeSize='xs'
             ellipses
             fullWidth
+            hideArtistCoinBadge
           />
         ) : (
           <Skeleton h='24px' w='100px' />

--- a/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
@@ -121,6 +121,7 @@ const renderTokenNameCell = (cellInfo: CoinCell) => {
             ellipses
             fullWidth
             hideArtistCoinBadge
+            popover
           />
         ) : (
           <Skeleton h='24px' w='100px' />


### PR DESCRIPTION
### Description
- hide artist coin badge in artist coin table bc redundant
- enable artist popover

### How Has This Been Tested?


<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-26 at 15 27 00" src="https://github.com/user-attachments/assets/05cbc5fe-068e-442d-9576-6906d653d64b" />
<img width="951" height="534" alt="Screenshot 2025-09-26 at 3 34 32 PM" src="https://github.com/user-attachments/assets/70ea939f-b64e-4ce7-a5c4-d1b4d97839a3" />
