### PR TITLE
allow /indexing routes to hit DN

### DIFF
--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -153,7 +153,7 @@ http {
         }
 
         # allow DN to be health-checked for now
-        location ~ ^/(health_check|audio_transactions_check|tips_check|purchases_check|usdc_transactions_check)$ {
+        location ~ ^/(health_check|indexing|audio_transactions_check|tips_check|purchases_check|usdc_transactions_check)$ {
             resolver 127.0.0.11 valid=30s;
             set $upstream server:5000;
             proxy_pass http://$upstream;


### PR DESCRIPTION
### Description
Breaks ability for indexer to confirm indexing status with other nodes. We still need this at the moment until we yank that out.

