### PR TITLE
[PE-7204] Associate external wallet after swap

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -18,6 +18,7 @@ import { verifySignatures } from '../../utils/verifySignatures'
 
 import { InvalidRelayInstructionError } from './InvalidRelayInstructionError'
 import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
+import { associateExternalWallet } from './associateExternalWallet'
 
 /**
  * Gets the specified fee payer's key pair from the config.
@@ -107,6 +108,13 @@ export const relay = async (
       }
       transaction.sign([feePayerKeyPair])
     } else if (verifySignatures(transaction)) {
+      if (res.locals.signerUser?.user_id) {
+        res.locals.logger.info('Associating external wallet...')
+        await associateExternalWallet(
+          transaction,
+          res.locals.signerUser?.user_id
+        )
+      }
       res.locals.logger.info(
         `Transaction already signed by '${feePayerKey.toBase58()}'`
       )

--- a/packages/web/src/hooks/useExternalWalletSwap.ts
+++ b/packages/web/src/hooks/useExternalWalletSwap.ts
@@ -7,7 +7,8 @@ import {
   SwapErrorType,
   SwapStatus,
   SwapTokensParams,
-  SwapTokensResult
+  SwapTokensResult,
+  getConnectedWalletsQueryOptions
 } from '@audius/common/api'
 import { ErrorLevel, Feature } from '@audius/common/models'
 import {
@@ -681,6 +682,15 @@ export const useExternalWalletSwap = () => {
       if (result.status === SwapStatus.SUCCESS) {
         // Update internal wallet balances & user info
         optimisticallyUpdateSwapBalances(params, result, queryClient, user, env)
+
+        if (user?.user_id) {
+          queryClient.invalidateQueries({
+            queryKey: getConnectedWalletsQueryOptions(
+              { audiusSdk },
+              { userId: user.user_id }
+            ).queryKey
+          })
+        }
 
         // Update external wallet balances
         // NOTE: invalidate queries does not work here, need to manually update the balances


### PR DESCRIPTION
### Description

After a wallet swap, auto-associate wallet so balance + coin-gated tracks work right away