### PR TITLE
Update mobile apps to 1.1.186, fix bundlesize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98207,6 +98207,12 @@
         "node": ">=18"
       }
     },
+    "packages/commands/node_modules/bn.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
+      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+      "license": "MIT"
+    },
     "packages/commands/node_modules/commander": {
       "version": "9.5.0",
       "license": "MIT",
@@ -98356,6 +98362,25 @@
       "license": "MIT",
       "dependencies": {
         "proxy-compare": "^3.0.0"
+      }
+    },
+    "packages/common/node_modules/redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "packages/common/node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/common/node_modules/type-fest": {
@@ -121891,6 +121916,12 @@
         "is-buffer": "^2.0.2"
       }
     },
+    "packages/identity-service/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
+    },
     "packages/identity-service/node_modules/cookie": {
       "version": "0.3.1",
       "license": "MIT",
@@ -122219,9 +122250,48 @@
         "node": ">= 0.8"
       }
     },
+    "packages/identity-service/node_modules/react": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.11.0.tgz",
+      "integrity": "sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/identity-service/node_modules/react-dom": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
+      "integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.17.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
+      }
+    },
     "packages/identity-service/node_modules/safe-buffer": {
       "version": "5.1.1",
       "license": "MIT"
+    },
+    "packages/identity-service/node_modules/scheduler": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+      "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "packages/identity-service/node_modules/scrypt-js": {
       "version": "2.0.3",
@@ -128146,6 +128216,16 @@
         "@types/babel__traverse": "*"
       }
     },
+    "packages/protocol-dashboard/node_modules/@types/bn.js": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.2.tgz",
+      "integrity": "sha512-dkpZu0szUtn9UXTmw+e0AJFd4D2XAxDnsCLdc05SfqpqzPEBft8eQr8uaFitfo/dUUOZERaLec2hHMG87A4Dxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "packages/protocol-dashboard/node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -133214,7 +133294,7 @@
         "base64url": "3.0.1",
         "browserify-zlib": "0.2.0",
         "buffer": "6.0.3",
-        "bundlesize": "1.0.0-beta.2",
+        "bundlesize": "0.18.2",
         "commander": "2.20.3",
         "constants-browserify": "^1.0.0",
         "crypto-browserify": "^3.12.0",

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -128,7 +128,7 @@ android {
         // versionCode is automatically incremented in CI
         versionCode 1
         // Make sure this is above the currently released Android version in the play store if your changes touch native code:
-        versionName "1.1.517"
+        versionName "1.1.518"
         resValue "string", "build_config_package", "co.audius.app"
         resConfigs "en"
     }

--- a/packages/mobile/ios/AudiusReactNative/Info.plist
+++ b/packages/mobile/ios/AudiusReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.185</string>
+	<string>1.1.186</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1400,7 +1400,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-netinfo (11.2.1):
+  - react-native-netinfo (11.4.1):
     - React-Core
   - react-native-notifications (5.1.0):
     - React-Core
@@ -1814,7 +1814,7 @@ PODS:
     - React-Core
   - RNCAsyncStorage (2.2.0):
     - React-Core
-  - RNCClipboard (1.13.2):
+  - RNCClipboard (1.16.3):
     - React-Core
   - RNCMaskedView (0.3.2):
     - DoubleConversion
@@ -2194,7 +2194,7 @@ DEPENDENCIES:
   - react-native-image-picker (from `../../../node_modules/react-native-image-picker`)
   - react-native-in-app-review (from `../node_modules/react-native-in-app-review`)
   - react-native-keyboard-controller (from `../../../node_modules/react-native-keyboard-controller`)
-  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
+  - "react-native-netinfo (from `../../../node_modules/@react-native-community/netinfo`)"
   - react-native-notifications (from `../node_modules/react-native-notifications`)
   - react-native-pager-view (from `../../../node_modules/react-native-pager-view`)
   - react-native-randombytes (from `../../../node_modules/react-native-randombytes`)
