### PR TITLE
Drop decimals to fix swaps

### DIFF
--- a/packages/common/src/api/tan-query/jupiter/types.ts
+++ b/packages/common/src/api/tan-query/jupiter/types.ts
@@ -29,8 +29,6 @@ export enum SwapErrorType {
 export type SwapTokensParams = {
   inputMint: string
   outputMint: string
-  inputDecimals: number
-  outputDecimals: number
   amountUi: number
   slippageBps?: number
   wrapUnwrapSol?: boolean

--- a/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
+++ b/packages/common/src/store/ui/buy-sell/useBuySellSwap.ts
@@ -32,8 +32,6 @@ type SwapParams = {
   outputMint: string
   amountUi: number
   slippageBps: number
-  inputDecimals: number
-  outputDecimals: number
 }
 
 type UseBuySellSwapProps = {
@@ -88,15 +86,11 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
       outputMintAddress = selectedPair.quoteToken.address ?? ''
     }
 
-    if (!baseCoin?.decimals || !quoteCoin?.decimals) return
-
     handleSwap({
       inputMint: inputMintAddress,
       outputMint: outputMintAddress,
       amountUi: inputAmount,
-      slippageBps: SLIPPAGE_BPS,
-      inputDecimals: baseCoin.decimals,
-      outputDecimals: quoteCoin.decimals
+      slippageBps: SLIPPAGE_BPS
     })
   }
 


### PR DESCRIPTION
### Description

Fixes issue where quoteToken decimals is not present for usdc swaps. We dont need decimals at all so dropping the type and the check