### PR TITLE
[PE-7277] Hide chat blast coin holder audience if no coin

### DIFF
--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -257,6 +257,8 @@ const CoinHoldersMessageField = () => {
   const coinSymbol = coin?.ticker ?? ''
   const isDisabled = coinMembersCount === 0
 
+  if (!coin) return null
+
   return (
     <ExpandableRadio
       value={ChatBlastAudience.COIN_HOLDERS}

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -363,6 +363,7 @@ const CoinHoldersMessageField = () => {
     mint: coin?.mint
   })
   const isDisabled = coinMembersCount === 0
+  if (!coin) return null
 
   return (
     <Flex


### PR DESCRIPTION
### Description
Missed this in the no coin case whoops

### How Has This Been Tested?

<img width="508" height="430" alt="Screenshot 2025-11-03 at 12 37 41 PM" src="https://github.com/user-attachments/assets/b7e128e2-f9db-4d49-849f-1906bdaddbcb" />
