### PR TITLE
[PROTO-2032] Remove deprecated chain health checks in dashboard

### DIFF
--- a/packages/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
+++ b/packages/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
@@ -209,14 +209,6 @@ const NodeOverview = ({
             }
           />
         )}
-        {health?.chainError && (
-          <ServiceDetail
-            label={messages.chain}
-            value={
-              <TextWithIcon icon={<IconWarning />} text={health.chainError} />
-            }
-          />
-        )}
         {!health?.startedAt && (
           <ServiceDetail
             label={messages.uptime}

--- a/packages/protocol-dashboard/src/hooks/useNodeHealth.ts
+++ b/packages/protocol-dashboard/src/hooks/useNodeHealth.ts
@@ -43,10 +43,6 @@ const useNodeHealth = (endpoint: string, serviceType: ServiceType) => {
   if (serviceType === 'discovery-node') {
     // ----------Discovery health----------
 
-    let chainError
-    if (!health?.chain_health) chainError = 'Missing health info'
-    if (!data?.portHealth) chainError = "Can't reach port 30300"
-
     res = {
       diskGbUsed: health?.filesystem_used
         ? bytesToGb(health.filesystem_used)
@@ -61,7 +57,6 @@ const useNodeHealth = (endpoint: string, serviceType: ServiceType) => {
       version: health?.version,
       operatorWallet: '', // not exposed in Discovery's health check
       delegateOwnerWallet: data?.signer,
-      chainError,
       startedAt: data?.comms?.booted ? new Date(data?.comms.booted) : undefined,
       otherErrors: health?.errors?.length ? health.errors : undefined
     }


### PR DESCRIPTION
### Description

These health checks were for acdc

### How Has This Been Tested?

Ran locally against prod data and verified port warning no longer appears.