### PR TITLE
[PE-6971] Swipe back on artist coin explore screen

### DIFF
--- a/packages/mobile/src/components/core/Screen/Screen.tsx
+++ b/packages/mobile/src/components/core/Screen/Screen.tsx
@@ -93,7 +93,6 @@ export const Screen = (props: ScreenProps) => {
       removeUndefined({
         header,
         headerShown: header ? true : undefined,
-        gestureEnabled: header ? false : undefined,
         headerLeft: topbarLeft === undefined ? undefined : () => topbarLeft,
         headerRight: topbarRight
           ? () => topbarRight


### PR DESCRIPTION
### Description

This feels a little scary, but it works for artist-coin-explore-screen at least

Oh on further research it has to do with this ticket: https://github.com/AudiusProject/audius-protocol/pull/12978 @faridsalau can you add some context?