@@ -2236,7 +2236,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNBootSplash (from `../../../node_modules/react-native-bootsplash`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
-  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
+  - "RNCClipboard (from `../../../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - "RNFingerprintjsPro (from `../../../node_modules/@fingerprintjs/fingerprintjs-pro-react-native`)"
@@ -2380,7 +2380,7 @@ EXTERNAL SOURCES:
   react-native-keyboard-controller:
     :path: "../../../node_modules/react-native-keyboard-controller"
   react-native-netinfo:
-    :path: "../node_modules/@react-native-community/netinfo"
+    :path: "../../../node_modules/@react-native-community/netinfo"
   react-native-notifications:
     :path: "../node_modules/react-native-notifications"
   react-native-pager-view:
@@ -2464,7 +2464,7 @@ EXTERNAL SOURCES:
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
-    :path: "../node_modules/@react-native-clipboard/clipboard"
+    :path: "../../../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNDateTimePicker:
@@ -2561,7 +2561,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: f104798044ef2c9211c42a48025d0693b5f34981
   react-native-in-app-review: db8bb167a5f238e7ceca5c242d6b36ce8c4404a4
   react-native-keyboard-controller: 7c1271a9fe703b7ee588b75d6c486eda79e5081b
-  react-native-netinfo: 8a7fd3f7130ef4ad2fb4276d5c9f8d3f28d2df3d
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
   react-native-pager-view: d4742f3ffb0aacc4bb8d5c7b4f1805ef1ab0589a
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
@@ -2603,7 +2603,7 @@ SPEC CHECKSUMS:
   ReactCommon: 7ea8ee50e489e9cc75922f19a06ea45c1b59b4bd
   RNBootSplash: c2ae3f80f6c90979ee57977672f57e74981f85a5
   RNCAsyncStorage: 23e56519cc41d3bade3c8d4479f7760cb1c11996
-  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
+  RNCClipboard: dfeb43751adff21e588657b5b6c888c72f3aa68e
   RNCMaskedView: 6d4bf14f158d1a93484edf30850cbbd7ccbb8668
   RNDateTimePicker: a793ed8822283f576dd0a205a0916c5098c2611f
   RNFingerprintjsPro: eeda8165fe366f1039cd8823277295a525cb81b5

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,6 +10,7 @@
     "analyze": "env-cmd ./env/.env.bundle npm run build:prod",
     "analyze:ssr": "env-cmd ./env/.env.bundle npm run build:ssr:prod",
     "bundlesize:prod": "bundlesize --config bundlesize.prod.config.json",
+    "postinstall": "node scripts/apply-bundlesize-patch.js",
     "build:dev": "env-cmd ./env/.env.dev turbo run build && rm -rf build-development && mv build build-development",
     "build:prod-source-maps": "env-cmd ./env/.env.prod env-cmd ./env/.env.source-maps turbo run build && rm -rf build-production && mv build build-production",
     "build:prod": "env-cmd ./env/.env.prod turbo run build && rm -rf build-production && mv build build-production",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes native mobile dependency/version bumps and modifies install-time behavior via a new `postinstall` script, which can affect CI/build reproducibility if the patch script or dependency resolutions differ across environments.
> 
> **Overview**
> Bumps the mobile app release versions (Android `versionName` to `1.1.518`, iOS `CFBundleShortVersionString` to `1.1.186`) and updates iOS CocoaPods lockfile entries, including `react-native-netinfo` and `@react-native-clipboard/clipboard` versions and their resolved paths.
> 
> Fixes web build tooling by downgrading `bundlesize` to `0.18.2`, adding a `postinstall` hook to apply a local bundlesize patch, and updating `package-lock.json` with newly-resolved dependency entries (e.g., `bn.js`, `redux`, `symbol-observable`, `@types/bn.js`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d593fa24825746d4118257a52a9d5eedbc87f969. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->