### PR TITLE
Fix rounding in buy/sell flow to match cash wallet

### DIFF
--- a/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenAmountFormatting.ts
@@ -56,7 +56,12 @@ export const useTokenAmountFormatting = ({
       const maxFractionDigits =
         absAmount >= 0.1 ? 2 : getTokenDecimalPlaces(availableBalance)
 
-      return availableBalance.toLocaleString('en-US', {
+      // Use FixedDecimal truncation for consistency with cash wallet
+      // Create FixedDecimal with the token's decimal precision to avoid rounding during construction
+      const fd = new FixedDecimal(availableBalance, decimals)
+      const truncatedValue = Number(fd.trunc(maxFractionDigits).toString())
+
+      return truncatedValue.toLocaleString('en-US', {
         minimumFractionDigits: 2,
         maximumFractionDigits: maxFractionDigits
       })


### PR DESCRIPTION
### Description
Cash wallet component (shows the users USDC wallet balance) was truncating but buy/sell flow was flooring. Updated to be consistent and show same number across the board

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
