### PR TITLE
[PE-7125] Fix missing audio balance

### DIFF
--- a/packages/common/src/adapters/coin.ts
+++ b/packages/common/src/adapters/coin.ts
@@ -5,7 +5,6 @@ import {
 } from '@audius/sdk'
 
 import { ID } from '~/models'
-import { Env } from '~/services/env'
 import { removeNullable } from '~/utils/typeUtils'
 
 // Define a cleaner coin model without UI dependencies


### PR DESCRIPTION
### Description

Fixes issue where AUDIO balance showed 0 in coin overview, and didn't show at all in coin details:

Before:
<img width="816" height="470" alt="image" src="https://github.com/user-attachments/assets/ba459e70-0527-410a-8885-7db30a9f9457" />

After:
<img width="816" height="470" alt="image" src="https://github.com/user-attachments/assets/3278321d-88d2-4a9b-94ce-ada627b78ea5" />
