### PR TITLE
[PE-7146] Round market cap in artist coins table

### DIFF
--- a/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
+++ b/packages/web/src/pages/artist-coins-launchpad-page/components/ArtistCoinsTable.tsx
@@ -142,7 +142,7 @@ const renderMarketCapCell = (cellInfo: CoinCell) => {
   return (
     <Text variant='body' size='m'>
       {walletMessages.dollarSign}
-      {formatCount(coin.marketCap)}
+      {formatCount(Math.round(coin.marketCap))}
     </Text>
   )
 }


### PR DESCRIPTION
### Description
This makes more sense to me, but don't think we necessarily want to enforce this everywhere. Would require a bigger discussion with design folks which i don't think is worth right now.

### How Has This Been Tested?

<img width="1272" height="517" alt="Screenshot 2025-10-13 at 5 01 44 PM" src="https://github.com/user-attachments/assets/a2695bf4-775b-4f72-9087-3c11da820747" />
