### PR TITLE
[PE-2834] Fix balance history hover issue

### DIFF
--- a/packages/common/src/messages/walletMessages.ts
+++ b/packages/common/src/messages/walletMessages.ts
@@ -142,5 +142,11 @@ export const walletMessages = {
     sortVolume: 'Volume',
     sortLaunchDate: 'Launch Date',
     sortHolders: 'Holders'
+  },
+
+  // Balance History messages
+  balanceHistory: {
+    loading: 'Loading balance history...',
+    error: 'Unable to load balance history'
   }
 }

--- a/packages/mobile/src/components/user-balance-history-graph/UserBalanceHistoryGraph.tsx
+++ b/packages/mobile/src/components/user-balance-history-graph/UserBalanceHistoryGraph.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 
 import { useCurrentUserId, useUserBalanceHistory } from '@audius/common/api'
+import { walletMessages } from '@audius/common/messages'
 import type { ID } from '@audius/common/models'
 import { LineChart } from 'react-native-gifted-charts'
 import type { lineDataItem } from 'react-native-gifted-charts'
@@ -8,10 +9,7 @@ import type { lineDataItem } from 'react-native-gifted-charts'
 import { Flex, Paper, Text, useTheme } from '@audius/harmony-native'
 import LoadingSpinner from 'app/components/loading-spinner'
 
-const messages = {
-  loading: 'Loading balance history...',
-  error: 'Unable to load balance history'
-}
+const messages = walletMessages.balanceHistory
 
 type UserBalanceHistoryGraphProps = {
   userId?: ID
@@ -130,7 +128,7 @@ export const UserBalanceHistoryGraph = ({
         style={{ minHeight: height }}
       >
         <LoadingSpinner />
-        <Text variant='body' size='s' strength='weak'>
+        <Text variant='body' size='s'>
           {messages.loading}
         </Text>
       </Flex>
@@ -144,7 +142,7 @@ export const UserBalanceHistoryGraph = ({
         justifyContent='center'
         style={{ minHeight: height }}
       >
-        <Text variant='body' size='m' strength='weak' color='danger'>
+        <Text variant='body' size='m' color='danger'>
           {messages.error}
         </Text>
       </Flex>

--- a/packages/web/src/components/user-balance-history-graph/UserBalanceHistoryGraph.tsx
+++ b/packages/web/src/components/user-balance-history-graph/UserBalanceHistoryGraph.tsx
@@ -5,6 +5,7 @@ import {
   useCurrentUserId,
   useUserBalanceHistory
 } from '@audius/common/api'
+import { walletMessages } from '@audius/common/messages'
 import type { ID } from '@audius/common/models'
 import { Flex, Text, useTheme } from '@audius/harmony'
 import { Line } from 'react-chartjs-2'
@@ -13,10 +14,7 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 
 import styles from './UserBalanceHistoryGraph.module.css'
 
-const messages = {
-  loading: 'Loading balance history...',
-  error: 'Unable to load balance history'
-}
+const messages = walletMessages.balanceHistory
 
 type UserBalanceHistoryGraphProps = {
   userId?: ID
@@ -162,10 +160,16 @@ const getChartOptions = (
   legend: {
     display: false
   },
+  hover: {
+    mode: 'index',
+    intersect: false,
+    axis: 'x'
+  },
   tooltips: {
     enabled: false,
     mode: 'index',
     intersect: false,
+    axis: 'x',
     custom: function (tooltipModel: any) {
       let tooltipEl = document.getElementById(
         `balance-chart-tooltip-${chartId}`
@@ -253,7 +257,7 @@ export const UserBalanceHistoryGraph = ({
           css={{ minHeight: '200px' }}
         >
           <LoadingSpinner />
-          <Text variant='body' size='s' strength='weak'>
+          <Text variant='body' size='s'>
             {messages.loading}
           </Text>
         </Flex>
@@ -271,7 +275,7 @@ export const UserBalanceHistoryGraph = ({
           gap='l'
           css={{ minHeight: '200px' }}
         >
-          <Text variant='body' size='m' strength='weak' color='danger'>
+          <Text variant='body' size='m' color='danger'>
             {messages.error}
           </Text>
         </Flex>


### PR DESCRIPTION
### Description

Ensures hovering below the user-balance graph line still shows the data-circle on the line. Also consolidates messages and updates style