### PR TITLE
[PE-6453] Add artist pick ui

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
@@ -48,6 +48,7 @@ type Props = {
   trackId: ID
   duration: number
   isLongFormContent: boolean
+  isArtistPick?: boolean
 }
 
 export const LineupTileMetadata = ({
@@ -59,7 +60,8 @@ export const LineupTileMetadata = ({
   type,
   trackId,
   duration,
-  isLongFormContent
+  isLongFormContent,
+  isArtistPick = false
 }: Props) => {
   const styles = useStyles()
   const tileStyles = useTileStyles()
@@ -129,6 +131,7 @@ export const LineupTileMetadata = ({
         trackId={trackId}
         isLongFormContent={isLongFormContent}
         isCollection={false}
+        isArtistPick={isArtistPick}
       />
     </View>
   )

--- a/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
@@ -4,7 +4,7 @@ import { formatLineupTileDuration } from '@audius/common/utils'
 import { StyleSheet, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
-import { IconCheck } from '@audius/harmony-native'
+import { IconCheck, IconPin, IconText } from '@audius/harmony-native'
 import Text from 'app/components/text'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -14,7 +14,8 @@ const { getTrackPosition } = playbackPositionSelectors
 
 const messages = {
   timeLeft: 'left',
-  played: 'Played'
+  played: 'Played',
+  artistPick: 'Artist Pick'
 }
 
 const styles = StyleSheet.create({
@@ -41,13 +42,18 @@ type Props = {
    * Whether or not the track is long-form content (podcast/audiobook/etc)
    */
   isLongFormContent?: boolean
+  /**
+   * Whether or not this track is the artist pick
+   */
+  isArtistPick?: boolean
 }
 
 export const LineupTileTopRight = ({
   duration,
   trackId,
   isCollection,
-  isLongFormContent
+  isLongFormContent,
+  isArtistPick = false
 }: Props) => {
   const { secondary } = useThemeColors()
   const trackTileStyles = useTrackTileStyles()
@@ -72,6 +78,13 @@ export const LineupTileTopRight = ({
   return (
     <View style={styles.topRight}>
       <View style={trackTileStyles.statTextContainer}>
+        {isArtistPick ? (
+          <View style={{ marginRight: 8 }}>
+            <IconText icons={[{ icon: IconPin }]}>
+              {messages.artistPick}
+            </IconText>
+          </View>
+        ) : null}
         <Text
           style={[
             trackTileStyles.statText,

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -81,6 +81,7 @@ export const TrackTile = (props: TrackTileProps) => {
       track_id: track.track_id,
       genre: track.genre,
       stream_conditions: track.stream_conditions,
+
       ddex_app: track.ddex_app,
       is_unlisted: track.is_unlisted,
       album_backlink: track.album_backlink,
@@ -275,6 +276,7 @@ export const TrackTile = (props: TrackTileProps) => {
   const isOwner = currentUserId === track.owner_id
   const hideShare = !isOwner && track.field_visibility?.share === false
   const isReadonly = variant === 'readonly'
+  const isArtistPick = user?.artist_pick_track_id === track.track_id
 
   return (
     <Paper onPress={handlePress} style={style}>
@@ -291,6 +293,7 @@ export const TrackTile = (props: TrackTileProps) => {
         isLongFormContent={
           track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
         }
+        isArtistPick={isArtistPick}
       />
       <TrackTileStats
         trackId={track.track_id}

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -141,7 +141,7 @@ export const ProfileScreen = () => {
       <ScreenContent isOfflineCapable>
         {!profile ? (
           <ProfileScreenSkeleton />
-        ) : !profile.is_deactivated ? (
+        ) : profile.is_deactivated ? (
           <DeactivatedProfileTombstone />
         ) : (
           <>

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -25,7 +25,9 @@ import {
   Paper,
   Box,
   IconButton,
-  IconVolumeLevel2 as IconVolume
+  IconVolumeLevel2 as IconVolume,
+  IconPin,
+  IconText
 } from '@audius/harmony'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -45,6 +47,7 @@ import { TrackDogEar } from '../TrackDogEar'
 import { TrackTileStats } from '../TrackTileStats'
 import { ViewerActionButtons } from '../ViewerActionButtons'
 import { getTrackWithFallback, getUserWithFallback } from '../helpers'
+import { messages } from '../trackTileMessages'
 import { TrackTileSize } from '../types'
 
 import { TrackTileDuration } from './TrackTileDuration'
@@ -128,6 +131,8 @@ export const TrackTile = ({
     has_current_user_reposted: isReposted,
     has_current_user_saved: isFavorited
   } = trackWithFallback
+
+  const isArtistPick = partialUser?.artist_pick_track_id === trackId
 
   const { isFetchingNFTAccess, hasStreamAccess, isPreviewable } =
     useGatedContentAccess(trackWithFallback)
@@ -360,7 +365,10 @@ export const TrackTile = ({
                       disabled={disableActions}
                       ellipses
                     >
-                      <Text ellipses>{title}</Text>
+                      <Text ellipses>
+                        {title}
+                        {title}
+                      </Text>
                       {isTrackPlaying ? <IconVolume size='m' /> : null}
                     </TextLink>
                   )}
@@ -376,7 +384,14 @@ export const TrackTile = ({
                     />
                   )}
                 </Flex>
-                <TrackTileDuration trackId={trackId} isLoading={isLoading} />
+                <Flex gap='s' alignItems='center'>
+                  {isArtistPick ? (
+                    <IconText icons={[{ icon: IconPin }]}>
+                      {messages.artistPick}
+                    </IconText>
+                  ) : null}
+                  <TrackTileDuration trackId={trackId} isLoading={isLoading} />
+                </Flex>
               </Flex>
             </Flex>
           </Flex>

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -35,7 +35,9 @@ import {
   Flex,
   Box,
   IconButton,
-  IconKebabHorizontal
+  IconKebabHorizontal,
+  IconPin,
+  IconText
 } from '@audius/harmony'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
@@ -112,7 +114,8 @@ export const TrackTile = ({
       handle: user?.handle,
       name: user?.name,
       is_verified: user?.is_verified,
-      is_deactivated: user?.is_deactivated
+      is_deactivated: user?.is_deactivated,
+      artist_pick_track_id: user?.artist_pick_track_id
     })
   })
   const { user_id, handle, name, is_deactivated } =
@@ -168,6 +171,7 @@ export const TrackTile = ({
   } = trackWithFallback
 
   const isOwner = user_id === currentUserId
+  const isArtistPick = partialUser?.artist_pick_track_id === track_id
 
   const { isFetchingNFTAccess, hasStreamAccess } =
     useGatedContentAccess(trackWithFallback)
@@ -380,20 +384,25 @@ export const TrackTile = ({
     >
       <TrackDogEar trackId={track_id} hideUnlocked />
       <div className={styles.mainContent} onClick={handleClick}>
-        <Text
-          variant='body'
-          size='xs'
-          className={cn(styles.topRight, styles.statText)}
-        >
-          <div className={cn(styles.duration, fadeIn)}>
+        <div className={cn(styles.topRight, styles.statText)}>
+          <Flex
+            gap='s'
+            alignItems='center'
+            className={cn(styles.duration, fadeIn)}
+          >
+            {isArtistPick ? (
+              <IconText icons={[{ icon: IconPin }]}>
+                {messages.artistPick}
+              </IconText>
+            ) : null}
             {duration
               ? formatLineupTileDuration(
                   duration,
                   genre === Genre.PODCASTS || genre === Genre.AUDIOBOOKS
                 )
               : null}
-          </div>
-        </Text>
+          </Flex>
+        </div>
         <div className={styles.metadata}>
           <TrackTileArt
             id={track_id}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Displays an Artist Pick pin/label on track tiles across mobile and web, wires through isArtistPick, adds mobile overflow actions to set/unset, and fixes deactivated profile rendering.
> 
> - **Track Tiles (Mobile & Web)**
>   - Show `Artist Pick` badge (pin icon + label) in top-right metadata when `user.artist_pick_track_id === track_id`.
>   - Plumb `isArtistPick` through `LineupTileMetadata` → `LineupTileTopRight` (mobile) and compute in web/mobile tiles.
>   - Add imports and use of `IconPin`/`IconText`; use shared `messages.artistPick` on web.
> - **Mobile Overflow Actions**
>   - Include `SET_ARTIST_PICK` / `UNSET_ARTIST_PICK` for owners based on current state.
> - **Profile Screen (Mobile)**
>   - Correct conditional to render `DeactivatedProfileTombstone` when `profile.is_deactivated` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7163fe2e52b9e181afd61c07a6dff049ee1a9dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->