### PR TITLE
[API-359] Implement non-blocking user score update function

### DIFF
--- a/packages/discovery-provider/ddl/functions/refresh_all_user_scores.sql
+++ b/packages/discovery-provider/ddl/functions/refresh_all_user_scores.sql
@@ -1,0 +1,63 @@
+-- Recompute scores for everyone, then update only changed rows.
+-- Uses an advisory lock to ensure only one runner at a time.
+-- Writes updates to a temp table to avoid locking, since the score calculation is slow
+-- and we don't want to block other indexing that writes to aggregate_user
+-- returns whether lock was acquired (false if run concurrently) and number of rows that were different/updated
+create or replace function refresh_all_user_scores()
+returns table(
+  acquired     boolean,
+  diff_rows    bigint,
+  updated_rows bigint
+)
+language plpgsql
+as $$
+declare
+  v_lock_key bigint := hashtext('refresh_all_user_scores');
+  v_diff bigint := 0;
+  v_upd  bigint := 0;
+  v_got  boolean;
+begin
+  v_got := pg_try_advisory_lock(v_lock_key);
+  if not v_got then
+    acquired     := false;
+    diff_rows    := 0;
+    updated_rows := 0;
+    return next;
+    return;
+  end if;
+
+  begin
+    create temp table _scores_new (
+      user_id int primary key,
+      score   int
+    ) on commit drop;
+
+    insert into _scores_new (user_id, score)
+    select s.user_id, s.score
+    from get_user_scores() as s
+    join aggregate_user au using (user_id)
+    where au.score is distinct from s.score;
+
+    get diagnostics v_diff = row_count;
+    create index on _scores_new (user_id);
+
+    update aggregate_user au
+    set score = sn.score
+    from _scores_new sn
+    where au.user_id = sn.user_id;
+
+    get diagnostics v_upd = row_count;
+
+    acquired     := true;
+    diff_rows    := v_diff;
+    updated_rows := v_upd;
+    return next;
+
+  exception when others then
+    perform pg_advisory_unlock(v_lock_key);
+    raise;
+  end;
+
+  perform pg_advisory_unlock(v_lock_key);
+end
+$$;

--- a/packages/discovery-provider/src/tasks/update_aggregates.py
+++ b/packages/discovery-provider/src/tasks/update_aggregates.py
@@ -90,7 +90,7 @@ track_comments as (
     comments c
   where
     c.is_delete is false
-    and c.is_visible is true 
+    and c.is_visible is true
     and c.entity_type = 'Track'
   group by
     comment_entity_id
@@ -298,12 +298,7 @@ returning au.user_id;
 """
 
 update_user_score_query = """
-update aggregate_user
-set score = scores.score
-from get_user_scores() as scores
-where aggregate_user.user_id = scores.user_id
-and aggregate_user.score != scores.score
-returning aggregate_user.user_id;
+select * from refresh_all_user_scores();
 """
 
 
@@ -319,10 +314,24 @@ def _update_aggregates(session):
     start_time = datetime.now()
 
     logger.debug("update_aggregates.py | updating user scores...")
-    updated_user_ids = session.execute(update_user_score_query).fetchall()
-    logger.debug(
-        f"update_aggregates.py | updated user scores {updated_user_ids} in {datetime.now() - start_time}"
-    )
+    result = session.execute(update_user_score_query).fetchone()
+
+    if result:
+        acquired, diff_rows, updated_rows = result
+        logger.info(
+            f"update_aggregates.py | user scores update completed - acquired: {acquired}, "
+            f"diff_rows: {diff_rows}, updated_rows: {updated_rows} in {datetime.now() - start_time}"
+        )
+
+        if not acquired:
+            logger.error(
+                "update_aggregates.py | Failed to acquire lock for user scores update - "
+                "another instance is already running this update"
+            )
+    else:
+        logger.warning(
+            "update_aggregates.py | No result returned from refresh_user_scores_all()"
+        )
 
     start_time = datetime.now()
 


### PR DESCRIPTION
### Description
This is not the most ideal fix, but it's less dangerous than an overhaul to the functions and tables involved.
A better long term fix would be to update get_user_scores() to require a list of IDs, fetch those IDs in batches, and run the updates in batches so that no part of this query takes several hundred seconds.

But this at least makes the very long running score computation non-blocking for other writers by writing it into a temp table. In practice, the number of user scores that get updated per round is a few thousand at most. 

### How Has This Been Tested?
Tested the function against live data and verified it runs without issue. Will also make sure discovery integration tests are passing since they check the update results.
