### PR TITLE
[PE-7089] Add user generated text to info section

### DIFF
--- a/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
+++ b/packages/web/src/pages/asset-detail-page/components/AssetInfoSection.tsx
@@ -518,7 +518,6 @@ export const AssetInfoSection = ({ mint }: AssetInfoSectionProps) => {
                   variant='body'
                   size='m'
                   color='subdued'
-                  linkSource='profile page'
                 >
                   {paragraph}
                 </UserGeneratedText>


### PR DESCRIPTION
### Description
<img width="663" height="355" alt="image" src="https://github.com/user-attachments/assets/d8f7e9f0-fc95-4049-b7ce-10b43039f585" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
