### PR TITLE
[PE-7304] Fix upload saga test

### DIFF
--- a/packages/web/src/common/store/upload/sagas.test.ts
+++ b/packages/web/src/common/store/upload/sagas.test.ts
@@ -223,8 +223,7 @@ describe('upload', () => {
     )
   })
 
-  // Skipped - PE-7304
-  it.skip('does not upload parent if stem fails and deletes orphaned stems', () => {
+  it('does not upload parent if stem fails and deletes orphaned stems', () => {
     const stem1: StemUploadWithFile = {
       file: new File(['abcdefghijklmnopqrstuvwxyz'], 'test stem1'),
       metadata: { ...emptyMetadata, track_id: 2, title: 'stem1' },
@@ -336,7 +335,7 @@ describe('upload', () => {
         .call(deleteTracks, [2])
         // Expect the saga to throw since no tracks succeeded
         .throws(Error)
-        .run()
+        .silentRun()
         .then(() => {
           // Never published the parent track
           expect(mockWriteTrackUploadToChain).not.toBeCalledWith(


### PR DESCRIPTION
### Description
Fix the flaky upload saga test

The Issue:
The test at line 338 uses .throws(Error) followed by .run() and then .then(). In the saga code (line 808 of sagas.ts), when no tracks are successfully uploaded, it throws:
throw new Error('No tracks were successfully uploaded.', { cause: errored })
The combination of .throws(Error) + .run() + .then() creates a timing issue where redux-saga-test-plan generates an unhandled promise rejection, especially with the complexity of forked tasks and channels in this saga. CI environments are slower, which makes this race condition more apparent.
The Fix:
The other passing test (lines 135-224) uses .silentRun() instead of .run(), which suppresses console output and handles promise rejections better. Let's update the failing test to match:

### How Has This Been Tested?

tests pass on CI
