### PR TITLE
raise validation error for failed sig parsing in associated wallets

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -564,8 +564,15 @@ def validate_signature(
     chain: str, web3, user_id: int, associated_wallet: str, signature: str
 ):
     if chain == "eth":
-        signed_wallet = recover_user_id_hash(web3, user_id, signature)
-        return signed_wallet == associated_wallet
+        try:
+            signed_wallet = recover_user_id_hash(web3, user_id, signature)
+            return signed_wallet == associated_wallet
+        except Exception as e:
+            logger.error(
+                f"index.py | users.py | Verifying ETH validation signature for user_id {user_id} {e}",
+                exc_info=True,
+            )
+            return False
     if chain == "sol":
         try:
             message = f"AudiusUserID:{user_id}"


### PR DESCRIPTION
### Description
We try/catch the SOL parsing logic, but not the ETH one.
I'm not sure why the sigs are insane, but this at least keeps us from halting on bad ones.

### How Has This Been Tested?
hot hot hotfix
