### PR TITLE
[PE-7190] Fix audio balance

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -879,8 +879,8 @@ export const audiusBackend = ({
       const account = await getAccount(connection, pubkey)
       return account.address
     } catch (err) {
-      // Account exists but is not a token account. Assume it's a root account
-      // and try to derive an associated account from it.
+      // Account is not a valid token account (either doesn't exist or wrong owner).
+      // Assume it's a wallet address and derive the associated token account from it.
       if (
         err instanceof TokenInvalidAccountOwnerError ||
         err instanceof TokenAccountNotFoundError
@@ -1062,8 +1062,8 @@ export const audiusBackend = ({
     try {
       return await getAccount(connection, pubkey)
     } catch (err) {
-      // Account exists but is not a token account. Assume it's a root account
-      // and try to derive an associated account from it.
+      // Account is not a valid token account (either doesn't exist or wrong owner).
+      // Assume it's a wallet address and derive the associated token account from it.
       if (
         err instanceof TokenInvalidAccountOwnerError ||
         err instanceof TokenAccountNotFoundError


### PR DESCRIPTION
### Description
We were previously not checking for `TokenAccountNotFoundError` in `getAssociatedTokenAccountInfo`  which is a state that can happen for connected wallets when the root wallet indeed does has a valid ATA. This led to us showing incorrect AUDIO balances when including external wallets.

### How Has This Been Tested?

- Associate a phantom wallet
- Send AUDIO to it
- Go to `/coins/AUDIO`
- ensure that the balance is reflected 
