### PR TITLE
Fix other sdk dependencies

### DIFF
--- a/packages/common/turbo.json
+++ b/packages/common/turbo.json
@@ -4,9 +4,9 @@
     "build": {
       "dependsOn": [
         "@audius/fixed-decimal#build",
+        "@audius/eth#build",
         "@audius/spl#build"
       ]
     }
   }
 }
-

--- a/packages/mobile/turbo.json
+++ b/packages/mobile/turbo.json
@@ -5,6 +5,7 @@
       "dependsOn": [
         "@audius/common#build",
         "@audius/fixed-decimal#build",
+        "@audius/eth#build",
         "@audius/spl#build"
       ],
       "outputs": ["dist/**", "build/**"],

--- a/packages/web/turbo.json
+++ b/packages/web/turbo.json
@@ -11,6 +11,7 @@
         "@audius/common#build",
         "@audius/fixed-decimal#build",
         "@audius/harmony#build:css",
+        "@audius/eth#build",
         "@audius/spl#build"
       ],
       "outputLogs": "new-only",
@@ -22,6 +23,7 @@
         "@audius/common#build",
         "@audius/fixed-decimal#build",
         "@audius/harmony#build:css",
+        "@audius/eth#build",
         "@audius/spl#build"
       ],
       "outputLogs": "new-only"
@@ -33,6 +35,7 @@
         "@audius/common#build",
         "@audius/fixed-decimal#build",
         "@audius/harmony#build:css",
+        "@audius/eth#build",
         "@audius/spl#build"
       ],
       "outputLogs": "new-only"


### PR DESCRIPTION
Now that we are not building sdk, we need to add the other @audius dependencies it relies on to common/web/mobile turbo