### PR TITLE
Fix artist coins table loading state

### DIFF
--- a/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   Flex,
   IconSearch,
-  LoadingSpinner,
   Paper,
   Skeleton,
   spacing,


### PR DESCRIPTION
### Description
Previously the loading spinner would take up the whole table. Now it shows the headers while loading.

### How Has This Been Tested?


https://github.com/user-attachments/assets/d68bd71f-3a46-4e7d-aedb-63de0808e058

