### PR TITLE
[PE-7239] Fix issues due to stale local storage data

### DIFF
--- a/packages/common/src/api/tan-query/saga-utils/queryAccount.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryAccount.ts
@@ -15,7 +15,6 @@ import { queryUser } from './queryUser'
 export function* queryCurrentAccount() {
   const sdk = yield* getSDK()
   const queryClient = yield* getContext('queryClient')
-  const localStorage = yield* getContext('localStorage')
   const walletAddresses = queryClient.getQueryData(
     getWalletAddressesQueryKey()
   ) ?? {
@@ -27,12 +26,7 @@ export function* queryCurrentAccount() {
   const queryData = yield* call([queryClient, queryClient.fetchQuery], {
     queryKey: getCurrentAccountQueryKey(),
     queryFn: async () =>
-      getCurrentAccountQueryFn(
-        sdk,
-        localStorage,
-        currentUserWallet,
-        queryClient
-      ),
+      getCurrentAccountQueryFn(sdk, currentUserWallet, queryClient),
     staleTime: Infinity,
     gcTime: Infinity
   })

--- a/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
@@ -2,7 +2,7 @@ import { AudiusSdk } from '@audius/sdk'
 import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { accountFromSDK } from '~/adapters/user'
-import { primeUserData, useQueryContext } from '~/api/tan-query/utils'
+import { useQueryContext } from '~/api/tan-query/utils'
 import { useAppContext } from '~/context/appContext'
 import { Status } from '~/models'
 import { UserMetadata } from '~/models/User'
@@ -11,7 +11,6 @@ import { AccountState } from '~/store'
 
 import { QUERY_KEYS } from '../../queryKeys'
 import { QueryKey, SelectableQueryOptions } from '../../types'
-import { getUserQueryKey } from '../useUser'
 
 import { getAccountStatusQueryKey } from './useAccountStatus'
 import { useWalletAddresses } from './useWalletAddresses'
@@ -22,20 +21,11 @@ export const getCurrentAccountQueryKey = () =>
     QUERY_KEYS.accountUser
   ] as unknown as QueryKey<AccountState>
 
-const getLocalAccount = (
-  localStorage: LocalStorage,
-  queryClient: QueryClient
-) => {
+const getLocalAccount = (localStorage: LocalStorage) => {
   const localAccount = localStorage.getAudiusAccountSync?.()
   const localAccountUser =
     localStorage.getAudiusAccountUserSync?.() as UserMetadata
   if (localAccount && localAccountUser) {
-    if (
-      localAccountUser &&
-      !queryClient.getQueryData(getUserQueryKey(localAccountUser.user_id))
-    ) {
-      primeUserData({ users: [localAccountUser], queryClient })
-    }
     // feature-tan-query TODO: when removing account sagas,
     //    need to add wallets and local account user from local storage
     return {
@@ -57,15 +47,9 @@ const getLocalAccount = (
 
 export const getCurrentAccountQueryFn = async (
   sdk: AudiusSdk,
-  localStorage: LocalStorage,
   currentUserWallet: string | null,
   queryClient: QueryClient
 ): Promise<AccountState | null | undefined> => {
-  const localAccount = getLocalAccount(localStorage, queryClient)
-  if (localAccount) {
-    return localAccount
-  }
-
   if (!currentUserWallet) {
     return null
   }
@@ -83,7 +67,6 @@ export const getCurrentAccountQueryFn = async (
 
   if (account) {
     queryClient.setQueryData(getAccountStatusQueryKey(), Status.SUCCESS)
-    primeUserData({ users: [account.user], queryClient })
   } else {
     queryClient.setQueryData(getAccountStatusQueryKey(), Status.ERROR)
   }
@@ -120,11 +103,12 @@ export const useCurrentAccount = <TResult = AccountState | null | undefined>(
     queryFn: async () =>
       getCurrentAccountQueryFn(
         await audiusSdk(),
-        localStorage,
         currentUserWallet!,
         queryClient
       ),
     staleTime: Infinity,
+    // Use function form so localStorage is only accessed once on initial mount
+    initialData: () => getLocalAccount(localStorage) ?? undefined,
     gcTime: Infinity,
     enabled: options?.enabled !== false && !!currentUserWallet,
     ...options

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -14,7 +14,6 @@ import {
   queryAccountUser,
   getCurrentAccountQueryKey,
   queryCurrentUserId,
-  primeUserData,
   getUserQueryKey,
   getWalletAccountSaga
 } from '~/api'
@@ -358,10 +357,6 @@ function* fetchLocalAccountAsync() {
     wallet &&
     !cachedAccountUser.is_deactivated
   ) {
-    primeUserData({
-      users: [cachedAccountUser],
-      queryClient
-    })
     queryClient.setQueryData(getAccountStatusQueryKey(), Status.SUCCESS)
     yield* put(fetchAccountSucceeded(cachedAccount))
   }


### PR DESCRIPTION
### Description

There have been a few cases lately of stale account local storage causing issues with update profile-photos and is_verified values. For now im turning this feature off until we can think through the various implications of it. As it stands i dont see a performance hit having to wait for account data