### PR TITLE
[PE-7280] Enable 16KB page size support for Android 15+

### DIFF
--- a/packages/mobile/android/build.gradle
+++ b/packages/mobile/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 35
         castFrameworkVersion = "21.0.0"
-        ndkVersion = "26.1.10909125"
+        ndkVersion = "27.0.12077973"
         kotlinVersion = "1.9.25"
     }
     repositories {


### PR DESCRIPTION
### Description

Fixes issue where android 15+ now requires 16kb page support to release android apps on play-store