### PR TITLE
Update popup menu styling in buy/sell flow dropdown

### DIFF
--- a/packages/harmony/src/components/popup/Popup.tsx
+++ b/packages/harmony/src/components/popup/Popup.tsx
@@ -203,7 +203,8 @@ export const PopupInternal = forwardRef<
     portalLocation = document.body,
     shadow = 'mid',
     fixed,
-    takeWidthOfAnchor
+    takeWidthOfAnchor,
+    disableAutoFlip = false
   } = props
   const { spring, shadows } = useTheme()
 
@@ -257,14 +258,16 @@ export const PopupInternal = forwardRef<
         const {
           anchorOrigin: anchorOriginComputed,
           transformOrigin: transformOriginComputed
-        } = getComputedOrigins(
-          anchorOrigin,
-          transformOrigin,
-          anchorRect,
-          wrapperRect,
-          portalLocation,
-          containerRef
-        )
+        } = disableAutoFlip
+          ? { anchorOrigin, transformOrigin }
+          : getComputedOrigins(
+              anchorOrigin,
+              transformOrigin,
+              anchorRect,
+              wrapperRect,
+              portalLocation,
+              containerRef
+            )
         setComputedTransformOrigin(transformOriginComputed)
 
         const anchorTranslation = getOriginTranslation(
@@ -282,14 +285,12 @@ export const PopupInternal = forwardRef<
         // Ensure popup stays within viewport bounds
         const viewportHeight = window.innerHeight
         const viewportWidth = window.innerWidth
-        const adjustedTop = Math.min(
-          Math.max(0, top),
-          viewportHeight - wrapperRect.height
-        )
-        const adjustedLeft = Math.min(
-          Math.max(0, left),
-          viewportWidth - wrapperRect.width
-        )
+        const adjustedTop = disableAutoFlip
+          ? top
+          : Math.min(Math.max(0, top), viewportHeight - wrapperRect.height)
+        const adjustedLeft = disableAutoFlip
+          ? left
+          : Math.min(Math.max(0, left), viewportWidth - wrapperRect.width)
 
         if (wrapperRef.current) {
           wrapperRef.current.style.top = `${adjustedTop}px`

--- a/packages/harmony/src/components/popup/types.ts
+++ b/packages/harmony/src/components/popup/types.ts
@@ -96,6 +96,12 @@ export type PopupProps = {
   fixed?: boolean
 
   /**
+   * When true, the popup will respect the provided origins and avoid flipping
+   * or clamping itself to remain within the viewport.
+   */
+  disableAutoFlip?: boolean
+
+  /**
    * Whether to take the width of the anchor element
    */
   takeWidthOfAnchor?: boolean

--- a/packages/web/src/components/buy-sell-modal/components/TokenDropdown.tsx
+++ b/packages/web/src/components/buy-sell-modal/components/TokenDropdown.tsx
@@ -197,6 +197,8 @@ export const TokenDropdown = ({
       <Menu
         isVisible={isOpen}
         anchorRef={wrapperRef}
+        disableAutoFlip
+        PaperProps={{ mt: 'none' }}
         css={{
           border: 'none',
           boxShadow: 'none',


### PR DESCRIPTION
### Description
Forces the popup menu in buy/sell flow to render below the trigger as show in the designs

<img width="722" height="390" alt="image" src="https://github.com/user-attachments/assets/c935fe1c-da9a-4e7f-ae7e-89bf4c4e67f6" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
