### PR TITLE
Remove account requirement for unlock track modal coin buy

### DIFF
--- a/packages/web/src/components/track/GatedContentSection.tsx
+++ b/packages/web/src/components/track/GatedContentSection.tsx
@@ -184,7 +184,7 @@ const LockedGatedContentSection = ({
 
   const { onOpen: openBuySellModal } = useBuySellModal()
 
-  const handlePurchaseToken = useRequiresAccountCallback(() => {
+  const handlePurchaseToken = useCallback(() => {
     if (!coin?.ticker) return
     openBuySellModal({ isOpen: true, ticker: coin.ticker })
 


### PR DESCRIPTION
### Description
Small update to remove the account requirement for the Buy Artist Coin button in the How To Unlock modal for tracks

### How Has This Been Tested?
Manually tested
