### PR TITLE
[QA-2393] Fix nft gated tracks borking page

### DIFF
--- a/packages/common/src/adapters/accessConditionsFromSDK.ts
+++ b/packages/common/src/adapters/accessConditionsFromSDK.ts
@@ -3,14 +3,15 @@ import {
   instanceOfTipGate,
   instanceOfFollowGate,
   instanceOfPurchaseGate,
-  instanceOfTokenGate
+  instanceOfTokenGate,
+  instanceOfNftGate
 } from '@audius/sdk/src/sdk/api/generated/full'
 
 import { AccessConditions } from '~/models'
 
 export const accessConditionsFromSDK = (
   input: full.AccessGate
-): AccessConditions => {
+): AccessConditions | null => {
   if (instanceOfFollowGate(input)) {
     return { follow_user_id: input.followUserId }
   } else if (instanceOfPurchaseGate(input)) {
@@ -24,7 +25,9 @@ export const accessConditionsFromSDK = (
         token_amount: input.tokenGate.tokenAmount
       }
     }
+  } else if (instanceOfNftGate(input)) {
+    return null
   } else {
-    throw new Error(`Unsupported access gate type: ${input}`)
+    throw new Error(`Unsupported access gate type: ${JSON.stringify(input)}`)
   }
 }

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -55,6 +55,17 @@ export type TokenGatedConditions = {
   }
 }
 
+export type NftGatedConditions = {
+  nft_collection: {
+    chain: 'eth' | 'sol'
+    standard?: 'ERC721' | 'ERC1155'
+    address: string
+    name: string
+    imageUrl?: string | null
+    externalLink?: string | null
+  }
+}
+
 export type USDCPurchaseConditions = {
   usdc_purchase: {
     price: number
@@ -68,6 +79,7 @@ export type AccessConditions =
   | TipGatedConditions
   | USDCPurchaseConditions
   | TokenGatedConditions
+  | NftGatedConditions
 
 export type AccessPermissions = {
   stream: boolean
@@ -102,6 +114,11 @@ export const isContentTokenGated = (
   gatedConditions?: Nullable<AccessConditions>
 ): gatedConditions is TokenGatedConditions =>
   !!gatedConditions && 'token_gate' in (gatedConditions ?? {})
+
+export const isContentNftGated = (
+  gatedConditions?: Nullable<AccessConditions>
+): gatedConditions is NftGatedConditions =>
+  !!gatedConditions && 'nft_collection' in (gatedConditions ?? {})
 
 export const isContentSpecialAccess = (
   gatedConditions?: Nullable<AccessConditions>


### PR DESCRIPTION
### Description

**Handle NFT Gates in Access Conditions Adapter**

- Update `accessConditionsFromSDK` to return `null` for NFT gates since NFT functionality was removed from the app
- Change return type to `AccessConditions | null` 
- Remove NFT gate type definitions and handling logic that are no longer needed

This prevents the "Unsupported access gate type" error when encountering NFT-gated content.

### How Has This Been Tested?

`npm run web:prod`
http://localhost:3002/Wables411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle NFT-gated access by returning null in the adapter and add NFT gating types/guards to models.
> 
> - **Adapters**:
>   - Update `accessConditionsFromSDK` to return `null` for `instanceOfNftGate` and change return type to `AccessConditions | null`.
>   - Import `instanceOfNftGate`; improve error by stringifying `input`.
> - **Models**:
>   - Add `NftGatedConditions` and include in `AccessConditions`.
>   - Add `isContentNftGated` type guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31e9e358f2b856390589711050f6272874498086. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->