### PR TITLE
Fix tooltip onClick, fixing repost/favorite button

### DIFF
--- a/packages/harmony/src/components/tooltip/Tooltip.tsx
+++ b/packages/harmony/src/components/tooltip/Tooltip.tsx
@@ -208,12 +208,24 @@ export const Tooltip = ({
   }, [handleMouseLeave])
 
   // Handle click on trigger
-  const handleClick = useCallback(() => {
-    if (shouldDismissOnClick) {
-      setIsHiddenOverride(true)
-      setIsVisible(false)
-    }
-  }, [shouldDismissOnClick])
+  const handleClick = useCallback(
+    (event: any) => {
+      // Call the original onClick handler from the child if it exists
+      if (isValidElement(children)) {
+        const originalOnClick = (children as ReactElement).props?.onClick
+        if (typeof originalOnClick === 'function') {
+          originalOnClick(event)
+        }
+      }
+
+      // Handle tooltip dismissal
+      if (shouldDismissOnClick) {
+        setIsHiddenOverride(true)
+        setIsVisible(false)
+      }
+    },
+    [shouldDismissOnClick, children]
+  )
 
   // Calculate tooltip position
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI behavior change limited to tooltip click handling; main risk is potential double-handling or event mismatch for wrapped triggers.
> 
> **Overview**
> Fixes `Tooltip` click handling so wrapped elements (e.g., repost/favorite buttons) still receive their original `onClick` while the tooltip can optionally dismiss itself.
> 
> `handleClick` now forwards the click event to the child’s existing `onClick` (when `children` is a valid element) before applying the `shouldDismissOnClick` hide behavior, and updates hook deps accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b68b3ce0d6208f7f36af411f31f06e540f5269fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->