### PR TITLE
Increase max file size for uploads

### DIFF
--- a/packages/common/src/utils/uploadConstants.ts
+++ b/packages/common/src/utils/uploadConstants.ts
@@ -1,4 +1,5 @@
-export const ALLOWED_MAX_AUDIO_SIZE_BYTES = 500 * 1000 * 1000
+// 1.1 GB
+export const ALLOWED_MAX_AUDIO_SIZE_BYTES = 1.1 * 1000 * 1000 * 1000
 
 export const ALLOWED_AUDIO_FILE_EXTENSIONS = [
   'mp2',


### PR DESCRIPTION
Updates the max file size for audio files to 1.1GB