### PR TITLE
Fix e2e tests 404ing on relay

### DIFF
--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -20,16 +20,6 @@ server {
     listen      80;
     server_name audius-protocol-discovery-provider-1;
 
-    # default resolve DN to new API
-    location / {
-        # use localhost resolver to allow running api outside of docker
-        resolver 127.0.0.1 valid=30s;
-        set $upstream audius-protocol-api:1323;
-        proxy_pass http://$upstream;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
     location /health_check {
         resolver 127.0.0.11 valid=30s;
         set $upstream audius-protocol-discovery-provider-1:5000;
@@ -87,6 +77,16 @@ server {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://audiusd-1:26659/core$1$is_args$args;
         proxy_set_header Host $http_host;
+    }
+
+    # default resolve DN to new API
+    location / {
+        # use localhost resolver to allow running api outside of docker
+        resolver 127.0.0.1 valid=30s;
+        set $upstream audius-protocol-api:1323;
+        proxy_pass http://$upstream;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }
 
@@ -333,6 +333,27 @@ server {
     location / {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://audius-protocol-api:1323;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ ^/relay(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://audius-protocol-relay-1:6001/relay$1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ ^/archive(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://archiver:6004/archive$1$is_args$args;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ ^/attestation(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://anti-abuse:6003$request_uri;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -28,30 +28,9 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    location ~ ^/relay(/.*)?$ {
-        resolver 127.0.0.11 valid=30s;
-        proxy_pass http://audius-protocol-relay-1:6001/relay$1;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location ~ ^/archive(/.*)?$ {
-        resolver 127.0.0.11 valid=30s;
-        proxy_pass http://archiver:6004/archive$1$is_args$args;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
     location ~ ^/solana(/.*)?$ {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://audius-protocol-solana-relay-1:6002/solana$1;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location ~ ^/attestation(/.*)?$ {
-        resolver 127.0.0.11 valid=30s;
-        proxy_pass http://anti-abuse:6003$request_uri;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }


### PR DESCRIPTION
### Description
We use a load balancer in deployed environments to direct this traffic to the relay container. Need to match that behavior in local stack.

### How Has This Been Tested?
In the future, with the e2e tests. Timecop-style.
