### PR TITLE
[PE-7263] Fix external wallets failing to disconnect

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -457,12 +457,13 @@ def add_associated_wallet(
 
         # Check if wallet already exists, and remove it from other users
         existing_wallet = None
-        for _, wallet in params.existing_records["AssociatedWallet"].items():
-            if wallet.chain == chain and wallet.wallet == wallet_address:
-                if wallet.user_id == user_id:
-                    existing_wallet = wallet
-                else:
-                    session.delete(wallet)
+        for _, wallets in params.existing_records["AssociatedWallet"].items():
+            for wallet in wallets:
+                if wallet.chain == chain and wallet.wallet == wallet_address:
+                    if wallet.user_id == user_id:
+                        existing_wallet = wallet
+                    else:
+                        session.delete(wallet)
 
         if not existing_wallet:
             # Create new wallet association only if it doesn't exist for this user
@@ -497,14 +498,15 @@ def remove_associated_wallet(params: ManageEntityParameters):
     try:
         # Find the wallet to remove
         wallet_to_remove = None
-        for _, wallet in params.existing_records["AssociatedWallet"].items():
-            if (
-                wallet.chain == chain
-                and wallet.user_id == user_id
-                and wallet.wallet == wallet_address
-            ):
-                wallet_to_remove = wallet
-                break
+        for _, wallets in params.existing_records["AssociatedWallet"].items():
+            for wallet in wallets:
+                if (
+                    wallet.chain == chain
+                    and wallet.user_id == user_id
+                    and wallet.wallet == wallet_address
+                ):
+                    wallet_to_remove = wallet
+                    break
 
         if wallet_to_remove:
             session.delete(wallet_to_remove)

--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -1024,10 +1024,13 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
             .all()
         )
         existing_entities[EntityType.ASSOCIATED_WALLET] = {
-            wallet.wallet: wallet for wallet, _ in associated_wallets
+            wallet.wallet: [wallet for wallet, _ in associated_wallets]
+            for wallet, _ in associated_wallets
         }
         existing_entities_in_json[EntityType.ASSOCIATED_WALLET] = {
-            (wallet_json["wallet"]): wallet_json
+            wallet_json["wallet"]: [
+                wallet_json for _, wallet_json in associated_wallets
+            ]
             for _, wallet_json in associated_wallets
         }
 

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -175,7 +175,7 @@ class RecordDict(TypedDict):
 
 
 class ExistingRecordDict(TypedDict):
-    AssociatedWallet: Dict[str, AssociatedWallet]
+    AssociatedWallet: Dict[str, List[AssociatedWallet]]
     Playlist: Dict[int, Playlist]
     Track: Dict[int, Track]
     UserWallet: Dict[str, User]


### PR DESCRIPTION
### Description
Co-author: @rickyrombo branch `mjp-ass-wallet`

Bug was that there was a duplicate row for the same wallet address, associated with a different user, but with `is_delete = True` which caused `existing_records` to pick up that row instead.

Added logic to include all records for the given wallet address, then cycle through them and make sure we delete the right row with the correct user ID.

There's a bigger convo around whether we should be deleting rows outright, or marking them with `is_delete = True` like we do for other operations.

### How Has This Been Tested?

Added a row with `is_delete = True` to the existing wallet removal test.
Also added a new test case to confirm that associating a wallet that's already associated with a different user results in the old row getting deleted and the new association getting created. Also added a row with `is_delete = True` for this case.