### PR TITLE
[PE-7111] Fix mobile artist coin explore scrolling

### DIFF
--- a/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
+++ b/packages/mobile/src/screens/artist-coins-explore-screen/ArtistCoinsExploreScreen.tsx
@@ -225,7 +225,13 @@ export const ArtistCoinsExploreScreen = () => {
       )}
     >
       <VirtualizedScrollView>
-        <Flex mh='l' mv='xl' border='default' borderRadius='m' flex={1}>
+        <Flex
+          mh='l'
+          mv='xl'
+          border='default'
+          borderRadius='m'
+          backgroundColor='white'
+        >
           <Flex
             row
             ph='l'


### PR DESCRIPTION
### Description
`VirtualizedScrollView` makes it so that you can scroll outside the boundaries of the list, and the screen header doesn't disappear.

### How Has This Been Tested?


https://github.com/user-attachments/assets/9c3cbd03-dd89-4671-a952-0d1a612c5fcb

