### PR TITLE
Prevent android app from handling oauth routes

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,8 @@
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
             </intent-filter>
 
+            <!-- Deeplink intent filter for audius.co and redirect.audius.co -->
+            <!-- Note: /oauth routes are black-listed via separate intent filter below -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -62,6 +64,18 @@
                 <data android:scheme="http" />
                 <data android:host="redirect.audius.co" />
                 <data android:host="audius.co" />
+            </intent-filter>
+            <!-- Intent filter for oauth routes with autoVerify=false to black-list from App Links verification -->
+            <!-- These routes will still reach MainActivity which redirects them to browser -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+                <data android:host="redirect.audius.co" />
+                <data android:host="audius.co" />
+                <data android:pathPrefix="/oauth" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/packages/mobile/android/app/src/main/java/co/audius/app/MainActivity.kt
+++ b/packages/mobile/android/app/src/main/java/co/audius/app/MainActivity.kt
@@ -79,10 +79,19 @@ class MainActivity : ReactActivity() {
       val path = data.path
       // If the path starts with /oauth, open in browser instead
       if (path != null && path.startsWith("/oauth")) {
-        val browserIntent = Intent(Intent.ACTION_VIEW, data)
-        browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivity(browserIntent)
-        return true
+        try {
+          val browserIntent = Intent(Intent.ACTION_VIEW, data)
+          browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+          // Verify that an activity can handle this intent
+          if (browserIntent.resolveActivity(packageManager) != null) {
+            startActivity(browserIntent)
+            return true
+          }
+        } catch (e: Exception) {
+          // If opening browser fails, at least prevent the app from handling the deeplink
+          e.printStackTrace()
+          return true
+        }
       }
     }
     


### PR DESCRIPTION
These are some recommended changes in lieu of not being able to do negative path patterns in the manifest.

oauth deep link may still get through, and our main-activity attempts to open browser with the url instead.