### PR TITLE
Revert "Increase max file size for uploads (#13430)"

### DIFF
--- a/packages/common/src/utils/uploadConstants.ts
+++ b/packages/common/src/utils/uploadConstants.ts
@@ -1,5 +1,4 @@
-// 1.1 GB
-export const ALLOWED_MAX_AUDIO_SIZE_BYTES = 1.1 * 1000 * 1000 * 1000
+export const ALLOWED_MAX_AUDIO_SIZE_BYTES = 500 * 1000 * 1000
 
 export const ALLOWED_AUDIO_FILE_EXTENSIONS = [
   'mp2',


### PR DESCRIPTION
This reverts commit e2d6f9ed56f956543fb80949dd14cb73dfb4e030.

Tried testing on stage and it times out within the  K8s cluster. Gonna revert for now unf... I think we can revisit holistically with chunking, etc.