### PR TITLE
[PE-6990] Update status bar style for coin explore screens

### DIFF
--- a/packages/mobile/src/hooks/useStatusBarStyle.ts
+++ b/packages/mobile/src/hooks/useStatusBarStyle.ts
@@ -1,0 +1,35 @@
+import { useCallback, useRef } from 'react'
+
+import { useFocusEffect } from '@react-navigation/native'
+import { StatusBar as RNStatusBar, NavigationBar } from 'react-native-bars'
+
+/**
+ * Hook to set status bar style when screen is focused
+ * @param barStyle - 'light-content' for dark backgrounds, 'dark-content' for light backgrounds
+ */
+export const useStatusBarStyle = (
+  barStyle: 'light-content' | 'dark-content'
+) => {
+  const statusBarEntryRef = useRef<any>(null)
+  const navigationBarEntryRef = useRef<any>(null)
+
+  useFocusEffect(
+    useCallback(() => {
+      // Set status bar style when screen is focused
+      statusBarEntryRef.current = RNStatusBar.pushStackEntry({ barStyle })
+      navigationBarEntryRef.current = NavigationBar.pushStackEntry({ barStyle })
+
+      // Cleanup: restore default when screen loses focus
+      return () => {
+        if (statusBarEntryRef.current) {
+          RNStatusBar.popStackEntry(statusBarEntryRef.current)
+          statusBarEntryRef.current = null
+        }
+        if (navigationBarEntryRef.current) {
+          NavigationBar.popStackEntry(navigationBarEntryRef.current)
+          navigationBarEntryRef.current = null
+        }
+      }
+    }, [barStyle])
+  )
+}

--- a/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
+++ b/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
@@ -28,6 +28,7 @@ import imageSearchHeaderBackground from 'app/assets/images/imageCoinsBackgroundI
 import { PlayBarChin } from 'app/components/core/PlayBarChin'
 import { UserLink } from 'app/components/user-link'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { useStatusBarStyle } from 'app/hooks/useStatusBarStyle'
 import { env } from 'app/services/env'
 
 import { GradientText, TokenIcon, Screen } from '../../components/core'
@@ -120,6 +121,9 @@ export const ArtistCoinsExploreScreen = () => {
   const [sortDirection, setSortDirection] = useState<GetCoinsSortDirectionEnum>(
     GetCoinsSortDirectionEnum.Desc
   )
+
+  // Set status bar to light content for dark header
+  useStatusBarStyle('light-content')
 
   // Debounce search value to avoid excessive API calls
   useDebounce(() => setDebouncedSearchValue(searchValue), 300, [searchValue])

--- a/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/SearchExploreScreen.tsx
@@ -16,6 +16,7 @@ import Animated, {
 import { useTheme } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
 import { useScrollToTop } from 'app/hooks/useScrollToTop'
+import { useStatusBarStyle } from 'app/hooks/useStatusBarStyle'
 
 import { SearchResults } from '../search-screen/search-results/SearchResults'
 import {
@@ -40,6 +41,9 @@ export const SCROLL_FACTOR = Platform.OS === 'ios' ? 1 : 3
 const SearchExploreContent = () => {
   const { spacing, motion } = useTheme()
   const { params } = useExploreRoute<'SearchExplore'>()
+
+  // Set status bar to light content for dark header
+  useStatusBarStyle('light-content')
 
   // Get state from context
   const [, setCategory] = useSearchCategory()


### PR DESCRIPTION
### Description

Before: 
<img width="452" height="242" alt="image" src="https://github.com/user-attachments/assets/1256829a-3df0-4e99-a08e-96c472c41db6" />

After:
<img width="452" height="242" alt="image" src="https://github.com/user-attachments/assets/bb11b388-f6c3-4cc1-a337-b2c94498b36f" />