### PR TITLE
TUS: Fix collection uploads, fix upload success tracking

### DIFF
--- a/packages/common/src/api/tan-query/upload/usePublishTracks.ts
+++ b/packages/common/src/api/tan-query/upload/usePublishTracks.ts
@@ -93,6 +93,15 @@ export const publishTracks = async (
             })
           )
 
+          dispatch(
+            updateProgress({
+              clientId: param.clientId,
+              stemIndex: null,
+              key: 'image',
+              progress: { status: ProgressStatus.COMPLETE }
+            })
+          )
+
           // Track success analytics for this individual track
           const analyticsKind =
             (kind ?? 'tracks') === 'tracks'

--- a/packages/common/src/api/tan-query/upload/useUpload.ts
+++ b/packages/common/src/api/tan-query/upload/useUpload.ts
@@ -287,6 +287,16 @@ export const useUpload = () => {
         return
       }
       const sdk = await audiusSdk()
+
+      // Finish the audio progress for the collection (there is none)
+      dispatch(
+        updateProgress({
+          clientId: 'collection-artwork',
+          key: 'audio',
+          stemIndex: null,
+          progress: { status: ProgressStatus.COMPLETE }
+        })
+      )
       const uploadHandle = sdk.tracks.uploadTrackFiles({
         imageFile: fileToSdk(formState.metadata.artwork.file, 'artwork'),
         onProgress: (key, { loaded, total }) => {


### PR DESCRIPTION
- When uploading collections, use the collection artwork for tracks (must have been a regression)
- When tracks finish publishing, mark the image uploads as complete (for collection uploads, no onProgress will fire to do so otherwise since they separately upload the images)