### PR TITLE
Fix yak links

### DIFF
--- a/packages/common/src/utils/linking.ts
+++ b/packages/common/src/utils/linking.ts
@@ -6,6 +6,7 @@ export const externalLinkAllowList = new Set([
   'x.com',
   'blog.audius.co',
   'link.audius.co',
+  'yak.audius.co',
   'audius.co',
   'discord.gg',
   'solscan.io',
@@ -15,7 +16,12 @@ export const externalLinkAllowList = new Set([
 
 export const isAllowedExternalLink = (link: string) => {
   try {
-    let hostname = new URL(link).hostname
+    // Add protocol if missing to allow URL parsing
+    const urlWithProtocol =
+      link.startsWith('http://') || link.startsWith('https://')
+        ? link
+        : `https://${link}`
+    let hostname = new URL(urlWithProtocol).hostname
     hostname = hostname.replace(/^www\./, '')
     return externalLinkAllowList.has(hostname)
   } catch (e) {

--- a/packages/mobile/src/harmony-native/components/TextLink/ExternalLink.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/ExternalLink.tsx
@@ -42,10 +42,16 @@ export const useExternalLinkHandlePress = ({
       onPress?.(e)
 
       try {
-        const supported = await Linking.canOpenURL(url)
+        // Ensure URL has a protocol for Linking.openURL
+        const urlWithProtocol =
+          url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `https://${url}`
+
+        const supported = await Linking.canOpenURL(urlWithProtocol)
         if (supported) {
           if (isAllowedExternalLink(url)) {
-            await Linking.openURL(url)
+            await Linking.openURL(urlWithProtocol)
           } else {
             openLeavingAudiusModal({ link: url })
           }


### PR DESCRIPTION
### Description

- Adds yak.audius.co to allow-list
- Handles urls missing protocol (http/https) in user-generated-text 