### PR TITLE
[PE-7159] Add counts to profile view all buttons

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
@@ -65,6 +65,7 @@ export const ProfileMutuals = () => {
       <ProfilePictureListTile
         onClick={handleClick}
         users={users}
+        totalUserCount={profile.current_user_followee_follow_count}
         limit={MAX_MUTUALS}
         disableProfileClick
       />

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePictureListTile.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePictureListTile.tsx
@@ -11,11 +11,13 @@ const messages = {
 
 type ProfilePictureListTileProps = UserProfileListProps & {
   onClick: () => void
+  totalUserCount?: number
 }
 
 export const ProfilePictureListTile = ({
   onClick,
   users,
+  totalUserCount,
   limit,
   disableProfileClick,
   disablePopover,
@@ -42,6 +44,7 @@ export const ProfilePictureListTile = ({
       />
       <PlainButton variant='subdued' iconRight={IconArrowRight}>
         {messages.viewAll}
+        {totalUserCount ? ` (${totalUserCount})` : null}
       </PlainButton>
     </Paper>
   )

--- a/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
@@ -19,6 +19,8 @@ import { ProfilePageNavSectionItem } from './ProfilePageNavSectionItem'
 import { ProfilePageNavSectionTitle } from './ProfilePageNavSectionTitle'
 import { ProfilePictureListTile } from './ProfilePictureListTile'
 
+const DEFAULT_RELATED_ARTISTS_COUNT = 100
+
 const messages = {
   relatedArtists: 'Related Artists'
 }
@@ -60,6 +62,11 @@ export const RelatedArtists = () => {
       <ProfilePictureListTile
         onClick={handleClick}
         users={relatedArtists as User[]}
+        totalUserCount={
+          relatedArtists.length < MAX_PROFILE_RELATED_ARTISTS
+            ? relatedArtists.length
+            : DEFAULT_RELATED_ARTISTS_COUNT
+        }
         limit={MAX_PROFILE_RELATED_ARTISTS}
         disableProfileClick
       />

--- a/packages/web/src/pages/profile-page/components/desktop/TopSupporters.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/TopSupporters.tsx
@@ -59,6 +59,7 @@ export const TopSupporters = () => {
         <ProfilePictureListTile
           onClick={handleClick}
           users={supporters.map((supporter) => supporter.sender)}
+          totalUserCount={profile.supporter_count}
           limit={MAX_PROFILE_TOP_SUPPORTERS}
           disableProfileClick
         />


### PR DESCRIPTION
### Description
Small update requested by design after the counts were removed from the userProfilePicureLists

### How Has This Been Tested?
Manually tested

Before
<img width="272" height="294" alt="Screenshot 2025-10-15 at 12 53 33 PM" src="https://github.com/user-attachments/assets/bf1c773a-40c4-47d3-8dff-13c28675458e" />

After
<img width="270" height="290" alt="Screenshot 2025-10-15 at 12 54 20 PM" src="https://github.com/user-attachments/assets/21c3f611-5f3e-47f3-8d0d-92e41c4fca20" />

