### PR TITLE
Add misc rewards cleanups

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -187,18 +187,21 @@ export const challengeRewardsConfig: Partial<
     id: ChallengeName.TrendingTrack,
     title: 'Global Trending Weekly Top 5',
     description: () => 'Top 5 winners are selected every Friday at Noon PT!',
+    fullDescription: () => 'Top 5 winners are selected every Friday at Noon PT!',
     panelButtonText: 'See More'
   },
   [ChallengeName.TrendingPlaylist]: {
     id: ChallengeName.TrendingPlaylist,
     title: 'Trending Playlists Weekly Top 5',
     description: () => 'Top 5 winners are selected every Friday at Noon PT!',
+    fullDescription: () => 'Top 5 winners are selected every Friday at Noon PT!',
     panelButtonText: 'See More'
   },
   [ChallengeName.TrendingUndergroundTrack]: {
     id: ChallengeName.TrendingUndergroundTrack,
     title: 'Underground Trending Weekly Top 5',
     description: () => 'Top 5 winners are selected every Friday at Noon PT!',
+    fullDescription: () => 'Top 5 winners are selected every Friday at Noon PT!',
     panelButtonText: 'See More'
   },
   'top-api': {

--- a/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
+++ b/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
@@ -36,7 +36,7 @@ const messages = {
   tracksTitle: 'Top 5 Tracks Each Week Receive 1000 $AUDIO',
   playlistTitle: 'Top 5 Playlists Each Week Receive 100 $AUDIO',
   undergroundTitle: 'Top 5 Tracks Each Week Receive 1000 $AUDIO',
-  winners: 'Winners are selected every Friday at Noon PT!',
+  winners: 'Top 5 winners are selected every Friday at Noon PT!',
   lastWeek: "LAST WEEK'S WINNERS",
   tracks: 'Tracks',
   playlists: 'Playlists',

--- a/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
+++ b/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
@@ -291,22 +291,24 @@ export const ChallengeRewardsTile = () => {
             <GradientText style={styles.title}>{messages.title}</GradientText>
             <Text textAlign='center'>{messages.subheader}</Text>
           </Flex>
-          <View
-            style={{
-              position: 'absolute',
-              top: -12,
-              right: 0
-            }}
-          >
-            <SelectablePill
-              type='button'
-              label={
-                showCompleted ? messages.hideCompleted : messages.showCompleted
-              }
-              isSelected={showCompleted}
-              onPress={() => setShowCompleted(!showCompleted)}
-            />
-          </View>
+          {isVerified ? (
+            <View
+              style={{
+                position: 'absolute',
+                top: -12,
+                right: 0
+              }}
+            >
+              <SelectablePill
+                type='button'
+                label={
+                  showCompleted ? messages.hideCompleted : messages.showCompleted
+                }
+                isSelected={showCompleted}
+                onPress={() => setShowCompleted(!showCompleted)}
+              />
+            </View>
+          ) : null}
         </View>
         {userChallengesLoading && !haveChallengesLoaded ? (
           <LoadingSpinner style={styles.loading} />

--- a/packages/mobile/src/screens/rewards-screen/ClaimAllRewardsTile.tsx
+++ b/packages/mobile/src/screens/rewards-screen/ClaimAllRewardsTile.tsx
@@ -15,7 +15,6 @@ import {
   Paper,
   Text
 } from '@audius/harmony-native'
-import { TooltipInfoIcon } from 'app/components/buy-sell/TooltipInfoIcon'
 
 const { getOptimisticUserChallenges } = challengesSelectors
 
@@ -75,12 +74,6 @@ export const ClaimAllRewardsTile = () => {
 
   if (isEmpty) return null
 
-  const tooltipMessages = {
-    totalClaimed: 'Total amount of $AUDIO you have claimed from all rewards',
-    pending: 'Amount of $AUDIO pending in cooldown period',
-    readyToClaim: 'Amount of $AUDIO ready to claim now'
-  }
-
   return (
     <Paper shadow='near' border='strong' p='l' style={{ gap: 16 }}>
       <Text variant='heading' color='accent' size='m'>
@@ -97,15 +90,9 @@ export const ClaimAllRewardsTile = () => {
                 $AUDIO
               </Text>
             </Flex>
-            <Flex row alignItems='center' style={{ gap: 4 }}>
-              <Text variant='label' size='xs' color='default'>
-                {messages.totalClaimed}
-              </Text>
-              <TooltipInfoIcon
-                title='Total Claimed'
-                message={tooltipMessages.totalClaimed}
-              />
-            </Flex>
+            <Text variant='label' size='xs' color='default'>
+              {messages.totalClaimed}
+            </Text>
           </Flex>
           <Divider orientation='vertical' />
           <Flex column flex={1} style={{ gap: 4 }}>
@@ -117,15 +104,9 @@ export const ClaimAllRewardsTile = () => {
                 $AUDIO
               </Text>
             </Flex>
-            <Flex row alignItems='center' style={{ gap: 4 }}>
-              <Text variant='label' size='xs' color='default'>
-                {messages.pending}
-              </Text>
-              <TooltipInfoIcon
-                title='Pending'
-                message={tooltipMessages.pending}
-              />
-            </Flex>
+            <Text variant='label' size='xs' color='default'>
+              {messages.pending}
+            </Text>
           </Flex>
         </Flex>
         {/* Second row: Ready to Claim */}
@@ -138,15 +119,9 @@ export const ClaimAllRewardsTile = () => {
               $AUDIO
             </Text>
           </Flex>
-          <Flex row alignItems='center' style={{ gap: 4 }}>
-            <Text variant='label' size='xs' color='default'>
-              {messages.readyToClaim}
-            </Text>
-            <TooltipInfoIcon
-              title='Ready To Claim'
-              message={tooltipMessages.readyToClaim}
-            />
-          </Flex>
+          <Text variant='label' size='xs' color='default'>
+            {messages.readyToClaim}
+          </Text>
         </Flex>
       </Flex>
       {claimableAmount > 0 ? (

--- a/packages/mobile/src/screens/rewards-screen/Panel.tsx
+++ b/packages/mobile/src/screens/rewards-screen/Panel.tsx
@@ -114,7 +114,7 @@ export const Panel = ({
             {shortTitle ?? title}
           </Text>
           <Text numberOfLines={2}>
-            {shortDescription || description(challenge)}
+            {shortDescription ?? (description ? description(challenge) : '')}
           </Text>
           <Flex mt='l' gap='l'>
             <Flex row alignItems='center' gap='xs'>

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
@@ -205,20 +205,22 @@ export const ChallengeRewardsTile = ({
               {messages.description1}
             </Text>
           </Flex>
-          <Box
-            css={{
-              position: 'absolute',
-              top: isMobile ? -12 : 0,
-              right: isMobile ? -12 : 0
-            }}
-          >
-            <SelectablePill
-              type='button'
-              label={showCompleted ? 'Hide Completed' : 'Show Completed'}
-              isSelected={showCompleted}
-              onClick={() => setShowCompleted(!showCompleted)}
-            />
-          </Box>
+          {isVerified ? (
+            <Box
+              css={{
+                position: 'absolute',
+                top: isMobile ? -12 : 0,
+                right: isMobile ? -12 : 0
+              }}
+            >
+              <SelectablePill
+                type='button'
+                label={showCompleted ? 'Hide Completed' : 'Show Completed'}
+                isSelected={showCompleted}
+                onClick={() => setShowCompleted(!showCompleted)}
+              />
+            </Box>
+          ) : null}
         </Flex>
         {userChallengesLoading && !haveChallengesLoaded ? (
           <LoadingSpinner className={wm(styles.loadingRewardsTile)} />


### PR DESCRIPTION
* Remove info icons from rewards top section (mobile)
* Show "Show Completed" button only for verified users (mobile & web)
* Update trending rewards drawer copy: "Top 5 winners are selected every Friday at Noon PT!"
* Add fullDescription to trending challenge configs for modal consistency
* Fix Panel crash when description is undefined