### PR TITLE
Pin dotenv-linter version to 3.3.0

### DIFF
--- a/packages/dotenv-linter/package.json
+++ b/packages/dotenv-linter/package.json
@@ -10,7 +10,7 @@
     "dotenv-linter": "bin/dotenv-linter"
   },
   "scripts": {
-    "install": "BINDIR=./bin curl -sSfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/v3.3.0/install.sh | sh -s",
+    "install": "BINDIR=./bin curl -sSfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/v3.3.0/install.sh | sh -s v3.3.0",
     "rebuild": "npm rebuild --ignore-scripts"
   },
   "bugs": {


### PR DESCRIPTION
Despite using the 3.3.0 install script, we weren't specifying a version to install