### PR TITLE
[PE-7122] Remove icons from mobile coin overflow menu

### DIFF
--- a/packages/mobile/src/screens/coin-details-screen/components/AssetInsightsOverflowMenu.tsx
+++ b/packages/mobile/src/screens/coin-details-screen/components/AssetInsightsOverflowMenu.tsx
@@ -7,12 +7,6 @@ import { route, makeXShareUrl } from '@audius/common/utils'
 import Clipboard from '@react-native-clipboard/clipboard'
 import { Linking } from 'react-native'
 
-import {
-  IconCopy,
-  IconExternalLink,
-  IconInfo,
-  IconX
-} from '@audius/harmony-native'
 import ActionDrawer, {
   type ActionDrawerRow
 } from 'app/components/action-drawer/ActionDrawer'


### PR DESCRIPTION
### Description
Designs = centered with no icons

### How Has This Been Tested?

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-09 at 15 29 24" src="https://github.com/user-attachments/assets/6e3af026-c6e0-428d-b24c-8289677dd48d" />
