### PR TITLE
[PE-7262] Fix external sell flow

### DIFF
--- a/packages/common/src/api/tan-query/jupiter/executors.ts
+++ b/packages/common/src/api/tan-query/jupiter/executors.ts
@@ -512,9 +512,12 @@ export class IndirectSwapExecutor extends BaseSwapExecutor {
 
       // Use the predicted amount if we have enough, otherwise use actual balance
       const predictedAmount = step1Result.firstQuote.outputAmount.uiAmount
-      const predictedFixed = new FixedDecimal(predictedAmount, AUDIO_DECIMALS)
+      const predictedFixed = new FixedDecimal(
+        predictedAmount.toFixed(AUDIO_DECIMALS),
+        AUDIO_DECIMALS
+      )
       const actualFixed = new FixedDecimal(
-        actualAudioBalance.uiAmount,
+        actualAudioBalance.uiAmount.toFixed(AUDIO_DECIMALS),
         AUDIO_DECIMALS
       )
       const amountToSwap =

--- a/packages/common/src/api/tan-query/wallets/useExternalWalletBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useExternalWalletBalance.ts
@@ -92,7 +92,11 @@ const getExternalWalletBalanceQueryFn =
       }
 
       // Convert raw balance to FixedDecimal with proper decimals
-      return new FixedDecimal(tokenBalance.uiAmount, tokenBalance.decimals)
+      // Use toFixed to prevent scientific notation for very small balances
+      return new FixedDecimal(
+        tokenBalance.uiAmount.toFixed(tokenBalance.decimals),
+        tokenBalance.decimals
+      )
     } catch (error) {
       reportToSentry({
         error: toErrorWithMessage(error),

--- a/packages/common/src/services/Jupiter.ts
+++ b/packages/common/src/services/Jupiter.ts
@@ -108,10 +108,17 @@ export const getJupiterQuoteByMint = async ({
   onlyDirectRoutes = false,
   maxAccounts = DEFAULT_MAX_ACCOUNTS
 }: JupiterMintQuoteParams): Promise<JupiterQuoteResult> => {
+  // Convert to string using toFixed to prevent scientific notation for very small numbers
+  // Use the relevant decimal count based on swap mode
+  const relevantDecimals =
+    swapMode === 'ExactIn' ? inputDecimals : outputDecimals
+  const amountUiString = amountUi.toFixed(relevantDecimals)
   const amount =
     swapMode === 'ExactIn'
-      ? Number(new FixedDecimal(amountUi, inputDecimals).value.toString())
-      : Number(new FixedDecimal(amountUi, outputDecimals).value.toString())
+      ? Number(new FixedDecimal(amountUiString, inputDecimals).value.toString())
+      : Number(
+          new FixedDecimal(amountUiString, outputDecimals).value.toString()
+        )
 
   const quote = await jupiterInstance.quoteGet({
     inputMint,

--- a/packages/common/src/store/ui/buy-sell/swapFormSchema.ts
+++ b/packages/common/src/store/ui/buy-sell/swapFormSchema.ts
@@ -39,7 +39,7 @@ export const createSwapFormSchema = (
           if (val === '') return false
           try {
             const amount = new FixedDecimal(val, decimals)
-            const minAmount = new FixedDecimal(min, decimals)
+            const minAmount = new FixedDecimal(min.toFixed(decimals), decimals)
             return amount.value >= minAmount.value
           } catch {
             return false
@@ -54,7 +54,7 @@ export const createSwapFormSchema = (
           if (val === '') return false
           try {
             const amount = new FixedDecimal(val, decimals)
-            const maxAmount = new FixedDecimal(max, decimals)
+            const maxAmount = new FixedDecimal(max.toFixed(decimals), decimals)
             return amount.value <= maxAmount.value
           } catch {
             return false
@@ -71,7 +71,10 @@ export const createSwapFormSchema = (
           if (balance == null || balance === undefined) return true
           try {
             const amount = new FixedDecimal(val, decimals)
-            const balanceAmount = new FixedDecimal(balance, decimals)
+            const balanceAmount = new FixedDecimal(
+              balance.toFixed(decimals),
+              decimals
+            )
             return amount.value <= balanceAmount.value
           } catch {
             return false

--- a/packages/common/src/store/ui/buy-sell/useCoinAmountFormatting.ts
+++ b/packages/common/src/store/ui/buy-sell/useCoinAmountFormatting.ts
@@ -58,7 +58,7 @@ export const useCoinAmountFormatting = ({
 
       // Use FixedDecimal truncation for consistency with cash wallet
       // Create FixedDecimal with the token's decimal precision to avoid rounding during construction
-      const fd = new FixedDecimal(availableBalance, decimals)
+      const fd = new FixedDecimal(availableBalance.toFixed(decimals), decimals)
       const truncatedValue = Number(fd.trunc(maxFractionDigits).toString())
 
       return truncatedValue.toLocaleString('en-US', {
@@ -67,7 +67,10 @@ export const useCoinAmountFormatting = ({
       })
     }
 
-    const tokenAmount = new FixedDecimal(availableBalance, decimals)
+    const tokenAmount = new FixedDecimal(
+      availableBalance.toFixed(decimals),
+      decimals
+    )
     const displayDecimals = getTokenDecimalPlaces(availableBalance)
     const maxFractionDigits = Math.min(displayDecimals, decimals)
 
@@ -95,7 +98,10 @@ export const useCoinAmountFormatting = ({
       })
     }
 
-    const tokenAmount = new FixedDecimal(safeNumericAmount, decimals)
+    const tokenAmount = new FixedDecimal(
+      safeNumericAmount.toFixed(decimals),
+      decimals
+    )
     const displayDecimals = getTokenDecimalPlaces(safeNumericAmount)
     const maxFractionDigits = Math.min(displayDecimals, decimals)
 

--- a/packages/common/src/store/ui/buy-sell/utils/validationHelpers.ts
+++ b/packages/common/src/store/ui/buy-sell/utils/validationHelpers.ts
@@ -55,7 +55,7 @@ export const validateMinimumAmount = (
   try {
     const amount = new FixedDecimal(value, decimals)
     // The UI displays this value up to 2 decimal places. To prevent confusion we round this number up
-    const minAmount = new FixedDecimal(min, decimals).round(2)
+    const minAmount = new FixedDecimal(min.toFixed(decimals), decimals).round(2)
 
     if (amount.value < minAmount.value) {
       return messages.minAmount(min, tokenSymbol)
@@ -80,7 +80,7 @@ export const validateMaximumAmount = (
 
   try {
     const amount = new FixedDecimal(value, decimals)
-    const maxAmount = new FixedDecimal(max, decimals)
+    const maxAmount = new FixedDecimal(max.toFixed(decimals), decimals)
 
     if (amount.value > maxAmount.value) {
       return messages.maxAmount(max, tokenSymbol)
@@ -110,7 +110,7 @@ export const validateSufficientBalance = (
 
   try {
     const amount = new FixedDecimal(value, decimals)
-    const balanceAmount = new FixedDecimal(balance, decimals)
+    const balanceAmount = new FixedDecimal(balance.toFixed(decimals), decimals)
 
     if (amount.value > balanceAmount.value) {
       return messages.insufficientBalance(tokenSymbol)

--- a/packages/web/src/hooks/useExternalWalletSwap.ts
+++ b/packages/web/src/hooks/useExternalWalletSwap.ts
@@ -437,7 +437,10 @@ export const useExternalWalletSwap = () => {
               const currentAmount = Number(oldBalance.toString())
               const inputAmount = result.inputAmount!.uiAmount
               const newAmount = Math.max(0, currentAmount - inputAmount) // Ensure non-negative
-              return new FixedDecimal(newAmount, oldBalance.decimalPlaces)
+              return new FixedDecimal(
+                newAmount.toFixed(oldBalance.decimalPlaces),
+                oldBalance.decimalPlaces
+              )
             }
           )
         }
@@ -453,14 +456,17 @@ export const useExternalWalletSwap = () => {
               if (!oldBalance) {
                 // If no previous balance, create a new FixedDecimal with the output amount
                 return new FixedDecimal(
-                  result.outputAmount!.uiAmount,
+                  result.outputAmount!.uiAmount.toFixed(params.outputDecimals),
                   params.outputDecimals
                 )
               }
               const currentAmount = Number(oldBalance.toString())
               const outputAmount = result.outputAmount!.uiAmount
               const newAmount = currentAmount + outputAmount
-              return new FixedDecimal(newAmount, oldBalance.decimalPlaces)
+              return new FixedDecimal(
+                newAmount.toFixed(oldBalance.decimalPlaces),
+                oldBalance.decimalPlaces
+              )
             }
           )
         }


### PR DESCRIPTION
### Description

Fixes issue where small values passed to fixed decimal fail to convert due to scientific notation, leading to broken sell flow for external wallets. This fixes the issue, though we may want fixed decimal to handle this?