### PR TITLE
Prevent android oauth deeplink

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -51,6 +51,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE"/>
             </intent-filter>
+            <!-- Deep link intent filter for audius.co and redirect.audius.co
+                 Note: OAuth routes (/oauth/*) are excluded from deep linking via
+                 code-level filtering in NavigationContainer.tsx -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/packages/mobile/android/app/src/main/java/co/audius/app/MainActivity.kt
+++ b/packages/mobile/android/app/src/main/java/co/audius/app/MainActivity.kt
@@ -1,5 +1,7 @@
 package co.audius.app
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import com.bytedance.sdk.open.tiktok.TikTokOpenApiFactory
 import com.bytedance.sdk.open.tiktok.TikTokOpenConfig
@@ -37,6 +39,12 @@ class MainActivity : ReactActivity() {
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    // Check if this is an oauth deep link and redirect to browser
+    if (handleOAuthDeepLink(intent)) {
+      finish()
+      return
+    }
+    
     RNBootSplash.init(this, R.style.BootTheme)
     super.onCreate(null)
     RNBars.init(this, "light-content")
@@ -44,6 +52,38 @@ class MainActivity : ReactActivity() {
 
     // lazy load Google Cast context
     CastContext.getSharedInstance(this)
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    
+    // Check if this is an oauth deep link and redirect to browser
+    if (handleOAuthDeepLink(intent)) {
+      finish()
+      return
+    }
+  }
+
+  /**
+   * Handles oauth deep links by opening them in the browser instead of the app.
+   * Returns true if the intent was an oauth route and was handled.
+   */
+  private fun handleOAuthDeepLink(intent: Intent?): Boolean {
+    if (intent == null) return false
+    
+    val data: Uri? = intent.data
+    if (data != null) {
+      val path = data.path
+      // If the path starts with /oauth, open in browser instead
+      if (path != null && path.startsWith("/oauth")) {
+        val browserIntent = Intent(Intent.ACTION_VIEW, data)
+        browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity(browserIntent)
+        return true
+      }
+    }
+    
+    return false
   }
 
   override fun onDestroy() {


### PR DESCRIPTION
### Description

Prevents /oauth from deep linking to the android mobile app.


Unfortunately android does not allow negative filters, and since we have :handle routes, we can't do explicit whitelist either. The only solution in this case is to have an app-level filter that boots us back to the browser