### PR TITLE
Remove playwright install publish-packages.sh

### DIFF
--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -3,9 +3,6 @@
 
 set -e
 
-echo "Installing playwright..."
-npx playwright install
-
 echo "Running build, lint, typecheck, and test..."
 # Ensure that all public packages are in this list,
 # otherwise they won't get built/linted/tested before being published


### PR DESCRIPTION
### Description
Not sure why this is needed. create-audius-app already runs playwright tests in its own e2e tests.

### How Has This Been Tested?

Not tested, but AI claims this is safe... 🤖 