### PR TITLE
Use imageFile and audioFile everywhere for consistency

### DIFF
--- a/packages/common/src/api/tan-query/upload/usePublishCollection.ts
+++ b/packages/common/src/api/tan-query/upload/usePublishCollection.ts
@@ -107,7 +107,7 @@ const getPublishCollectionOptions = (context: PublishCollectionContext) =>
       if (params.collectionMetadata.is_album) {
         return await sdk.albums.createAlbum({
           userId: Id.parse(userId),
-          coverArtFile,
+          imageFile: coverArtFile,
           metadata: albumMetadataForCreateWithSDK(params.collectionMetadata),
           trackIds: publishedTracks
             .filter((t) => t.trackId && !t.error)
@@ -116,7 +116,7 @@ const getPublishCollectionOptions = (context: PublishCollectionContext) =>
       } else {
         return await sdk.playlists.createPlaylist({
           userId: Id.parse(userId),
-          coverArtFile,
+          imageFile: coverArtFile,
           metadata: playlistMetadataForCreateWithSDK(params.collectionMetadata),
           trackIds: publishedTracks
             .filter((t) => t.trackId && !t.error)

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -166,7 +166,7 @@ describe('AlbumsApi', () => {
     it('uploads an album if valid metadata is provided', async () => {
       const result = await albums.uploadAlbum({
         userId: '7eP5n',
-        coverArtFile: {
+        imageFile: {
           buffer: pngFile,
           name: 'coverArt'
         },
@@ -199,7 +199,7 @@ describe('AlbumsApi', () => {
       await expect(async () => {
         await albums.uploadAlbum({
           userId: '7eP5n',
-          coverArtFile: {
+          imageFile: {
             buffer: pngFile,
             name: 'coverArt'
           },
@@ -225,7 +225,7 @@ describe('AlbumsApi', () => {
       const result = await albums.updateAlbum({
         userId: '7eP5n',
         albumId: 'x5pJ3Aj',
-        coverArtFile: {
+        imageFile: {
           buffer: pngFile,
           name: 'coverArt'
         },
@@ -247,7 +247,7 @@ describe('AlbumsApi', () => {
         await albums.updateAlbum({
           userId: '7eP5n',
           albumId: 'x5pJ3Aj',
-          coverArtFile: {
+          imageFile: {
             buffer: pngFile,
             name: 'coverArt'
           },

--- a/packages/sdk/src/sdk/api/albums/types.ts
+++ b/packages/sdk/src/sdk/api/albums/types.ts
@@ -60,7 +60,7 @@ export const CreateAlbumSchema = z
   .object({
     albumId: z.optional(HashId),
     userId: HashId,
-    coverArtFile: z.optional(ImageFile),
+    imageFile: z.optional(ImageFile),
     metadata: CreateAlbumMetadataSchema,
     onProgress: z.optional(z.function()),
     trackIds: z.optional(z.array(HashId))
@@ -106,7 +106,7 @@ export const UpdateAlbumMetadataSchema = UploadAlbumMetadataSchema.partial()
 export const UploadAlbumSchema = z
   .object({
     userId: HashId,
-    coverArtFile: ImageFile,
+    imageFile: ImageFile,
     metadata: UploadAlbumMetadataSchema,
     onProgress: z.optional(z.function()),
     /**
@@ -123,7 +123,7 @@ export const UpdateAlbumSchema = z
   .object({
     userId: HashId,
     albumId: HashId,
-    coverArtFile: z.optional(ImageFile),
+    imageFile: z.optional(ImageFile),
     metadata: UpdateAlbumMetadataSchema,
     onProgress: z.optional(z.function())
   })

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
@@ -130,7 +130,7 @@ describe('PlaylistsApi', () => {
     it('creates a playlist if valid metadata is provided', async () => {
       const result = await playlists.createPlaylist({
         userId: '7eP5n',
-        coverArtFile: {
+        imageFile: {
           buffer: pngFile,
           name: 'coverArt'
         },
@@ -151,7 +151,7 @@ describe('PlaylistsApi', () => {
       await expect(async () => {
         await playlists.createPlaylist({
           userId: '7eP5n',
-          coverArtFile: {
+          imageFile: {
             buffer: pngFile,
             name: 'coverArt'
           },
@@ -166,7 +166,7 @@ describe('PlaylistsApi', () => {
     it('uploads a playlist if valid metadata is provided', async () => {
       const result = await playlists.uploadPlaylist({
         userId: '7eP5n',
-        coverArtFile: {
+        imageFile: {
           buffer: pngFile,
           name: 'coverArt'
         },
@@ -180,7 +180,7 @@ describe('PlaylistsApi', () => {
             title: 'BachGavotte'
           }
         ],
-        trackFiles: [
+        audioFiles: [
           {
             buffer: wavFile,
             name: 'trackArt'
@@ -199,7 +199,7 @@ describe('PlaylistsApi', () => {
       await expect(async () => {
         await playlists.uploadPlaylist({
           userId: '7eP5n',
-          coverArtFile: {
+          imageFile: {
             buffer: pngFile,
             name: 'coverArt'
           },
@@ -209,7 +209,7 @@ describe('PlaylistsApi', () => {
               title: 'BachGavotte'
             }
           ],
-          trackFiles: [
+          audioFiles: [
             {
               buffer: wavFile,
               name: 'trackArt'
@@ -294,7 +294,7 @@ describe('PlaylistsApi', () => {
       const result = await playlists.updatePlaylist({
         userId: '7eP5n',
         playlistId: 'x5pJ3Aj',
-        coverArtFile: {
+        imageFile: {
           buffer: pngFile,
           name: 'coverArt'
         },
@@ -316,7 +316,7 @@ describe('PlaylistsApi', () => {
         await playlists.updatePlaylist({
           userId: '7eP5n',
           playlistId: 'x5pJ3Aj',
-          coverArtFile: {
+          imageFile: {
             buffer: pngFile,
             name: 'coverArt'
           },

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
@@ -422,8 +422,8 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
   public async uploadPlaylistInternal<Metadata extends PlaylistMetadata>(
     {
       userId,
-      coverArtFile,
-      trackFiles,
+      imageFile,
+      audioFiles,
       onProgress,
       metadata,
       trackMetadatas
@@ -438,7 +438,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
         async () =>
           await this.storage
             .uploadFile({
-              file: coverArtFile,
+              file: imageFile,
               onProgress,
               metadata: {
                 template: 'img_square'
@@ -449,7 +449,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
           this.logger.info('Retrying uploadPlaylistCoverArt', e)
         }
       ),
-      ...trackFiles.map(
+      ...audioFiles.map(
         async (trackFile, idx) =>
           await retry3(
             async () =>
@@ -557,7 +557,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     {
       userId,
       playlistId,
-      coverArtFile,
+      imageFile,
       onProgress,
       metadata
     }: z.infer<typeof UpdatePlaylistSchema> & {
@@ -567,12 +567,12 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
   ) {
     // Upload cover art to storage node
     const coverArtResponse =
-      coverArtFile &&
+      imageFile &&
       (await retry3(
         async () =>
           await this.storage
             .uploadFile({
-              file: coverArtFile,
+              file: imageFile,
               onProgress,
               metadata: {
                 template: 'img_square'
@@ -611,7 +611,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
   public async createPlaylistInternal<Metadata extends PlaylistMetadata>(
     {
       userId,
-      coverArtFile,
+      imageFile,
       metadata,
       onProgress,
       trackIds,
@@ -621,12 +621,12 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
   ) {
     // Upload cover art to storage node
     const coverArtResponse =
-      coverArtFile &&
+      imageFile &&
       (await retry3(
         async () =>
           await this.storage
             .uploadFile({
-              file: coverArtFile,
+              file: imageFile,
               onProgress,
               metadata: {
                 template: 'img_square'

--- a/packages/sdk/src/sdk/api/playlists/types.ts
+++ b/packages/sdk/src/sdk/api/playlists/types.ts
@@ -35,7 +35,7 @@ export type CreatePlaylistMetadata = z.input<
 export const CreatePlaylistSchema = z
   .object({
     playlistId: z.optional(HashId),
-    coverArtFile: z.optional(ImageFile),
+    imageFile: z.optional(ImageFile),
     metadata: CreatePlaylistMetadataSchema,
     onProgress: z.optional(z.function()),
     trackIds: z.optional(z.array(HashId)),
@@ -88,7 +88,7 @@ export const UpdatePlaylistSchema = z
   .object({
     userId: HashId,
     playlistId: HashId,
-    coverArtFile: z.optional(ImageFile),
+    imageFile: z.optional(ImageFile),
     metadata: UpdatePlaylistMetadataSchema,
     onProgress: z.optional(z.function())
   })
@@ -99,14 +99,14 @@ export type UpdatePlaylistRequest = z.input<typeof UpdatePlaylistSchema>
 export const UploadPlaylistSchema = z
   .object({
     userId: HashId,
-    coverArtFile: ImageFile,
+    imageFile: ImageFile,
     metadata: UploadPlaylistMetadataSchema,
     onProgress: z.optional(z.function()),
     /**
      * Track metadata is populated from the playlist if fields are missing
      */
     trackMetadatas: z.array(PlaylistTrackMetadataSchema),
-    trackFiles: z.array(AudioFile)
+    audioFiles: z.array(AudioFile)
   })
   .strict()
 

--- a/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
@@ -187,7 +187,7 @@ function* confirmAddTrackToPlaylist(
           metadata: playlistMetadataForUpdateWithSDK(playlist),
           userId: Id.parse(userId),
           playlistId: Id.parse(playlistId),
-          coverArtFile: coverArtFile
+          imageFile: coverArtFile
             ? fileToSdk(coverArtFile, 'cover_art')
             : undefined
         })

--- a/packages/web/src/common/store/cache/collections/commonSagas.ts
+++ b/packages/web/src/common/store/cache/collections/commonSagas.ts
@@ -179,7 +179,7 @@ function* confirmEditPlaylist(
 
         if (formFields.is_album) {
           yield* call([sdk.albums, sdk.albums.updateAlbum], {
-            coverArtFile: coverArtFile
+            imageFile: coverArtFile
               ? fileToSdk(coverArtFile, 'cover_art')
               : undefined,
             metadata: albumMetadataForUpdateWithSDK(formFields),
@@ -188,7 +188,7 @@ function* confirmEditPlaylist(
           })
         } else {
           yield* call([sdk.playlists, sdk.playlists.updatePlaylist], {
-            coverArtFile: coverArtFile
+            imageFile: coverArtFile
               ? fileToSdk(coverArtFile, 'cover_art')
               : undefined,
             metadata: playlistMetadataForUpdateWithSDK(formFields),
@@ -310,7 +310,7 @@ function* confirmRemoveTrackFromPlaylist(
           metadata: playlistMetadataForUpdateWithSDK(playlist),
           userId: Id.parse(userId),
           playlistId: Id.parse(playlistId),
-          coverArtFile: coverArtFile
+          imageFile: coverArtFile
             ? fileToSdk(coverArtFile, 'cover_art')
             : undefined
         })


### PR DESCRIPTION
In `mjp-tus-upload` i started making tracks use `imageFile` and `audioFile` (lmk if feel strongly against) this pr gets albums/playlists following the same nomenclature. Docs update to follow,

Caveat: Keeping "coverArtFile" and "profilePicture" separate in UsersApi.