### PR TITLE
SDK: Refactor onProgress event/handler

### DIFF
--- a/packages/common/src/api/tan-query/collection/useUpdateCollection.ts
+++ b/packages/common/src/api/tan-query/collection/useUpdateCollection.ts
@@ -117,7 +117,7 @@ export const useUpdateCollection = () => {
       )
 
       const response = await sdk.playlists.updatePlaylist({
-        coverArtFile: coverArtFile
+        imageFile: coverArtFile
           ? fileToSdk(coverArtFile, 'cover_art')
           : undefined,
         playlistId: Id.parse(collectionId),
@@ -176,7 +176,7 @@ export const useUpdateCollection = () => {
       // Return context with the previous collection
       return { previousCollection, collectionUpdate }
     },
-    onError: (_err, { collectionId }, context?: MutationContext) => {
+    onError: (_err, _, context?: MutationContext) => {
       // If the mutation fails, roll back collection data
       if (context?.previousCollection) {
         primeCollectionData({

--- a/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
@@ -64,8 +64,8 @@ export const useUpdateTrack = () => {
         trackId: Id.parse(trackId),
         userId: Id.parse(userId),
         metadata: sdkMetadata,
-        onProgress: (type, progress) => {
-          if (type === 'audio') {
+        onProgress: (_, progress) => {
+          if (progress.key === 'audio') {
             dispatch(
               replaceTrackProgressModalActions.set({
                 ...progress,
@@ -183,10 +183,6 @@ export const useUpdateTrack = () => {
         feature: Feature.Edit,
         name: 'Edit Track'
       })
-    },
-    onSettled: (_, __, { trackId }) => {
-      // Always refetch after error or success to ensure cache is in sync with server
-      // queryClient.invalidateQueries({ queryKey: getTrackQueryKey(trackId) })
     }
   })
 }

--- a/packages/common/src/api/tan-query/upload/useUpload.ts
+++ b/packages/common/src/api/tan-query/upload/useUpload.ts
@@ -64,7 +64,7 @@ const getStemUploadTasks = async (
         const file = (stemFile as StemUploadWithFile).file
         const task = sdk.tracks.uploadTrackFiles({
           audioFile: fileToSdk(file, 'audio'),
-          onProgress: (key, { loaded, total, transcode }) => {
+          onProgress: (_, { key, loaded, total, transcode }) => {
             context.dispatch(
               updateProgress({
                 clientId: t.clientId,
@@ -115,7 +115,7 @@ const getCoverArtUploadTasks = async (
       const file = fileToSdk(t.metadata.artwork.file, 'cover_art')
       const task = sdk.tracks.uploadTrackFiles({
         imageFile: file,
-        onProgress: (key, { loaded, total }) => {
+        onProgress: (_, { key, loaded, total }) => {
           context.dispatch(
             uploadActions.updateProgress({
               clientId: t.clientId,
@@ -150,7 +150,7 @@ const getTrackUploadTasks = async (
   return tracks.map((t) => {
     const task = sdk.tracks.uploadTrackFiles({
       audioFile: fileToSdk(t.file, 'audio'),
-      onProgress: (key, { loaded, total, transcode }) => {
+      onProgress: (_, { key, loaded, total, transcode }) => {
         context.dispatch(
           uploadActions.updateProgress({
             clientId: t.clientId,
@@ -317,7 +317,7 @@ export const useUpload = () => {
 
       const uploadTask = sdk.tracks.uploadTrackFiles({
         imageFile: fileToSdk(imageFile, 'artwork'),
-        onProgress: (key, { loaded, total }) => {
+        onProgress: (_, { key, loaded, total }) => {
           dispatch(
             updateProgress({
               clientId: 'collection-artwork',

--- a/packages/common/src/api/tan-query/users/useUpdateUser.ts
+++ b/packages/common/src/api/tan-query/users/useUpdateUser.ts
@@ -66,7 +66,7 @@ export const useUpdateUser = () => {
       // Return context with the previous user
       return { previousUser }
     },
-    onError: (_err, { userId }, context?: MutationContext) => {
+    onError: (_err, _, context?: MutationContext) => {
       // If the mutation fails, roll back user data
       if (context?.previousUser) {
         primeUserData({

--- a/packages/common/src/store/upload/selectors.test.ts
+++ b/packages/common/src/store/upload/selectors.test.ts
@@ -15,7 +15,8 @@ describe('upload selectors', () => {
   it('starts at 0%', () => {
     const zero = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -26,7 +27,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '2',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -37,7 +39,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '3',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -54,7 +57,8 @@ describe('upload selectors', () => {
   it('is at 50% when uploading finished', () => {
     const half = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -65,7 +69,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '2',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -76,7 +81,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '3',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -93,7 +99,8 @@ describe('upload selectors', () => {
   it('is at 33% when two thirds transferred', () => {
     const twoThirdsUploaded = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -104,7 +111,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '2',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -115,7 +123,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '3',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -132,7 +141,8 @@ describe('upload selectors', () => {
   it('weights upload by file size', () => {
     const nearlyUploaded = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -143,7 +153,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '2',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -154,7 +165,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '3',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -171,7 +183,8 @@ describe('upload selectors', () => {
   it('includes stems tracks correctly', () => {
     const nearlyUploaded = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -181,7 +194,8 @@ describe('upload selectors', () => {
         },
         stems: [
           {
-            art: {
+            clientId: '1-1',
+            image: {
               status: ProgressStatus.UPLOADING
             },
             audio: {
@@ -192,7 +206,8 @@ describe('upload selectors', () => {
             stems: []
           },
           {
-            art: {
+            clientId: '1-2',
+            image: {
               status: ProgressStatus.UPLOADING
             },
             audio: {
@@ -203,7 +218,8 @@ describe('upload selectors', () => {
             stems: []
           },
           {
-            art: {
+            clientId: '1-3',
+            image: {
               status: ProgressStatus.UPLOADING
             },
             audio: {
@@ -216,7 +232,8 @@ describe('upload selectors', () => {
         ]
       },
       {
-        art: {
+        clientId: '2',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -227,7 +244,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '3',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -244,7 +262,8 @@ describe('upload selectors', () => {
   it('caps to 100%', () => {
     const completed = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -262,7 +281,8 @@ describe('upload selectors', () => {
   it('weights transcode by file size', () => {
     const completed = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -274,7 +294,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '2',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -292,7 +313,8 @@ describe('upload selectors', () => {
   it('treats errors as completed', () => {
     const completed = [
       {
-        art: {
+        clientId: '1',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {
@@ -304,7 +326,8 @@ describe('upload selectors', () => {
         stems: []
       },
       {
-        art: {
+        clientId: '2',
+        image: {
           status: ProgressStatus.UPLOADING
         },
         audio: {

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -180,7 +180,7 @@ describe('AlbumsApi', () => {
             title: 'BachGavotte'
           }
         ],
-        trackFiles: [
+        audioFiles: [
           {
             buffer: wavFile,
             name: 'trackArt'
@@ -209,7 +209,7 @@ describe('AlbumsApi', () => {
               title: 'BachGavotte'
             }
           ],
-          trackFiles: [
+          audioFiles: [
             {
               buffer: wavFile,
               name: 'trackArt'

--- a/packages/sdk/src/sdk/api/albums/types.ts
+++ b/packages/sdk/src/sdk/api/albums/types.ts
@@ -113,7 +113,7 @@ export const UploadAlbumSchema = z
      * Track metadata is populated from the album if fields are missing
      */
     trackMetadatas: z.array(AlbumTrackMetadataSchema),
-    trackFiles: z.array(AudioFile)
+    audioFiles: z.array(AudioFile)
   })
   .strict()
 

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
@@ -432,6 +432,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     },
     advancedOptions?: AdvancedOptions
   ) {
+    const progresses = audioFiles.map(() => 0)
     // Upload track audio and cover art to storage node
     const [coverArtResponse, ...audioResponses] = await Promise.all([
       retry3(
@@ -439,7 +440,11 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
           await this.storage
             .uploadFile({
               file: imageFile,
-              onProgress,
+              onProgress: (progress) =>
+                onProgress?.(
+                  progresses.reduce((a, b) => a + b, 0) / audioFiles.length,
+                  { ...progress, key: 'image' }
+                ),
               metadata: {
                 template: 'img_square'
               }
@@ -456,7 +461,17 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
               await this.storage
                 .uploadFile({
                   file: trackFile,
-                  onProgress,
+                  onProgress: (progress) => {
+                    progresses[idx] =
+                      (progress.loaded / progress.total) * 0.5 +
+                      progress.transcode * 0.5
+                    const overallProgress =
+                      progresses.reduce((a, b) => a + b, 0) / audioFiles.length
+                    onProgress?.(overallProgress, {
+                      ...progress,
+                      key: idx
+                    })
+                  },
                   metadata: {
                     template: 'audio',
                     ...this.trackUploadHelper.extractMediorumUploadOptions(

--- a/packages/sdk/src/sdk/api/playlists/types.ts
+++ b/packages/sdk/src/sdk/api/playlists/types.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
 
+import {
+  ProgressEventHandlerSchema,
+  ProgressEventSchema
+} from '../../services/Storage/types'
 import { DDEXResourceContributor, DDEXCopyright } from '../../types/DDEX'
 import { AudioFile, ImageFile } from '../../types/File'
 import { Genre } from '../../types/Genre'
@@ -90,18 +94,46 @@ export const UpdatePlaylistSchema = z
     playlistId: HashId,
     imageFile: z.optional(ImageFile),
     metadata: UpdatePlaylistMetadataSchema,
-    onProgress: z.optional(z.function())
+    onProgress: ProgressEventHandlerSchema.optional()
   })
   .strict()
 
-export type UpdatePlaylistRequest = z.input<typeof UpdatePlaylistSchema>
+export const UploadPlaylistProgressEventSchema = ProgressEventSchema.extend({
+  /**
+   * Index of the track being uploaded in the playlist tracks array, or 'image' if for the image
+   */
+  key: z.number().or(z.literal('image'))
+})
+
+/**
+ * The progress event for updating a playlist
+ */
+type UploadPlaylistProgressEvent = z.input<
+  typeof UploadPlaylistProgressEventSchema
+>
+
+export const UploadPlaylistProgressHandlerSchema = z
+  .function()
+  .args(z.number(), UploadPlaylistProgressEventSchema)
+  .returns(z.void())
+
+export type UploadPlaylistProgressHandler = (
+  /**
+   * Overall progress percentage (0-1)
+   */
+  progress: number,
+  /**
+   * The progress event
+   */
+  event: UploadPlaylistProgressEvent
+) => void
 
 export const UploadPlaylistSchema = z
   .object({
     userId: HashId,
     imageFile: ImageFile,
     metadata: UploadPlaylistMetadataSchema,
-    onProgress: z.optional(z.function()),
+    onProgress: z.optional(UploadPlaylistProgressHandlerSchema),
     /**
      * Track metadata is populated from the playlist if fields are missing
      */
@@ -110,7 +142,14 @@ export const UploadPlaylistSchema = z
   })
   .strict()
 
-export type UploadPlaylistRequest = z.input<typeof UploadPlaylistSchema>
+export type UpdatePlaylistRequest = z.input<typeof UpdatePlaylistSchema>
+
+export type UploadPlaylistRequest = Omit<
+  z.input<typeof UploadPlaylistSchema>,
+  'onProgress'
+> & {
+  onProgress?: UploadPlaylistProgressHandler
+}
 
 export const PublishPlaylistSchema = z
   .object({

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -157,6 +157,7 @@ export class TracksApi extends GeneratedTracksApi {
   uploadTrackFiles(params: UploadTrackFilesRequest): UploadTrackFilesTask {
     let audioUpload: UploadHandle | null = null
     let imageUpload: UploadHandle | null = null
+    let totalProgressPercentage = 0
     return {
       start: async () => {
         const { audioFile, imageFile, fileMetadata, onProgress } =
@@ -165,7 +166,11 @@ export class TracksApi extends GeneratedTracksApi {
         imageUpload = imageFile
           ? this.storage.uploadFile({
               file: imageFile,
-              onProgress,
+              onProgress: (progress) =>
+                onProgress?.(totalProgressPercentage, {
+                  key: 'image',
+                  ...progress
+                }),
               metadata: {
                 template: 'img_square',
                 filename: imageFile.name ?? undefined,
@@ -177,7 +182,16 @@ export class TracksApi extends GeneratedTracksApi {
         audioUpload = audioFile
           ? this.storage.uploadFile({
               file: audioFile,
-              onProgress,
+              onProgress: (progress) => {
+                // Only audio affects the total progress
+                totalProgressPercentage =
+                  (progress.loaded / progress.total) * 0.5 +
+                  progress.transcode * 0.5
+                onProgress?.(totalProgressPercentage, {
+                  key: 'audio',
+                  ...progress
+                })
+              },
               metadata: {
                 template: 'audio',
                 filename: audioFile.name ?? undefined,

--- a/packages/sdk/src/sdk/api/tracks/types.ts
+++ b/packages/sdk/src/sdk/api/tracks/types.ts
@@ -2,10 +2,7 @@ import type { WalletAdapter } from '@solana/wallet-adapter-base'
 import { z } from 'zod'
 
 import { PublicKeySchema } from '../../services/Solana'
-import {
-  ProgressHandlerSchema,
-  type ProgressHandler
-} from '../../services/Storage/types'
+import { ProgressEventSchema } from '../../services/Storage/types'
 import {
   DDEXResourceContributor,
   DDEXCopyright,
@@ -196,13 +193,43 @@ export const UploadTrackMetadataSchema = z.object({
 
 export type TrackMetadata = z.input<typeof UploadTrackMetadataSchema>
 
+export const UploadTrackFilesProgressEventSchema = ProgressEventSchema.extend({
+  /**
+   * Whether the event is for the audio or image file
+   */
+  key: z.enum(['audio', 'image'])
+})
+
+/**
+ * The progress event emitted during track file uploads
+ */
+type UploadTrackFilesProgressEvent = z.input<
+  typeof UploadTrackFilesProgressEventSchema
+>
+
+export const UploadTrackFilesProgressHandlerSchema = z
+  .function()
+  .args(z.number(), UploadTrackFilesProgressEventSchema)
+  .returns(z.void())
+
+export type UploadTrackFilesProgressHandler = (
+  /**
+   * Overall progress percentage (0-1)
+   */
+  progress: number,
+  /**
+   * The progress event
+   */
+  event: UploadTrackFilesProgressEvent
+) => void
+
 export const UploadTrackSchema = z
   .object({
     userId: HashId,
     audioFile: AudioFile,
     imageFile: ImageFile,
     metadata: UploadTrackMetadataSchema.strict(),
-    onProgress: z.optional(ProgressHandlerSchema)
+    onProgress: z.optional(UploadTrackFilesProgressHandlerSchema)
   })
   .strict()
 
@@ -212,7 +239,7 @@ export type UploadTrackRequest = Omit<
 > & {
   // Typing function manually because z.function() does not
   // support argument names
-  onProgress?: ProgressHandler
+  onProgress?: UploadTrackFilesProgressHandler
 }
 
 export const UploadTrackFilesSchema = z
@@ -225,7 +252,7 @@ export const UploadTrackFilesSchema = z
         previewStartSeconds: z.number().optional()
       })
       .optional(),
-    onProgress: z.optional(ProgressHandlerSchema)
+    onProgress: z.optional(UploadTrackFilesProgressHandlerSchema)
   })
   .strict()
 
@@ -235,7 +262,7 @@ export type UploadTrackFilesRequest = Omit<
 > & {
   // Typing function manually because z.function() does not
   // support argument names
-  onProgress?: ProgressHandler
+  onProgress?: UploadTrackFilesProgressHandler
 }
 
 export const UpdateTrackSchema = z
@@ -246,7 +273,7 @@ export const UpdateTrackSchema = z
     audioFile: z.optional(AudioFile),
     imageFile: z.optional(ImageFile),
     generatePreview: z.optional(z.boolean()),
-    onProgress: z.optional(ProgressHandlerSchema)
+    onProgress: z.optional(UploadTrackFilesProgressHandlerSchema)
   })
   .strict()
 
@@ -254,7 +281,7 @@ export type UpdateTrackRequest = Omit<
   z.input<typeof UpdateTrackSchema>,
   'onProgress'
 > & {
-  onProgress?: ProgressHandler
+  onProgress?: UploadTrackFilesProgressHandler
 }
 
 export const DeleteTrackSchema = z

--- a/packages/sdk/src/sdk/services/Storage/Storage.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.ts
@@ -47,6 +47,7 @@ export class Storage implements StorageService {
     const ac = new AbortController()
     let upload: tus.Upload | undefined
     let uploadPromise: Promise<UploadResponse> | undefined
+    let cachedTotal = 0
 
     return {
       start: async () => {
@@ -84,14 +85,13 @@ export class Storage implements StorageService {
                     : {})
                 },
                 onError: reject,
-                onProgress: (bytesUploaded: number, bytesTotal: number) => {
-                  onProgress?.(
-                    metadata.template === 'audio' ? 'audio' : 'image',
-                    {
-                      loaded: bytesUploaded,
-                      total: bytesTotal
-                    }
-                  )
+                onProgress: (loaded: number, total: number) => {
+                  cachedTotal = total
+                  onProgress?.({
+                    loaded,
+                    total,
+                    transcode: 0
+                  })
                 },
                 onSuccess: async () => {
                   const uploadId = upload?.url?.split('/').pop()
@@ -102,6 +102,7 @@ export class Storage implements StorageService {
                   const res = await this.pollProcessingStatus(
                     uploadId,
                     metadata.template,
+                    cachedTotal,
                     onProgress,
                     ac.signal
                   )
@@ -190,6 +191,7 @@ export class Storage implements StorageService {
   private async pollProcessingStatus(
     id: string,
     template: FileTemplate,
+    total: number,
     onProgress?: ProgressHandler,
     abortSignal?: AbortSignal
   ) {
@@ -221,8 +223,9 @@ export class Storage implements StorageService {
               `No transcoding progress increase for ${MAX_TRACK_TRANSCODE_NO_PROGRESS_TIMEOUT}ms. Progress stuck at ${lastTranscodeProgress}. id=${id}`
             )
           }
-
-          onProgress?.(template === 'audio' ? 'audio' : 'image', {
+          onProgress?.({
+            loaded: total,
+            total,
             transcode: resp.transcode_progress
           })
         }

--- a/packages/sdk/src/sdk/services/Storage/types.ts
+++ b/packages/sdk/src/sdk/services/Storage/types.ts
@@ -33,15 +33,24 @@ export type StorageServiceConfig = Partial<StorageServiceConfigInternal> & {
   storageNodeSelector: StorageNodeSelectorService
 }
 
-const ProgressUpdateArgsSchema = z.object({
-  loaded: z.number().optional(),
-  total: z.number().optional(),
-  transcode: z.number().optional()
+export const ProgressEventSchema = z.object({
+  /**
+   * Number of bytes loaded so far
+   */
+  loaded: z.number(),
+  /**
+   * Total number of bytes to be loaded
+   */
+  total: z.number(),
+  /**
+   * Progress of the transcoding process (0-1)
+   */
+  transcode: z.number()
 })
 
-export const ProgressHandlerSchema = z
+export const ProgressEventHandlerSchema = z
   .function()
-  .args(z.enum(['audio', 'image']), ProgressUpdateArgsSchema)
+  .args(ProgressEventSchema)
   .returns(z.void())
 
 const UploadCreatedHandlerSchema = z
@@ -55,7 +64,7 @@ const UploadCreatedHandlerSchema = z
 
 export type UploadCreatedHandler = z.input<typeof UploadCreatedHandlerSchema>
 
-export type ProgressHandler = z.input<typeof ProgressHandlerSchema>
+export type ProgressHandler = z.input<typeof ProgressEventHandlerSchema>
 
 export type FileTemplate = 'audio' | 'img_square' | 'img_backdrop'
 


### PR DESCRIPTION
- Updates `onProgress` event handlers to have the "total" progress percentage as the first argument (from [0-1])
- Updates `onProgress` events to _always_ include all data, not optionally exclude things. Eg. always report a transcode percentage, always report loaded and total even after finishing that part.
- Fixes a few places where I forgot to rename to `imageFile` and `audioFile`
- Fixes some type errors in common
- Fixes the selector test