### PR TITLE
Use sol_locker_vesting_escrows in vested coins claiming

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/claim_vested_coins.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/claim_vested_coins.ts
@@ -305,10 +305,9 @@ export const claimVestedCoins = async (
       }>(
         `
       SELECT authority 
-      FROM sol_meteora_dbc_migrations m 
-      JOIN artist_coins ac ON ac.mint = m.base_mint 
+      FROM artist_coins ac 
       JOIN sol_reward_manager_inits r ON r.mint = ac.mint
-      WHERE m.base_mint = ?
+      WHERE ac.mint = ?
       `,
         [mintPublicKey.toBase58()]
       )


### PR DESCRIPTION
### Description
Some artist coins don't have entries in some of the various tables: `artist_coins`, `sol_meteora_dbc_pools`, `sol_meteora_dbc_configs`, as some of them were custom-created and don't have dbc's. But all graduated coins should have entries in `sol_locker_vesting_escrows`, which should contain all the same data as onchain.

### How Has This Been Tested?

Confirmed db state matches escrow state for a couple of stage mints.
Tested with local solana-relay against stage.