### PR TITLE
[PE-7166] Update convert flow defaults

### DIFF
--- a/packages/common/src/store/ui/buy-sell/useTokenStates.ts
+++ b/packages/common/src/store/ui/buy-sell/useTokenStates.ts
@@ -15,12 +15,25 @@ export const useTokenStates = (selectedPair: TokenPair | null) => {
     const baseSymbol = selectedPair?.baseToken?.symbol ?? 'AUDIO'
     const quoteSymbol = selectedPair?.quoteToken?.symbol ?? 'USDC'
 
+    let convertQuoteDefault = 'USDC'
+    if (
+      selectedPair?.baseToken?.symbol &&
+      selectedPair.baseToken.symbol !== 'AUDIO'
+    ) {
+      convertQuoteDefault = selectedPair.baseToken.symbol
+    } else if (
+      selectedPair?.quoteToken?.symbol &&
+      selectedPair.quoteToken.symbol !== 'AUDIO'
+    ) {
+      convertQuoteDefault = selectedPair.quoteToken.symbol
+    }
+
     return {
       buy: { baseToken: baseSymbol, quoteToken: quoteSymbol },
       sell: { baseToken: baseSymbol, quoteToken: quoteSymbol },
       convert: {
         baseToken: 'AUDIO',
-        quoteToken: baseSymbol
+        quoteToken: convertQuoteDefault
       }
     }
   }, [selectedPair?.baseToken?.symbol, selectedPair?.quoteToken?.symbol])


### PR DESCRIPTION
### Description
When a user goes to buy a coin, then selects convert instead of buy: 

1) The Artist Coin should default to  'you receive', not 'you pay’

2) 'You Pay' should default to Audio

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
