### PR TITLE
Use new validators endpoint in healthz to fetch nodes

### DIFF
--- a/monitoring/healthz/src/components/EnvironmentSelector.tsx
+++ b/monitoring/healthz/src/components/EnvironmentSelector.tsx
@@ -1,25 +1,16 @@
 import { useSearchParams } from 'react-router-dom'
 
 const isStageParam = 'isStaging'
-const isDevParam = 'isDev'
 const nodeTypeParam = 'nodeType'
 
 export function useEnvironmentSelection(): [
-  'staging' | 'prod' | 'dev',
+  'staging' | 'prod',
   'content' | 'core'
 ] {
   let [searchParams] = useSearchParams()
 
   const isStage = !!searchParams.get(isStageParam)
-  const isDev = !!searchParams.get(isDevParam)
   const nodeType = (searchParams.get(nodeTypeParam) as 'content' |  'core') || 'core'
-
-  if (isDev) {
-    return [
-      'dev',
-      nodeType
-    ]
-  }
 
   return [
     isStage ? 'staging' : 'prod',
@@ -31,7 +22,6 @@ export function EnvironmentSelector() {
   let [searchParams, setSearchParams] = useSearchParams()
 
   const isStage = !!searchParams.get(isStageParam)
-  const isDev = !!searchParams.get(isDevParam)
   const nodeType = searchParams.get(nodeTypeParam) || 'core'
 
   function toggleParam(name: string, value: '0' | '1') {
@@ -56,29 +46,17 @@ export function EnvironmentSelector() {
           className={`px-4 py-2 ${isStage ? 'bg-purple-300 text-white' : 'bg-gray-200 text-black'}`}
           onClick={() => {
             toggleParam(isStageParam, '1')
-            toggleParam(isDevParam, '0')
           }}
         >
           Stage
         </button>
         <button
-          className={`px-4 py-2 ${isStage || isDev ? 'bg-gray-200 text-black' : 'bg-purple-300 text-white'}`}
+          className={`px-4 py-2 ${isStage ? 'bg-gray-200 text-black' : 'bg-purple-300 text-white'}`}
           onClick={() => {
             toggleParam(isStageParam, '0')
-            toggleParam(isDevParam, '0')
           }}
         >
           Prod
-        </button>
-        <button
-          className={`px-4 py-2 ${isDev ? 'bg-purple-300 text-white' : 'bg-gray-200 text-black'}`}
-          onClick={() => {
-            toggleParam(isStageParam, '0')
-            toggleParam(isDevParam, '1')
-          }
-          }
-        >
-          Dev
         </button>
       </div>
       <div className="flex">

--- a/monitoring/healthz/src/pages/Nodes.tsx
+++ b/monitoring/healthz/src/pages/Nodes.tsx
@@ -27,7 +27,7 @@ const discprovWhitelist = [
 
 export default function Nodes() {
   const [env, nodeType] = useEnvironmentSelection()
-  let { data: sps, error } = useServiceProviders(env, nodeType)
+  let { data: sps, error } = useServiceProviders(env)
 
   if (error) return <div className="text-red-600 dark:text-red-400">Error</div>
   if (!sps) return <div className="text-gray-600 dark:text-gray-300">Loading...</div>
@@ -102,19 +102,12 @@ function HealthRow({ sp, isStaging }: { sp: SP, isStaging: boolean }) {
   const totalCoreBlocks = consoleHealth?.totalBlocks
   const totalCoreTxs = consoleHealth?.totalBlocks
 
-  // API response doesn't include isRegistered
-  if (sp.isRegistered !== false) {
-    sp.isRegistered = true
-  }
   const coreHealth = health?.core?.health
 
   if (!health) {
     let healthStatus = 'loading'
     let healthStatusClass = ''
-    if (!sp.isRegistered) {
-      healthStatus = 'Unregistered'
-      healthStatusClass = 'is-unregistered'
-    } else if (dataError) {
+    if (dataError) {
       healthStatus = 'error'
       healthStatusClass = 'is-unhealthy'
     }
@@ -207,10 +200,7 @@ function HealthRow({ sp, isStaging }: { sp: SP, isStaging: boolean }) {
 
   let healthStatus = 'Healthy'
   let healthStatusClass = ''
-  if (!sp.isRegistered) {
-    healthStatus = 'Unregistered'
-    healthStatusClass = 'is-unregistered'
-  } else if (!isHealthy) {
+  if (!isHealthy) {
     healthStatus = 'Unhealthy'
     healthStatusClass = 'is-unhealthy'
   }

--- a/monitoring/healthz/src/useServiceProviders.ts
+++ b/monitoring/healthz/src/useServiceProviders.ts
@@ -1,28 +1,20 @@
 import useSWR from 'swr'
 import { getRegisteredNodes } from './utils/contracts'
 
-const prodEndpoint =
-  'https://api.audius.co'
+const prodEndpoint = 'https://api.audius.co'
 
-const stagingEndpoint =
-  'https://api.staging.audius.co'
-
-const devEndpoint = 'http://audius-discovery-provider-1/core/nodes'
+const stagingEndpoint = 'https://api.staging.audius.co'
 
 export type SP = {
-  delegateOwnerWallet: string
+  id: string
+  owner: string
   endpoint: string
-  isRegistered: boolean
-  type: {
-    id: string
-  }
-
-  health?: any
-  apiJson?: any
-  discoveryHealth?: any
+  blockNumber: string
+  delegateWallet: string
+  serviceType: string
 }
 
-export function apiGatewayFetcher(env: string) {
+function ethServiceFetcher(env: string) {
   // abort initial ga request in 5 seconds
   const controller = new AbortController()
   const reqTimeout = setTimeout(() => controller.abort(), 5000)
@@ -31,52 +23,29 @@ export function apiGatewayFetcher(env: string) {
   if (env === 'staging') {
     endpoint = stagingEndpoint
   }
-  if (env === 'dev') {
-    endpoint = devEndpoint
-  }
 
-  return fetch(`${endpoint}/content/verbose?all=true`, { signal: controller.signal })
+  return fetch(`${endpoint}/validators`, { signal: controller.signal })
     .then(async (resp) => {
       const data = await resp.json()
       const sps = data.data as SP[]
       clearTimeout(reqTimeout)
-
-      const hostSortKey = (sp: SP) =>
-        new URL(sp.endpoint).hostname.split('.').reverse().join('.')
-
-      // useful for finding duplicate wallets:
-      // const hostSortKey = (sp: SP) => sp.delegateOwnerWallet
-
-      sps.sort((a, b) => (hostSortKey(a) < hostSortKey(b) ? -1 : 1))
-      // console.log(sps)
       return sps
     })
     .catch(async (e) => {
-      // fallback to chain if GA is down
-      console.warn("falling back to chain rpc to gather SPs", e)
-      const sps = getRegisteredNodes(env)
-      return sps
+      console.error(`failed to fetch sps from ${endpoint}`, e)
     })
 }
 
 export function useServiceProviders(env: string) {
   const { data: sps, error } = useSWR<SP[]>([env], async () => {
-    const sps = await apiGatewayFetcher(env)
+    const sps = await ethServiceFetcher(env)
     hostSort(sps)
     return sps
   })
   return { data: sps, error }
 }
 
-export function useDiscoveryProviders() {
-  return useServiceProviders('prod', 'discovery')
-}
-
-export function useContentProviders() {
-  return useServiceProviders('prod', 'content')
-}
-
-export function hostSort(sps: SP[]) {
+function hostSort(sps: SP[]) {
   const hostSortKey = (sp: SP) =>
     new URL(sp.endpoint).hostname.split('.').reverse().join('.')
   sps.sort((a, b) => (hostSortKey(a) < hostSortKey(b) ? -1 : 1))


### PR DESCRIPTION
### Description

Healthz uses an api endpoint that returns an outdated list of registered nodes. This switches it to use the newly created endpoint, keeping info up-to-date.

This is helpful because healthz consolidates a bunch of useful information about the state of storage on various machines. This information may be ported to the go-openaudio console at some point, but for now this is the easiest and most accessible place for it.

This also removes additional unused UI components such as the `dev` tab.

### How Has This Been Tested?

Ran locally and confirmed it loads data from the new api endpoint.
