### PR TITLE
Fix wallet connect not triggering success in claim flow

### DIFF
--- a/packages/web/src/hooks/useConnectExternalWallets.ts
+++ b/packages/web/src/hooks/useConnectExternalWallets.ts
@@ -128,12 +128,8 @@ export const useConnectExternalWallets = (
     return appkitModal.subscribeEvents(async (event) => {
       // Ignore events not meant for this hook instance
       if (!isConnecting) return
-      if (event.data.event === 'MODAL_CLOSE') {
-        setIsConnecting(false)
-        if (!isConnecting) {
-          await reconnectExternalAuthWallet()
-        }
-      } else if (event.data.event === 'CONNECT_SUCCESS') {
+
+      if (event.data.event === 'CONNECT_SUCCESS') {
         setIsConnecting(false)
         const solanaAccount = appkitModal.getAccount('solana')
         const ethAccount = appkitModal.getAccount('eip155')
@@ -147,6 +143,7 @@ export const useConnectExternalWallets = (
           solana: connectedAddress,
           eth: connectedEthAddress
         })
+        await reconnectExternalAuthWallet()
         closeAppKitModal()
       } else if (event.data.event === 'CONNECT_ERROR') {
         setIsConnecting(false)


### PR DESCRIPTION
### Description

- Redoes the fix intended with this change https://github.com/AudiusProject/apps/pull/13291, which caused some issues
- Remove logic for the modal close event, this honestly isnt really needed and is causing unintended effects since CONNECT_SUCCESS seems to be independent of CLOSE and could happen after close

### How Has This Been Tested?

claim fees works as expected, tried clearing local storage a few times, tried with refreshing and opening new tabs