### PR TITLE
Limit connected wallets to one account

### DIFF
--- a/packages/common/src/messages/coinDetailsMessages.ts
+++ b/packages/common/src/messages/coinDetailsMessages.ts
@@ -56,6 +56,8 @@ export const coinDetailsMessages = {
     options: 'Options',
     newWalletConnected: 'New Wallet Successfully Connected!',
     error: 'Something went wrong. Please try again.',
+    walletConnectedElsewhere:
+      'Wallet already connected to another Audius account.',
     walletAlreadyAdded: 'No new wallets selected to connect.',
     builtIn: 'Built-In Wallet',
     toasts: {

--- a/packages/common/src/messages/walletMessages.ts
+++ b/packages/common/src/messages/walletMessages.ts
@@ -117,6 +117,8 @@ export const walletMessages = {
     options: 'Options',
     newWalletConnected: 'New Wallet Successfully Connected!',
     error: 'Something went wrong. Please try again.',
+    walletConnectedElsewhere:
+      'Wallet already connected to another Audius account.',
     walletAlreadyAdded: 'No new wallets selected to connect.',
     linkedWallet: (index: number) => `Linked Wallet ${index + 1}`,
     linkWallet:

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -467,6 +467,22 @@ def add_associated_wallet(
                 existing_wallet = wallet
                 break
 
+        # Check if wallet already exists for another user
+        wallet_in_use = (
+            session.query(AssociatedWallet)
+            .filter(
+                AssociatedWallet.wallet == wallet_address,
+                AssociatedWallet.chain == chain,
+                AssociatedWallet.is_current == True,
+                AssociatedWallet.is_delete == False,
+            )
+            .first()
+        )
+        if wallet_in_use and wallet_in_use.user_id != user_id:
+            raise IndexingValidationError(
+                f"Associated wallet {wallet_address} already associated with another user",
+            )
+
         if not existing_wallet:
             # Create new wallet association only if it doesn't exist
             associated_wallet_entry = AssociatedWallet(

--- a/packages/web/src/pages/asset-detail-page/components/ExternalWallets.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/ExternalWallets.tsx
@@ -190,7 +190,11 @@ export const ExternalWallets = ({ mint }: ExternalWalletsProps) => {
   const handleAddWalletError = useCallback(
     async (e: unknown) => {
       if (e instanceof AlreadyAssociatedError) {
-        toast(messages.walletAlreadyAdded)
+        if (e.userId) {
+          toast(messages.walletConnectedElsewhere)
+        } else {
+          toast(messages.walletAlreadyAdded)
+        }
       } else {
         toast(messages.error)
       }

--- a/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
+++ b/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
@@ -47,6 +47,8 @@ const messages = {
   remove: 'Remove Wallet',
   ignore: 'Nevermind',
   error: 'Something went wrong. Please try again.',
+  walletConnectedElsewhere:
+    'Wallet already connected to another Audius account.',
   walletAlreadyAdded: 'No new wallets selected to connect.',
   goToDesktop:
     'To connect external wallets to your account, visit audius.co from a desktop browser.'
@@ -106,7 +108,11 @@ export const ConnectedWalletsModal = () => {
   const handleAddWalletError = useCallback(
     async (e: unknown) => {
       if (e instanceof AlreadyAssociatedError) {
-        toast(messages.walletAlreadyAdded)
+        if (e.userId) {
+          toast(messages.walletConnectedElsewhere)
+        } else {
+          toast(messages.walletAlreadyAdded)
+        }
       } else {
         toast(messages.error)
         await reportToSentry({

--- a/packages/web/src/pages/wallet-page/components/LinkedWallets.tsx
+++ b/packages/web/src/pages/wallet-page/components/LinkedWallets.tsx
@@ -200,7 +200,11 @@ const WalletEmptyState = () => {
   const handleAddWalletError = useCallback(
     async (e: unknown) => {
       if (e instanceof AlreadyAssociatedError) {
-        toast(walletMessages.linkedWallets.walletAlreadyAdded)
+        if (e.userId) {
+          toast(walletMessages.linkedWallets.walletConnectedElsewhere)
+        } else {
+          toast(walletMessages.linkedWallets.walletAlreadyAdded)
+        }
       } else {
         toast(walletMessages.linkedWallets.error)
       }
@@ -246,7 +250,11 @@ export const LinkedWallets = () => {
   const handleAddWalletError = useCallback(
     async (e: unknown) => {
       if (e instanceof AlreadyAssociatedError) {
-        toast(walletMessages.linkedWallets.walletAlreadyAdded)
+        if (e.userId) {
+          toast(walletMessages.linkedWallets.walletConnectedElsewhere)
+        } else {
+          toast(walletMessages.linkedWallets.walletAlreadyAdded)
+        }
       } else {
         toast(walletMessages.linkedWallets.error)
       }


### PR DESCRIPTION
- Adds check in indexing to mark transactions that add a wallet address to another account as invalid
- Adds a check on the frontend to fail early when trying to add a wallet that is already linked to another Audius account
- Fixes bug where the wallet page had two instances of the hook running at the same time causing two toasts when connecting external wallets