### PR TITLE
Empty DN allowlist to speed up libs init in dashboard

### DIFF
--- a/packages/protocol-dashboard/src/services/Audius/discoveryNodeSelector.ts
+++ b/packages/protocol-dashboard/src/services/Audius/discoveryNodeSelector.ts
@@ -9,15 +9,7 @@ import {
 const env = import.meta.env.VITE_ENVIRONMENT
 
 export const discoveryNodeAllowlist =
-  env === 'production'
-    ? new Set([
-        'https://discoveryprovider.audius.co',
-        'https://discoveryprovider2.audius.co',
-        'https://discoveryprovider3.audius.co',
-        'https://audius-dn1.tikilabs.com',
-        'https://dn1.monophonic.digital'
-      ])
-    : undefined
+  env === 'production' ? new Set([]) : undefined
 
 // Initialize a DN selector with allow list to be shared by SDK/libs
 const servicesConfig =


### PR DESCRIPTION
### Description
The health checks on the unregistered/down nodes have to time out before selection proceeds. Removing them all makes it fail faster.