### PR TITLE
fix audio volume label to be 24h

### DIFF
--- a/packages/common/src/utils/coinMetrics.ts
+++ b/packages/common/src/utils/coinMetrics.ts
@@ -17,6 +17,7 @@ const messages = {
   holdersOnAudius: 'Holders on Audius',
   uniqueHolders: 'Unique Holders',
   totalVolume: 'Volume (All-Time)',
+  volume24h: 'Volume (24h)',
   marketCap: 'Market Cap',
   graduationProgress: 'Graduation Progress'
 }
@@ -98,7 +99,7 @@ export const createAudioCoinMetrics = (
     ),
     createMetric(
       `$${formatCount(coingeckoResponse.market_data.total_volume.usd, 2)}`,
-      messages.totalVolume
+      messages.volume24h
     )
   ].filter((metric): metric is MetricData => metric !== null)
 }


### PR DESCRIPTION
### Description
The data we get back for this isn't all time, it's computed on a rolling 24 hour window. The "total" here refers to it being across all markets and chains.

### How Has This Been Tested?
npm run web:prod and view audio coin details page.
