### PR TITLE
[PE-7046] Use name for coin page header title

### DIFF
--- a/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
+++ b/packages/web/src/pages/asset-detail-page/AssetDetailPage.tsx
@@ -104,7 +104,7 @@ export const AssetDetailPage = () => {
   ) : (
     <DesktopAssetDetailPageContent
       mint={coin?.mint ?? ''}
-      title={coin?.ticker ? `$${coin.ticker}` : ''}
+      title={coin?.name ?? ''}
       ticker={coin?.ticker ?? ''}
       isOwner={isOwner}
     />


### PR DESCRIPTION
### Description

Per ticket
<img width="654" height="429" alt="image" src="https://github.com/user-attachments/assets/fa347d38-665b-44e6-8260-534621aba866" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
