### PR TITLE
[PE-7253] Fix web explore page title

### DIFF
--- a/packages/web/src/pages/search-explore-page/components/desktop/SearchExplorePage.tsx
+++ b/packages/web/src/pages/search-explore-page/components/desktop/SearchExplorePage.tsx
@@ -25,6 +25,7 @@ import { useSearchParams } from 'react-router-dom-v5-compat'
 import { useDebounce, useEffectOnce, usePrevious } from 'react-use'
 
 import BackgroundWaves from 'assets/img/publicSite/imageSearchHeaderBackground@2x.webp'
+import Page from 'components/page/Page'
 import useTabs from 'hooks/useTabs/useTabs'
 import { filters } from 'pages/search-page/SearchFilters'
 import { SearchResults } from 'pages/search-page/SearchResults'
@@ -58,7 +59,6 @@ import { RecentlyPlayedSection } from './RecentlyPlayedSection'
 import { RecommendedTracksSection } from './RecommendedTracksSection'
 import { TrendingPlaylistsSection } from './TrendingPlaylistsSection'
 import { UndergroundTrendingTracksSection } from './UndergroundTrendingTracksSection'
-import Page from 'components/page/Page'
 
 export type SearchExplorePageProps = {
   title: string


### PR DESCRIPTION
### Description
Was missing `<Page>` wrapper component

### How Has This Been Tested?
after:
<img width="1920" height="1080" alt="Screenshot 2025-10-28 at 2 21 34 PM" src="https://github.com/user-attachments/assets/484d849a-4845-4dd3-a24a-3348f11ae323" />

before:
<img width="1920" height="1080" alt="Screenshot 2025-10-28 at 2 21 36 PM" src="https://github.com/user-attachments/assets/c89916ba-96a6-4501-bd31-e15f32203c3c" />
