### PR TITLE
[PE-7002] Add coin badges and gates to embed

### DIFF
--- a/packages/embed/src/components/collection/CollectionPlayerCard.jsx
+++ b/packages/embed/src/components/collection/CollectionPlayerCard.jsx
@@ -141,6 +141,8 @@ const CollectionPlayerCard = ({
               isVerified={collection.user.isVerified}
               title={collection.playlistName}
               titleUrl={permalink}
+              artistCoinLogo={collection.user.artist_coin_badge?.logo_uri}
+              balance={collection.user.totalBalance}
             />
             <div className={styles.scrubber}>
               <BedtimeScrubber

--- a/packages/embed/src/components/dog-ear/DogEar.jsx
+++ b/packages/embed/src/components/dog-ear/DogEar.jsx
@@ -1,4 +1,9 @@
-import { IconCart, IconSparkles, IconReceive } from '@audius/harmony'
+import {
+  IconCart,
+  IconSparkles,
+  IconReceive,
+  IconArtistCoin
+} from '@audius/harmony'
 import cn from 'classnames'
 
 import Background from '../../assets/img/dogEar.svg'
@@ -8,7 +13,8 @@ import styles from './DogEar.module.css'
 const VARIANT_TO_ICON = {
   purchase: IconCart,
   special: IconSparkles,
-  extras: IconReceive
+  extras: IconReceive,
+  coin: IconArtistCoin
 }
 
 export const DogEar = ({ size, variant }) => {
@@ -20,7 +26,8 @@ export const DogEar = ({ size, variant }) => {
           [styles.small]: size === 's',
           [styles.purchase]: variant === 'purchase',
           [styles.special]: variant === 'special',
-          [styles.extras]: variant === 'extras'
+          [styles.extras]: variant === 'extras',
+          [styles.coin]: variant === 'coin'
         })}
       />
       <Icon

--- a/packages/embed/src/components/dog-ear/DogEar.module.css
+++ b/packages/embed/src/components/dog-ear/DogEar.module.css
@@ -19,6 +19,10 @@
   fill: var(--harmony-light-green);
 }
 
