### PR TITLE
Fix takeover cta

### DIFF
--- a/packages/web/src/public-site/pages/landing-page/components/CTAGetStarted.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/CTAGetStarted.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 
 import { coinPage } from '@audius/common/src/utils/route'
-import { route } from '@audius/common/utils'
 import { IconCaretRight } from '@audius/harmony'
 import cn from 'classnames'
 import { Parallax } from 'react-scroll-parallax'
@@ -14,8 +13,6 @@ import { handleClickRoute } from 'public-site/components/handleClickRoute'
 import { useMatchesBreakpoint } from 'utils/useMatchesBreakpoint'
 
 import styles from './CTAGetStarted.module.css'
-
-const { TRENDING_PAGE } = route
 
 const MOBILE_WIDTH_MEDIA_QUERY = window.matchMedia('(max-width: 1150px)')
 


### PR DESCRIPTION
### Description
forgot to update it for web. oof

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes the landing-page CTA to `coinPage('YAK')` instead of Trending and removes obsolete route references.
> 
> - **Public site landing CTA (`CTAGetStarted.tsx`)**:
>   - Update CTA click handler to navigate to `coinPage('YAK')` (applies to desktop and mobile variants).
>   - Remove unused `route` import and `TRENDING_PAGE` constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e1c65cf1b3b6cfeac0aea2c18f7f3df0a9c9f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->