### PR TITLE
Fix tooltip lint

### DIFF
--- a/packages/harmony/src/components/tooltip/Tooltip.tsx
+++ b/packages/harmony/src/components/tooltip/Tooltip.tsx
@@ -212,7 +212,9 @@ export const Tooltip = ({
     (event: any) => {
       // Call the original onClick handler from the child if it exists
       if (isValidElement(children)) {
-        const originalOnClick = (children as ReactElement).props?.onClick
+        const originalOnClick = (
+          children as ReactElement<{ onClick?: any }>
+        ).props?.onClick()
         if (typeof originalOnClick === 'function') {
           originalOnClick(event)
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Although small, this touches click propagation logic and currently changes `onClick` from being passed through to being invoked during lookup, which could alter runtime behavior or throw if `onClick` is undefined.
> 
> **Overview**
> Updates `Tooltip`’s trigger `handleClick` logic to change how the child’s `onClick` prop is accessed/cast (using `ReactElement<{ onClick?: any }>`), before optionally forwarding the click event and dismissing the tooltip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f6bf6cdb913f6d5352988bf650e947be5cd220b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->