### PR TITLE
Timeout image loading in case of hanging connections

### DIFF
--- a/packages/web/src/utils/image.ts
+++ b/packages/web/src/utils/image.ts
@@ -1,4 +1,4 @@
-export const preload = (url: string, timeoutMs: number = 10000) => {
+export const preload = (url: string, timeoutMs: number = 5000) => {
   return new Promise<void>((resolve, reject) => {
     const img = new Image()
     img.src = url


### PR DESCRIPTION
### Description

Some nodes might be down/unreachable in a way that causes connections to hang open indefinitely. This creates a default 10 second timeout for loading images before timing out to allow the fetcher to move on to the next mirror. 

### How Has This Been Tested?

Ran local web stack against a prod track. The track's artwork was stored on a node that creates hanging connections. The timeout triggered after the 10 second default and the artwork loaded quickly once the fetcher was able to try the next working mirror.
