### PR TITLE
Fix reanimated value reading in collapsible tab view

### DIFF
--- a/packages/mobile/patches/react-native-collapsible-tab-view+8.0.1.patch
+++ b/packages/mobile/patches/react-native-collapsible-tab-view+8.0.1.patch
@@ -1,0 +1,123 @@
+diff --git a/node_modules/react-native-collapsible-tab-view/lib/commonjs/Container.js b/node_modules/react-native-collapsible-tab-view/lib/commonjs/Container.js
+index 4c383f7..bd1b671 100644
+--- a/node_modules/react-native-collapsible-tab-view/lib/commonjs/Container.js
++++ b/node_modules/react-native-collapsible-tab-view/lib/commonjs/Container.js
+@@ -96,7 +96,9 @@ const Container = exports.Container = /*#__PURE__*/_react.default.memo(/*#__PURE
+   const headerScrollDistance = (0, _reactNativeReanimated.useDerivedValue)(() => {
+     return headerHeight !== undefined ? headerHeight - minHeaderHeight : 0;
+   }, [headerHeight, minHeaderHeight]);
+-  const indexDecimal = (0, _reactNativeReanimated.useSharedValue)(index.value);
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  // `index` is initialized from `initialIndex`, so we can seed `indexDecimal` directly.
++  const indexDecimal = (0, _reactNativeReanimated.useSharedValue)(initialIndex);
+   const afterRender = (0, _reactNativeReanimated.useSharedValue)(0);
+   _react.default.useEffect(() => {
+     afterRender.value = (0, _reactNativeReanimated.withDelay)(_helpers.ONE_FRAME_MS * 5, (0, _reactNativeReanimated.withTiming)(1, {
+diff --git a/node_modules/react-native-collapsible-tab-view/lib/commonjs/MaterialTabBar/TabBar.js b/node_modules/react-native-collapsible-tab-view/lib/commonjs/MaterialTabBar/TabBar.js
+index 3322cb0..d4634f8 100644
+--- a/node_modules/react-native-collapsible-tab-view/lib/commonjs/MaterialTabBar/TabBar.js
++++ b/node_modules/react-native-collapsible-tab-view/lib/commonjs/MaterialTabBar/TabBar.js
+@@ -102,7 +102,8 @@ const MaterialTabBar = ({
+       }
+     }
+   }, [scrollEnabled, tabNames]);
+-  const cancelNextScrollSync = (0, _reactNativeReanimated.useSharedValue)(index.value);
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  const cancelNextScrollSync = (0, _reactNativeReanimated.useSharedValue)(0);
+   const onScroll = (0, _reactNativeReanimated.useAnimatedScrollHandler)({
+     onScroll: event => {
+       tabsOffset.value = event.contentOffset.x;
+@@ -115,8 +116,9 @@ const MaterialTabBar = ({
+       isScrolling.value = false;
+     }
+   }, []);
+-  const currentIndexToSync = (0, _reactNativeReanimated.useSharedValue)(index.value);
+-  const targetIndexToSync = (0, _reactNativeReanimated.useSharedValue)(index.value);
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  const currentIndexToSync = (0, _reactNativeReanimated.useSharedValue)(0);
++  const targetIndexToSync = (0, _reactNativeReanimated.useSharedValue)(0);
+   (0, _reactNativeReanimated.useAnimatedReaction)(() => {
+     return index.value;
+   }, nextIndex => {
+diff --git a/node_modules/react-native-collapsible-tab-view/lib/module/Container.js b/node_modules/react-native-collapsible-tab-view/lib/module/Container.js
+index 50c3da7..3e26590 100644
+--- a/node_modules/react-native-collapsible-tab-view/lib/module/Container.js
++++ b/node_modules/react-native-collapsible-tab-view/lib/module/Container.js
+@@ -89,7 +89,9 @@ export const Container = /*#__PURE__*/React.memo(/*#__PURE__*/React.forwardRef((
+   const headerScrollDistance = useDerivedValue(() => {
+     return headerHeight !== undefined ? headerHeight - minHeaderHeight : 0;
+   }, [headerHeight, minHeaderHeight]);
+-  const indexDecimal = useSharedValue(index.value);
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  // `index` is initialized from `initialIndex`, so we can seed `indexDecimal` directly.
++  const indexDecimal = useSharedValue(initialIndex);
+   const afterRender = useSharedValue(0);
+   React.useEffect(() => {
+     afterRender.value = withDelay(ONE_FRAME_MS * 5, withTiming(1, {
+diff --git a/node_modules/react-native-collapsible-tab-view/lib/module/MaterialTabBar/TabBar.js b/node_modules/react-native-collapsible-tab-view/lib/module/MaterialTabBar/TabBar.js
+index 39d4211..553c706 100644
+--- a/node_modules/react-native-collapsible-tab-view/lib/module/MaterialTabBar/TabBar.js
++++ b/node_modules/react-native-collapsible-tab-view/lib/module/MaterialTabBar/TabBar.js
+@@ -95,7 +95,8 @@ const MaterialTabBar = ({
+       }
+     }
+   }, [scrollEnabled, tabNames]);
+-  const cancelNextScrollSync = useSharedValue(index.value);
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  const cancelNextScrollSync = useSharedValue(0);
+   const onScroll = useAnimatedScrollHandler({
+     onScroll: event => {
+       tabsOffset.value = event.contentOffset.x;
+@@ -108,8 +109,9 @@ const MaterialTabBar = ({
+       isScrolling.value = false;
+     }
+   }, []);
+-  const currentIndexToSync = useSharedValue(index.value);
+-  const targetIndexToSync = useSharedValue(index.value);
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  const currentIndexToSync = useSharedValue(0);
++  const targetIndexToSync = useSharedValue(0);
+   useAnimatedReaction(() => {
+     return index.value;
+   }, nextIndex => {
+diff --git a/node_modules/react-native-collapsible-tab-view/src/Container.tsx b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
+index e782b90..e181be8 100644
+--- a/node_modules/react-native-collapsible-tab-view/src/Container.tsx
++++ b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
+@@ -145,7 +145,9 @@ export const Container = React.memo(
+         }, [headerHeight, minHeaderHeight])
+ 
+       const indexDecimal: ContextType['indexDecimal'] = useSharedValue(
+-        index.value
++        // Avoid reading from a shared value during React render (Reanimated strict mode).
++        // `index` is initialized from `initialIndex`, so we can seed `indexDecimal` directly.
++        initialIndex
+       )
+ 
+       const afterRender = useSharedValue(0)
+diff --git a/node_modules/react-native-collapsible-tab-view/src/MaterialTabBar/TabBar.tsx b/node_modules/react-native-collapsible-tab-view/src/MaterialTabBar/TabBar.tsx
+index 60de38e..4e2dbbf 100644
+--- a/node_modules/react-native-collapsible-tab-view/src/MaterialTabBar/TabBar.tsx
++++ b/node_modules/react-native-collapsible-tab-view/src/MaterialTabBar/TabBar.tsx
+@@ -119,7 +119,8 @@ const MaterialTabBar = <T extends TabName = TabName>({
+     [scrollEnabled, tabNames]
+   )
+ 
+-  const cancelNextScrollSync = useSharedValue(index.value)
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  const cancelNextScrollSync = useSharedValue(0)
+ 
+   const onScroll = useAnimatedScrollHandler(
+     {
+@@ -137,8 +138,9 @@ const MaterialTabBar = <T extends TabName = TabName>({
+     []
+   )
+ 
+-  const currentIndexToSync = useSharedValue(index.value)
+-  const targetIndexToSync = useSharedValue(index.value)
++  // Avoid reading from a shared value during React render (Reanimated strict mode).
++  const currentIndexToSync = useSharedValue(0)
++  const targetIndexToSync = useSharedValue(0)
+ 
+   useAnimatedReaction(
+     () => {


### PR DESCRIPTION
Fixes issue where we get tons of reanimated warnings when rendering a profile screen. I think this may be part of the slowness we see on those pages as well, but still need to test on device.