### PR TITLE
Fix autoplay logic

### DIFF
--- a/packages/common/src/services/audio-player.ts
+++ b/packages/common/src/services/audio-player.ts
@@ -29,5 +29,6 @@ export type AudioPlayer = {
   getAudioPlaybackRate: () => number
   onBufferingChange: (isBuffering: boolean) => void
   onError: (error: string, data: string | Event) => void
+  onEnd: (() => void) | null
   audioCtx: Nullable<AudioContext>
 }

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -146,8 +146,6 @@ export function* watchPlay() {
       const isLongFormContent =
         track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
 
-      const onEndCallback = onEnd ?? queueActions.next
-
       const createEndChannel = async (url: string) => {
         const endChannel = eventChannel((emitter) => {
           audioPlayer.load(
@@ -157,8 +155,11 @@ export function* watchPlay() {
                 0
               ),
             () => {
-              if (onEndCallback) {
-                emitter(onEndCallback({}))
+              if (onEnd) {
+                const action = onEnd({})
+                if (action) {
+                  emitter(action)
+                }
               }
               if (isLongFormContent) {
                 emitter(
@@ -408,7 +409,13 @@ export function* handleAudioErrors() {
       const { shouldPreview } = calculatePlayerBehavior(track, playerBehavior)
       const streamObj = shouldPreview ? track?.preview : track?.stream
       if (streamObj?.mirrors && streamObj.mirrors.length + 1 > retries) {
-        yield* put(play({ trackId, retries: retries + 1 }))
+        yield* put(
+          play({
+            trackId,
+            retries: retries + 1,
+            onEnd: audioPlayer.onEnd ?? undefined
+          })
+        )
       } else {
         yield* put(
           errorAction({

--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -50,6 +50,7 @@ export class AudioPlayer {
   nextBufferIndex: number
   loadCounter: number
   recordListenedTime: number
+  onEnd: (() => void) | null
   endedListener: ((this: HTMLAudioElement, e: Event) => void) | null
   waitingListener: ((this: HTMLAudioElement, e: Event) => void) | null
   canPlayListener: ((this: HTMLAudioElement, e: Event) => void) | null
@@ -84,6 +85,9 @@ export class AudioPlayer {
     this.loadCounter = 0
 
     this.recordListenedTime = 5 /* seconds */
+
+    this.onEnd = null
+
     // Event listeners
     this.endedListener = null
     this.waitingListener = null
@@ -111,6 +115,7 @@ export class AudioPlayer {
     onEnd: () => void,
     mp3Url: string | null = null
   ) => {
+    this.onEnd = onEnd
     if (mp3Url) {
       this.stop()
       const prevVolume = this.audio.volume


### PR DESCRIPTION
Issue was when fetching from mirrors, we threw away the attached onEnd callback. This has been broken for a while, but because of recent content shuffling is much much more noticeable.

This logic all sucks can we please burn it to the ground.