### PR TITLE
[PE-7123] Fix support linking

### DIFF
--- a/packages/common/src/utils/linking.ts
+++ b/packages/common/src/utils/linking.ts
@@ -9,7 +9,8 @@ export const externalLinkAllowList = new Set([
   'audius.co',
   'discord.gg',
   'solscan.io',
-  'help.audius.co'
+  'help.audius.co',
+  'support.audius.co'
 ])
 
 export const isAllowedExternalLink = (link: string) => {


### PR DESCRIPTION
Support urls shouldnt show "are you sure" external link modal