### PR TITLE
TUS: Fix track replace not updating image, reverting state behind modal

### DIFF
--- a/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
@@ -1,8 +1,8 @@
-import { Id, type ProgressHandler } from '@audius/sdk'
+import { Id, type CrossPlatformFile, type ProgressHandler } from '@audius/sdk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useDispatch, useStore } from 'react-redux'
 
-import { fileToSdk, trackMetadataForUploadToSdk } from '~/adapters/track'
+import { trackMetadataForUploadToSdk } from '~/adapters/track'
 import { useQueryContext } from '~/api/tan-query/utils'
 import { UserTrackMetadata } from '~/models'
 import { Feature } from '~/models/ErrorReporting'
@@ -29,8 +29,8 @@ export type UpdateTrackParams = {
   trackId: ID
   userId: ID
   metadata: Partial<TrackMetadataForUpload>
-  audioFile?: File
-  coverArtFile?: File
+  audioFile?: CrossPlatformFile
+  imageFile?: CrossPlatformFile
   onProgress?: ProgressHandler
 }
 
@@ -47,7 +47,7 @@ export const useUpdateTrack = () => {
       userId,
       metadata,
       audioFile,
-      coverArtFile,
+      imageFile,
       onProgress
     }: UpdateTrackParams) => {
       const sdk = await audiusSdk()
@@ -60,10 +60,8 @@ export const useUpdateTrack = () => {
       )
 
       const response = await sdk.tracks.updateTrack({
-        audioFile: audioFile ? fileToSdk(audioFile, 'audio') : undefined,
-        imageFile: coverArtFile
-          ? fileToSdk(coverArtFile, 'cover_art')
-          : undefined,
+        audioFile,
+        imageFile,
         trackId: Id.parse(trackId),
         userId: Id.parse(userId),
         metadata: sdkMetadata,
@@ -89,7 +87,12 @@ export const useUpdateTrack = () => {
 
       return response
     },
-    onMutate: async ({ trackId, metadata }): Promise<MutationContext> => {
+    onMutate: async ({
+      trackId,
+      metadata,
+      audioFile,
+      imageFile
+    }): Promise<MutationContext> => {
       // Cancel any outgoing refetches
       await queryClient.cancelQueries({
         queryKey: getTrackQueryKey(trackId)
@@ -98,8 +101,10 @@ export const useUpdateTrack = () => {
       // Snapshot the previous values
       const previousTrack = queryClient.getQueryData(getTrackQueryKey(trackId))
 
-      // Optimistically update track
-      if (previousTrack) {
+      // Only perform optimistic update if we're not uploading files
+      // When files are being uploaded, we can't accurately represent the new state
+      // until the upload completes
+      if (previousTrack && !audioFile && !imageFile) {
         primeTrackData({
           tracks: [{ ...previousTrack, ...metadata }] as UserTrackMetadata[],
           queryClient,

--- a/packages/common/src/api/tan-query/upload/useUpload.ts
+++ b/packages/common/src/api/tan-query/upload/useUpload.ts
@@ -92,7 +92,7 @@ const getTrackArtworkUploadHandles = async (
       ) {
         throw new Error('Artwork file missing')
       }
-      const file = fileToSdk(t.metadata.artwork.file, 'artwork')
+      const file = fileToSdk(t.metadata.artwork.file, 'cover_art')
       const uploadHandle = sdk.tracks.uploadTrackFiles({
         imageFile: file,
         onProgress: (key, { loaded, total }) => {

--- a/packages/web/src/hooks/useReplaceTrackAudio.ts
+++ b/packages/web/src/hooks/useReplaceTrackAudio.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { trackMetadataForUploadToSdk } from '@audius/common/adapters'
+import { fileToSdk, trackMetadataForUploadToSdk } from '@audius/common/adapters'
 import { useCurrentUserId, useUpdateTrack } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
 import {
@@ -48,13 +48,23 @@ export const useReplaceTrackAudio = () => {
         // Prepare metadata for upload
         const uploadMetadata = trackMetadataForUploadToSdk(metadata)
 
+        // Extract the cover art file if present
+        const imageFile =
+          metadata.artwork &&
+          'file' in metadata.artwork &&
+          metadata.artwork.file
+            ? fileToSdk(metadata.artwork.file, 'cover_art')
+            : undefined
+
         // Update the track using TanStack Query mutation
         await updateTrack({
           trackId,
           userId: currentUserId,
           audioFile: file,
+          imageFile,
           metadata: uploadMetadata,
-          onProgress: (_, progress) => {
+          onProgress: (type, progress) => {
+            if (type !== 'audio') return
             dispatch(
               replaceTrackProgressModalActions.set({
                 ...progress,


### PR DESCRIPTION
- Ensure track replace flow updates cover art as well
- Don't optimistically update track when doing upload, as it "reverts" the state of the edit form while the track is uploading