+.dogEar.coin path {
+  fill: url(#coinGradient);
+}
+
 .dogEar.small {
   width: 50px;
   height: 50px;

--- a/packages/embed/src/components/titles/Titles.jsx
+++ b/packages/embed/src/components/titles/Titles.jsx
@@ -1,9 +1,57 @@
-import IconVerified from '../../assets/img/iconVerified.svg'
+import { AUDIO } from '@audius/fixed-decimal'
+import {
+  Flex,
+  Artwork,
+  IconVerified,
+  IconTokenBronze,
+  IconTokenSilver,
+  IconTokenGold,
+  IconTokenPlatinum
+} from '@audius/harmony'
+
 import { getCopyableLink } from '../../util/shareUtil'
 
 import styles from './Titles.module.css'
 
-const Titles = ({ title, handle, artistName, titleUrl, isVerified }) => {
+const badgeTiers = [
+  {
+    tier: 'platinum',
+    icon: IconTokenPlatinum,
+    amount: AUDIO('10000').value
+  },
+  {
+    tier: 'gold',
+    icon: IconTokenGold,
+    amount: AUDIO('1000').value
+  },
+  {
+    tier: 'silver',
+    icon: IconTokenSilver,
+    amount: AUDIO('100').value
+  },
+  {
+    tier: 'bronze',
+    icon: IconTokenBronze,
+    amount: AUDIO('10').value
+  }
+]
+
+const getTierIcon = (balance) => {
+  const balanceWei = AUDIO(balance).value
+  const index = badgeTiers.findIndex((t) => t.amount <= balanceWei)
+  const tier = index === -1 ? null : badgeTiers[index]
+  return tier ? tier.icon : null
+}
+
+const Titles = ({
+  title,
+  handle,
+  artistName,
+  titleUrl,
+  isVerified,
+  artistCoinLogo,
+  balance
+}) => {
   const onClickTitle = () => {
     window.open(getCopyableLink(titleUrl), '_blank')
   }
@@ -19,7 +67,17 @@ const Titles = ({ title, handle, artistName, titleUrl, isVerified }) => {
       </h1>
       <h2 className={styles.artistName} onClick={onClickArtist}>
         {artistName}
-        {isVerified && <IconVerified />}
+        <Flex alignItems='center' gap='xs'>
+          {isVerified && <IconVerified size='s' />}
+          {balance &&
+            (() => {
+              const Icon = getTierIcon(balance)
+              return Icon ? <Icon height={17} width={17} /> : null
+            })()}
+          {artistCoinLogo && (
+            <Artwork src={artistCoinLogo} hex h={18} w={18} borderWidth={0} />
+          )}
+        </Flex>
       </h2>
     </div>
   )

--- a/packages/embed/src/components/titles/Titles.module.css
+++ b/packages/embed/src/components/titles/Titles.module.css
@@ -25,6 +25,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   display: flex;
+  gap: 8px;
   align-items: center;
   overflow: hidden;
   margin: 0;
@@ -37,11 +38,9 @@
 .artistName svg {
   width: 14px;
   height: 14px;
-  margin-left: 8px;
   position: relative;
   top: -1px;
 }
-
-.artistName path {
+.artistName path[fill="#000"] {
   fill: #ffffff;
 }

--- a/packages/embed/src/components/track/TrackPlayerCard.jsx
+++ b/packages/embed/src/components/track/TrackPlayerCard.jsx
@@ -35,7 +35,9 @@ const TrackPlayerCard = ({
   streamConditions,
   hasPremiumExtras,
   audioPlayer,
-  isRemixContest
+  isRemixContest,
+  artistCoinLogo,
+  balance
 }) => {
   const mobileWebTwitter = isMobileWebTwitter(isTwitter)
   const getBottomWrapperStyle = () =>
@@ -67,6 +69,7 @@ const TrackPlayerCard = ({
     setArtworkWrapperStyle(newStyle)
   }, [height, width])
   const isGated = !!streamConditions
+  const isTokenGated = !!streamConditions?.tokenGate
   const isPurchaseable =
     streamConditions && instanceOfPurchaseGate(streamConditions)
 
@@ -79,7 +82,15 @@ const TrackPlayerCard = ({
       {isGated || hasPremiumExtras ? (
         <DogEar
           size='s'
-          variant={isPurchaseable ? 'purchase' : isGated ? 'special' : 'extras'}
+          variant={
+            isPurchaseable
+              ? 'purchase'
+              : isTokenGated
+                ? 'coin'
+                : isGated
+                  ? 'special'
+                  : 'extras'
+          }
         />
       ) : null}
       <div className={styles.paddingContainer}>
@@ -133,6 +144,8 @@ const TrackPlayerCard = ({
                 isVerified={isVerified}
                 title={title}
                 titleUrl={trackURL}
+                artistCoinLogo={artistCoinLogo}
+                balance={balance}
               />
             </div>
             <div className={styles.shareWrapper}>

--- a/packages/embed/src/components/track/TrackPlayerCompact.jsx
+++ b/packages/embed/src/components/track/TrackPlayerCompact.jsx
@@ -31,9 +31,12 @@ const TrackPlayerCompact = ({
   streamConditions,
   hasPremiumExtras,
   audioPlayer,
-  isRemixContest
+  isRemixContest,
+  artistCoinLogo,
+  balance
 }) => {
   const isGated = !!streamConditions
+  const isTokenGated = !!streamConditions?.tokenGate
   const isPurchaseable =
     streamConditions && instanceOfPurchaseGate(streamConditions)
 
@@ -62,7 +65,13 @@ const TrackPlayerCompact = ({
           <DogEar
             size='s'
             variant={
-              isPurchaseable ? 'purchase' : isGated ? 'special' : 'extras'
+              isPurchaseable
+                ? 'purchase'
+                : isTokenGated
+                  ? 'coin'
+                  : isGated
+                    ? 'special'
+                    : 'extras'
             }
           />
         ) : null}
@@ -111,6 +120,8 @@ const TrackPlayerCompact = ({
               handle={handle}
               isVerified={isVerified}
               titleUrl={trackURL}
+              artistCoinLogo={artistCoinLogo}
+              balance={balance}
             />
           </div>
           <div className={styles.shareButtonHolder}>

--- a/packages/embed/src/components/track/TrackPlayerContainer.jsx
+++ b/packages/embed/src/components/track/TrackPlayerContainer.jsx
@@ -162,7 +162,9 @@ const TrackPlayerContainer = ({
     audioPlayer,
     isRemixContest: track?.events?.some(
       (event) => event.eventType === 'remix_contest'
-    )
+    ),
+    artistCoinLogo: track?.user?.artistCoinBadge?.logoUri,
+    balance: track?.user?.totalBalance
   }
 
   let trackPlayer


### PR DESCRIPTION
### Description

- Coin gated dog ear
- Coin member badges
- Update verified to new logo
- Audio badges

<img width="760" height="860" alt="image" src="https://github.com/user-attachments/assets/8d997f07-452a-46aa-9372-78530cbeb7d3" />
<img width="749" height="854" alt="image" src="https://github.com/user-attachments/assets/a7aabcdb-d250-4b00-9314-a16f8eac37b1" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
