### PR TITLE
[PROTO-2031] Consolildate node types on dashboard user page

### DIFF
--- a/packages/protocol-dashboard/src/components/InfoTooltip/InfoTooltips.tsx
+++ b/packages/protocol-dashboard/src/components/InfoTooltip/InfoTooltips.tsx
@@ -41,6 +41,9 @@ const messages = {
   topContributorsTooltipTitle: 'Who are Top Contributors?',
   topContributorsTooltipBody:
     "'Top Contributors' is a ranked list of wallet addresses based on their Voting Weight, which reflects the amount of $AUDIO tokens they have staked or delegated.",
+  nodesTooltipTitle: 'What are Validator Nodes?',
+  nodesTooltipBody:
+    'Validator Nodes are vital for storing and maintaining the availability of all of the media on the Audius network as well as validating all transactions that happen on the network.',
   discoveryNodesTooltipTitle: 'What are Discovery Nodes?',
   discoveryNodesTooltipBody:
     'Discovery Nodes are services in the Audius network responsible for indexing metadata and making data available for queries. They store and update information such as user, track, and playlist details, along with social features, facilitating efficient data access for users.',
@@ -229,6 +232,17 @@ export const TopContributorsInfoTooltip = ({
       size={size}
       title={messages.topContributorsTooltipTitle}
       body={messages.topContributorsTooltipBody}
+    />
+  )
+}
+
+export const NodesInfoTooltip = ({ color, size }: AppliedInfoTooltipProps) => {
+  return (
+    <InfoTooltip
+      color={color}
+      size={size}
+      title={messages.nodesTooltipTitle}
+      body={messages.nodesTooltipBody}
     />
   )
 }

--- a/packages/protocol-dashboard/src/components/ManageService/ManageService.tsx
+++ b/packages/protocol-dashboard/src/components/ManageService/ManageService.tsx
@@ -25,12 +25,11 @@ import { InfoBox } from 'components/InfoBox/InfoBox'
 import {
   AggregateContributionInfoTooltip,
   AppliedInfoTooltipProps,
-  ContentNodesInfoTooltip,
   DelegatedAudioInfoTooltip,
   DelegatorsInfoTooltip,
-  DiscoveryNodesInfoTooltip,
   EstimatedAudioRewardsPoolInfoTooltip,
   NodeOperatorInfoTooltip,
+  NodesInfoTooltip,
   NodeServiceFeeInfoTooltip,
   OperatorStakeInfoTooltip
 } from 'components/InfoTooltip/InfoTooltips'
@@ -78,6 +77,8 @@ const messages = {
   contentNodesSingular: 'Content Node',
   discoveryNodes: 'Discovery Nodes',
   discoveryNodesSingular: 'Discovery Node',
+  nodes: 'Nodes',
+  nodesSingular: 'Node',
   delegators: 'Delegators',
   delegatorsSingular: 'Delegator',
   change: 'Change',
@@ -452,10 +453,10 @@ const ManageService = (props: ManageServiceProps) => {
 
   const isTotalStakeInBounds =
     (serviceUser as Operator)?.serviceProvider?.validBounds ?? false
-  const numDiscoveryNodes =
-    isServiceProvider && (serviceUser as Operator).discoveryProviders.length
-  const numContentNodes =
-    isServiceProvider && (serviceUser as Operator).contentNodes.length
+  const numNodes =
+    isServiceProvider &&
+    (serviceUser as Operator).discoveryProviders.length +
+      (serviceUser as Operator).contentNodes.length
   const numDelegators = isServiceProvider
     ? (serviceUser as Operator).delegators.length
     : 0
@@ -473,10 +474,7 @@ const ManageService = (props: ManageServiceProps) => {
     pendingClaim.status === Status.Success &&
     userDelegatesStatus === Status.Success
   const showDelegate =
-    isDoneLoading &&
-    (numDiscoveryNodes ?? 0) + (numContentNodes ?? 0) > 0 &&
-    !isOwner &&
-    delegates.isZero()
+    isDoneLoading && (numNodes ?? 0) > 0 && !isOwner && delegates.isZero()
   const showUndelegate =
     isDoneLoading &&
     !isOwner &&
@@ -555,28 +553,12 @@ const ManageService = (props: ManageServiceProps) => {
       </Flex>
       <Flex pv='l' ph='xl' gap='2xl' alignItems='stretch' wrap='wrap'>
         <Flex direction='column' alignItems='stretch' gap='s'>
-          {numContentNodes ? (
+          {numNodes ? (
             <ServiceBigStat
-              data={numContentNodes}
-              label={
-                numContentNodes === 1
-                  ? messages.contentNodesSingular
-                  : messages.contentNodes
-              }
-              tooltipComponent={ContentNodesInfoTooltip}
-              onClick={() => props.onClickContentTable?.()}
-            />
-          ) : null}
-          {numDiscoveryNodes ? (
-            <ServiceBigStat
-              data={numDiscoveryNodes}
-              label={
-                numDiscoveryNodes === 1
-                  ? messages.discoveryNodesSingular
-                  : messages.discoveryNodes
-              }
-              tooltipComponent={DiscoveryNodesInfoTooltip}
-              onClick={() => props.onClickDiscoveryTable?.()}
+              data={numNodes}
+              label={numNodes === 1 ? messages.nodesSingular : messages.nodes}
+              tooltipComponent={NodesInfoTooltip}
+              onClick={() => props.onClickNodesTable?.()}
             />
           ) : null}
           {numDelegators ? (

--- a/packages/protocol-dashboard/src/containers/User/User.tsx
+++ b/packages/protocol-dashboard/src/containers/User/User.tsx
@@ -1,14 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 import { Flex, IconUser } from '@audius/harmony'
-import clsx from 'clsx'
 import { matchPath, useLocation, useParams } from 'react-router-dom'
 
 import { ConnectAudiusProfileCard } from 'components/ConnectAudiusProfileCard/ConnectAudiusProfileCard'
-import ContentTable from 'components/ContentTable'
-import DiscoveryTable from 'components/DiscoveryTable'
 import { ManageAccountCard } from 'components/ManageAccountCard/ManageAccountCard'
 import ManageService from 'components/ManageService'
+import NodeTable from 'components/NodeTable'
 import Page from 'components/Page'
 import ProfileInfoCard from 'components/ProfileInfoCard/ProfileInfoCard'
 import Timeline from 'components/Timeline'
@@ -34,15 +32,15 @@ const messages = {
 const UserPage = () => {
   const { wallet } = useParams<{ wallet: string }>()
   const location = useLocation()
-  const discoveryTableRef = useRef(null)
+  const nodeTableRef = useRef(null)
   const scrollToNodeTables = useCallback(() => {
     window.scrollTo({
-      top: discoveryTableRef.current?.offsetTop,
+      top: nodeTableRef.current?.offsetTop,
       behavior: 'smooth'
     })
   }, [])
 
-  const handleClickNodes = discoveryTableRef?.current
+  const handleClickNodes = nodeTableRef?.current
     ? scrollToNodeTables
     : undefined
 
@@ -56,11 +54,6 @@ const UserPage = () => {
   const user = userAccount as User | Operator
 
   const isServiceProvider = user && 'serviceProvider' in user
-
-  const hasDiscoveryProviders =
-    isServiceProvider && (user as Operator).discoveryProviders.length > 0
-  const hasContentNodes =
-    isServiceProvider && (user as Operator).contentNodes.length > 0
 
   const replaceRoute = useReplaceRoute()
 
@@ -90,11 +83,7 @@ const UserPage = () => {
         />
         {isOwner ? <ConnectAudiusProfileCard /> : null}
         {isServiceProvider && (
-          <ManageService
-            wallet={wallet}
-            onClickDiscoveryTable={handleClickNodes}
-            onClickContentTable={handleClickNodes}
-          />
+          <ManageService wallet={wallet} onClickNodesTable={handleClickNodes} />
         )}
         {<ManageAccountCard wallet={wallet} />}
         {isOwner ? <TransactionStatus /> : null}
@@ -103,23 +92,8 @@ const UserPage = () => {
           wallet={user?.wallet}
           timelineType={isServiceProvider ? 'ServiceProvider' : 'Delegator'}
         />
-        <div className={styles.serviceContainer} ref={discoveryTableRef}>
-          {hasDiscoveryProviders && (
-            <DiscoveryTable
-              owner={user?.wallet}
-              className={clsx(styles.serviceTable, {
-                [styles.rightSpacing]: hasContentNodes
-              })}
-            />
-          )}
-          {hasContentNodes && (
-            <ContentTable
-              owner={user?.wallet}
-              className={clsx(styles.serviceTable, {
-                [styles.leftSpacing]: hasDiscoveryProviders
-              })}
-            />
-          )}
+        <div className={styles.serviceContainer} ref={nodeTableRef}>
+          <NodeTable owner={user?.wallet} className={styles.serviceTable} />
         </div>
       </Flex>
     </Page>


### PR DESCRIPTION
### Description

Combines content and discovery node counts and lists on the User page in the dashboard.

### How Has This Been Tested?

Visually confirmed component works, tooltip works, and clicking on the component takes you to the unified list of nodes at the bottom of the page.

<img width="837" height="357" alt="image" src="https://github.com/user-attachments/assets/cb59b100-99a4-4e5f-a9e3-8692b125f91d" />

<img width="313" height="213" alt="image" src="https://github.com/user-attachments/assets/f40a2c3a-a4b3-45d7-a0b3-fc16c1cc19c4" />

