### PR TITLE
Make entityManager service optional in API class constructors

### DIFF
--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
@@ -4,11 +4,9 @@ import { TransactionInstruction } from '@solana/web3.js'
 import type {
   ClaimableTokensClient,
   PaymentRouterClient,
-  SolanaRelayService,
-  StorageService
+  SolanaRelayService
 } from '../../services'
-import type { EntityManagerService } from '../../services/EntityManager/types'
-import type { LoggerService } from '../../services/Logger'
+import { Logger, type LoggerService } from '../../services/Logger'
 import type { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import { parseParams } from '../../utils/parseParams'
 import { prepareSplits } from '../../utils/preparePaymentSplits'
@@ -37,27 +35,30 @@ import {
   UnfavoriteAlbumRequest,
   RepostAlbumRequest,
   UnrepostAlbumRequest,
-  UpdateAlbumSchema
+  UpdateAlbumSchema,
+  type AlbumsApiServicesConfig
 } from './types'
 
 export class AlbumsApi {
   private readonly playlistsApi: PlaylistsApi
+  private logger: LoggerService
+  private claimableTokensClient: ClaimableTokensClient
+  private paymentRouterClient: PaymentRouterClient
+  private solanaRelay: SolanaRelayService
+  private solanaClient: SolanaClient
+
   constructor(
     configuration: Configuration,
-    storage: StorageService,
-    entityManager: EntityManagerService,
-    private logger: LoggerService,
-    private claimableTokensClient: ClaimableTokensClient,
-    private paymentRouterClient: PaymentRouterClient,
-    private solanaRelay: SolanaRelayService,
-    private solanaClient: SolanaClient
+    servicesConfig: AlbumsApiServicesConfig
   ) {
-    this.playlistsApi = new PlaylistsApi(
-      configuration,
-      storage,
-      entityManager,
-      logger
+    this.playlistsApi = new PlaylistsApi(configuration, servicesConfig)
+    this.logger = (servicesConfig.logger ?? new Logger()).createPrefixedLogger(
+      '[albums-api]'
     )
+    this.claimableTokensClient = servicesConfig.claimableTokensClient
+    this.paymentRouterClient = servicesConfig.paymentRouterClient
+    this.solanaRelay = servicesConfig.solanaRelay
+    this.solanaClient = servicesConfig.solanaClient
   }
 
   // READS

--- a/packages/sdk/src/sdk/api/albums/types.ts
+++ b/packages/sdk/src/sdk/api/albums/types.ts
@@ -1,6 +1,15 @@
 import { WalletAdapter } from '@solana/wallet-adapter-base'
 import { z } from 'zod'
 
+import type {
+  ClaimableTokensClient,
+  EntityManagerService,
+  LoggerService,
+  PaymentRouterClient,
+  SolanaClient,
+  SolanaRelayService,
+  StorageService
+} from '../../services'
 import { PublicKeySchema } from '../../services/Solana'
 import { DDEXResourceContributor, DDEXCopyright } from '../../types/DDEX'
 import { AudioFile, ImageFile } from '../../types/File'
@@ -15,6 +24,16 @@ import {
   UploadTrackMetadataSchema,
   USDCPurchaseConditions
 } from '../tracks/types'
+
+export type AlbumsApiServicesConfig = {
+  storage: StorageService
+  entityManager?: EntityManagerService
+  solanaRelay: SolanaRelayService
+  solanaClient: SolanaClient
+  claimableTokensClient: ClaimableTokensClient
+  paymentRouterClient: PaymentRouterClient
+  logger?: LoggerService
+}
 
 // Album request body types that wrap playlist types but use album field names
 export type CreateAlbumRequestBody = Omit<

--- a/packages/sdk/src/sdk/api/comments/CommentsAPI.ts
+++ b/packages/sdk/src/sdk/api/comments/CommentsAPI.ts
@@ -1,6 +1,6 @@
 import snakecaseKeys from 'snakecase-keys'
 
-import { LoggerService } from '../../services'
+import { UninitializedEntityManagerError } from '../../errors'
 import {
   Action,
   EntityManagerService,
@@ -33,16 +33,18 @@ import {
   EntityManagerDeleteCommentRequest,
   EntityManagerPinCommentRequest,
   EntityManagerReactCommentRequest,
-  EntityManagerReportCommentRequest
+  EntityManagerReportCommentRequest,
+  type CommentsApiServicesConfig
 } from './types'
 
 export class CommentsApi extends GeneratedCommentsApi {
+  private readonly entityManager?: EntityManagerService
   constructor(
     configuration: Configuration,
-    private readonly entityManager: EntityManagerService,
-    private readonly logger: LoggerService
+    services: CommentsApiServicesConfig
   ) {
     super(configuration)
+    this.entityManager = services.entityManager
   }
 
   async generateCommentId() {
@@ -66,6 +68,10 @@ export class CommentsApi extends GeneratedCommentsApi {
     )(params)
     const { userId, entityType = EntityType.TRACK, commentId } = metadata
     const newCommentId = commentId ?? (await this.generateCommentId())
+
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.COMMENT,
@@ -76,7 +82,6 @@ export class CommentsApi extends GeneratedCommentsApi {
         data: snakecaseKeys({ entityType, ...metadata })
       })
     })
-    this.logger.info('Successfully posted a comment')
     return encodeHashId(newCommentId)
   }
 
@@ -115,6 +120,9 @@ export class CommentsApi extends GeneratedCommentsApi {
       UpdateCommentSchema
     )(params)
     const { userId, entityId, trackId, body } = metadata
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.COMMENT,
@@ -158,6 +166,9 @@ export class CommentsApi extends GeneratedCommentsApi {
       DeleteCommentSchema
     )(params)
     const { userId, entityId } = metadata
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.COMMENT,
@@ -196,6 +207,9 @@ export class CommentsApi extends GeneratedCommentsApi {
       ReactCommentSchema
     )(params)
     const { userId, commentId, isLiked, trackId } = metadata
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.COMMENT,
@@ -253,6 +267,9 @@ export class CommentsApi extends GeneratedCommentsApi {
   async pinCommentWithEntityManager(params: EntityManagerPinCommentRequest) {
     const metadata = await parseParams('pinComment', PinCommentSchema)(params)
     const { userId, entityId, trackId, isPin } = metadata
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.COMMENT,
@@ -315,6 +332,9 @@ export class CommentsApi extends GeneratedCommentsApi {
       ReportCommentSchema
     )(params)
     const { userId, entityId } = metadata
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.COMMENT,
@@ -346,6 +366,9 @@ export class CommentsApi extends GeneratedCommentsApi {
    * Mute/unmute a user (entity manager only)
    */
   async muteUser(userId: number, mutedUserId: number, isMuted: boolean) {
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.USER,
@@ -365,6 +388,9 @@ export class CommentsApi extends GeneratedCommentsApi {
     entityId: number
     action: Action.MUTE | Action.UNMUTE
   }) {
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       ...config,
       metadata: ''

--- a/packages/sdk/src/sdk/api/comments/types.ts
+++ b/packages/sdk/src/sdk/api/comments/types.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod'
 
+import type { EntityManagerService } from '../../services'
 import { HashId } from '../../types/HashId'
 import type { CommentEntityType } from '../generated/default'
+
+export type CommentsApiServicesConfig = {
+  entityManager?: EntityManagerService
+}
 
 export type CommentMetadata = {
   body?: string

--- a/packages/sdk/src/sdk/api/dashboard-wallet-users/DashboardWalletUsersApi.ts
+++ b/packages/sdk/src/sdk/api/dashboard-wallet-users/DashboardWalletUsersApi.ts
@@ -1,3 +1,4 @@
+import { UninitializedEntityManagerError } from '../../errors'
 import type { EntityManagerService } from '../../services'
 import {
   Action,
@@ -14,15 +15,19 @@ import {
   CreateDashboardWalletUser,
   CreateDashboardWalletUserRequest,
   DeleteDashboardWalletUserRequest,
-  DeleteDashboardWalletUserSchema
+  DeleteDashboardWalletUserSchema,
+  type DashboardWalletUsersApiServicesConfig
 } from './types'
 
 export class DashboardWalletUsersApi extends GeneratedDashboardWalletUsersApi {
+  private readonly entityManager?: EntityManagerService
+
   constructor(
     config: Configuration,
-    private readonly entityManager: EntityManagerService
+    services: DashboardWalletUsersApiServicesConfig
   ) {
     super(config)
+    this.entityManager = services.entityManager
   }
 
   /**
@@ -52,6 +57,9 @@ export class DashboardWalletUsersApi extends GeneratedDashboardWalletUsersApi {
           }
         }
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.DASHBOARD_WALLET_USER,
@@ -80,6 +88,9 @@ export class DashboardWalletUsersApi extends GeneratedDashboardWalletUsersApi {
       DeleteDashboardWalletUserSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.DASHBOARD_WALLET_USER,

--- a/packages/sdk/src/sdk/api/dashboard-wallet-users/types.ts
+++ b/packages/sdk/src/sdk/api/dashboard-wallet-users/types.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod'
 
+import type { EntityManagerService } from '../../services'
 import { EthAddressSchema } from '../../types/EthAddress'
 import { HashId } from '../../types/HashId'
+
+export type DashboardWalletUsersApiServicesConfig = {
+  entityManager?: EntityManagerService
+}
 
 export const CreateDashboardWalletUser = z
   .object({

--- a/packages/sdk/src/sdk/api/developer-apps/DeveloperAppsApi.ts
+++ b/packages/sdk/src/sdk/api/developer-apps/DeveloperAppsApi.ts
@@ -1,5 +1,6 @@
 import { generatePrivateKey, privateKeyToAddress } from 'viem/accounts'
 
+import { UninitializedEntityManagerError } from '../../errors'
 import {
   createAppWalletClient,
   type EntityManagerService
@@ -24,7 +25,8 @@ import {
   EntityManagerUpdateDeveloperAppRequest,
   UpdateDeveloperAppSchema,
   EntityManagerDeleteDeveloperAppRequest,
-  DeleteDeveloperAppSchema
+  DeleteDeveloperAppSchema,
+  type DeveloperAppsApiServicesConfig
 } from './types'
 
 /** Extended params to allow bypassing entity manager for bearer token response */
@@ -34,11 +36,10 @@ type CreateDeveloperAppParams = CreateDeveloperAppRequest & {
 }
 
 export class DeveloperAppsApi extends GeneratedDeveloperAppsApi {
-  constructor(
-    config: Configuration,
-    private readonly entityManager: EntityManagerService
-  ) {
+  private readonly entityManager?: EntityManagerService
+  constructor(config: Configuration, services: DeveloperAppsApiServicesConfig) {
     super(config)
+    this.entityManager = services.entityManager
   }
 
   /**
@@ -66,6 +67,10 @@ export class DeveloperAppsApi extends GeneratedDeveloperAppsApi {
     const message = `Creating Audius developer app at ${unixTs}`
 
     const signature = await wallet.signMessage({ message })
+
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.DEVELOPER_APP,
@@ -195,6 +200,9 @@ export class DeveloperAppsApi extends GeneratedDeveloperAppsApi {
     const { appApiKey, name, userId, description, imageUrl } =
       await parseParams('updateDeveloperApp', UpdateDeveloperAppSchema)(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.DEVELOPER_APP,
@@ -240,6 +248,9 @@ export class DeveloperAppsApi extends GeneratedDeveloperAppsApi {
       DeleteDeveloperAppSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.DEVELOPER_APP,

--- a/packages/sdk/src/sdk/api/developer-apps/types.ts
+++ b/packages/sdk/src/sdk/api/developer-apps/types.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod'
 
+import type { EntityManagerService } from '../../services'
 import { HashId } from '../../types/HashId'
 import { isApiKeyValid } from '../../utils/apiKey'
 
 const DEVELOPER_APP_MAX_DESCRIPTION_LENGTH = 128
 const DEVELOPER_APP_MAX_IMAGE_URL_LENGTH = 2000
 const DEVELOPER_APP_IMAGE_URL_REGEX = /^(https?):\/\//i
+
+export type DeveloperAppsApiServicesConfig = {
+  entityManager?: EntityManagerService
+}
 
 export const CreateDeveloperAppSchema = z.object({
   name: z.string(),

--- a/packages/sdk/src/sdk/api/events/EventsApi.ts
+++ b/packages/sdk/src/sdk/api/events/EventsApi.ts
@@ -1,6 +1,6 @@
 import snakecaseKeys from 'snakecase-keys'
 
-import { LoggerService } from '../../services'
+import { UninitializedEntityManagerError } from '../../errors'
 import {
   EntityManagerService,
   EntityType,
@@ -19,17 +19,16 @@ import {
   UpdateEventRequest,
   UpdateEventSchema,
   DeleteEventRequest,
-  DeleteEventSchema
+  DeleteEventSchema,
+  type EventsApiServicesConfig
 } from './types'
 
 export class EventsApi extends GeneratedEventsApi {
-  constructor(
-    configuration: Configuration,
-    private readonly entityManager: EntityManagerService,
-    private readonly logger: LoggerService
-  ) {
+  private readonly entityManager?: EntityManagerService
+
+  constructor(configuration: Configuration, services: EventsApiServicesConfig) {
     super(configuration)
-    this.logger = logger.createPrefixedLogger('[events-api]')
+    this.entityManager = services.entityManager
   }
 
   async generateEventId() {
@@ -62,6 +61,9 @@ export class EventsApi extends GeneratedEventsApi {
     } = parsedParameters
     const entityId = eventId ?? (await this.generateEventId())
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       entityId,
       userId,
@@ -78,7 +80,6 @@ export class EventsApi extends GeneratedEventsApi {
         })
       })
     })
-    this.logger.info('Successfully created a event')
     return response
   }
 
@@ -93,6 +94,9 @@ export class EventsApi extends GeneratedEventsApi {
     )(params)
 
     const { userId, eventId, endDate, eventData } = parsedParameters
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       entityId: eventId,
       userId,
@@ -103,7 +107,6 @@ export class EventsApi extends GeneratedEventsApi {
         data: snakecaseKeys({ endDate, eventData })
       })
     })
-    this.logger.info('Successfully updated the event')
     return response
   }
 
@@ -119,6 +122,9 @@ export class EventsApi extends GeneratedEventsApi {
 
     const { userId, eventId } = parsedParameters
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       entityId: eventId,
       userId,
@@ -126,7 +132,6 @@ export class EventsApi extends GeneratedEventsApi {
       action: Action.DELETE,
       metadata: ''
     })
-    this.logger.info('Successfully deleted the event')
     return response
   }
 }

--- a/packages/sdk/src/sdk/api/events/types.ts
+++ b/packages/sdk/src/sdk/api/events/types.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
 
+import type { EntityManagerService } from '../../services'
 import { EventEventTypeEnum, EventEntityTypeEnum } from '../generated/default'
+
+export type EventsApiServicesConfig = {
+  entityManager?: EntityManagerService
+}
 
 // Base schema for event metadata
 export const EventMetadataSchema = z.object({

--- a/packages/sdk/src/sdk/api/grants/GrantsApi.ts
+++ b/packages/sdk/src/sdk/api/grants/GrantsApi.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   AddManagerRequest as GeneratedAddManagerRequest,
   ApproveGrantRequest as GeneratedApproveGrantRequest,
   Configuration,
@@ -8,6 +8,7 @@ import type {
   User,
   UsersApi
 } from '../../api/generated/default'
+import { UninitializedEntityManagerError } from '../../errors'
 import type { EntityManagerService } from '../../services'
 import {
   Action,
@@ -27,16 +28,17 @@ import {
   type EntityManagerApproveGrantRequest,
   type EntityManagerCreateGrantRequest,
   type EntityManagerRemoveManagerRequest,
-  type EntityManagerRevokeGrantRequest
+  type EntityManagerRevokeGrantRequest,
+  type GrantsApiServicesConfig
 } from './types'
 
 export class GrantsApi {
-  // eslint-disable-next-line no-useless-constructor
-  constructor(
-    _config: Configuration,
-    private readonly entityManager: EntityManagerService,
-    private readonly usersApi: UsersApi
-  ) {}
+  private readonly entityManager?: EntityManagerService
+  private readonly usersApi: UsersApi
+  constructor(config: Configuration, services: GrantsApiServicesConfig) {
+    this.entityManager = services.entityManager
+    this.usersApi = new UsersApi(config)
+  }
 
   async createGrantWithEntityManager(
     params: EntityManagerCreateGrantRequest,
@@ -47,6 +49,9 @@ export class GrantsApi {
       CreateGrantSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.GRANT,
@@ -87,6 +92,9 @@ export class GrantsApi {
     )(params)
     const managerUser = await this.getManagerUser(managerUserId, 'addManager')
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.GRANT,
@@ -132,6 +140,9 @@ export class GrantsApi {
       'removeManager'
     )
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.GRANT,
@@ -171,6 +182,9 @@ export class GrantsApi {
       RevokeGrantSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.GRANT,
@@ -210,6 +224,9 @@ export class GrantsApi {
       ApproveGrantSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.GRANT,

--- a/packages/sdk/src/sdk/api/grants/types.ts
+++ b/packages/sdk/src/sdk/api/grants/types.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod'
 
+import type { EntityManagerService } from '../../services'
 import { HashId } from '../../types/HashId'
 import { isApiKeyValid } from '../../utils/apiKey'
+
+export type GrantsApiServicesConfig = {
+  entityManager?: EntityManagerService
+}
 
 export const CreateGrantSchema = z.object({
   userId: HashId,

--- a/packages/sdk/src/sdk/api/notifications/NotificationsApi.ts
+++ b/packages/sdk/src/sdk/api/notifications/NotificationsApi.ts
@@ -2,6 +2,7 @@ import {
   NotificationsApi as GeneratedNotificationsApi,
   type Configuration
 } from '../../api/generated/default'
+import { UninitializedEntityManagerError } from '../../errors'
 import type { EntityManagerService } from '../../services'
 import { Action, EntityType } from '../../services/EntityManager/types'
 import { parseParams } from '../../utils/parseParams'
@@ -10,15 +11,15 @@ import {
   MarkAllNotificationsAsViewedRequest,
   UpdatePlaylistLastViewedAtRequest,
   MarkAllNotificationsAsViewedSchema,
-  UpdatePlaylistLastViewedAtSchema
+  UpdatePlaylistLastViewedAtSchema,
+  type NotificationsApiServicesConfig
 } from './types'
 
 export class NotificationsApi extends GeneratedNotificationsApi {
-  constructor(
-    config: Configuration,
-    private readonly entityManager: EntityManagerService
-  ) {
+  private readonly entityManager?: EntityManagerService
+  constructor(config: Configuration, services: NotificationsApiServicesConfig) {
     super(config)
+    this.entityManager = services.entityManager
   }
 
   /**
@@ -31,6 +32,9 @@ export class NotificationsApi extends GeneratedNotificationsApi {
       'markAllNotificationsAsViewed',
       MarkAllNotificationsAsViewedSchema
     )(params)
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.NOTIFICATION,
@@ -49,6 +53,9 @@ export class NotificationsApi extends GeneratedNotificationsApi {
       'updatePlaylistLastViewedAt',
       UpdatePlaylistLastViewedAtSchema
     )(params)
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.NOTIFICATION,

--- a/packages/sdk/src/sdk/api/notifications/types.ts
+++ b/packages/sdk/src/sdk/api/notifications/types.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
 
+import type { EntityManagerService } from '../../services'
 import { HashId } from '../../types/HashId'
+
+export type NotificationsApiServicesConfig = {
+  entityManager?: EntityManagerService
+}
 
 export const MarkAllNotificationsAsViewedSchema = z.object({
   userId: HashId

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
@@ -2,6 +2,7 @@ import { pick } from 'lodash'
 import snakecaseKeys from 'snakecase-keys'
 import type { z } from 'zod'
 
+import { UninitializedEntityManagerError } from '../../errors'
 import type { StorageService } from '../../services'
 import {
   Action,
@@ -9,10 +10,8 @@ import {
   EntityType,
   AdvancedOptions
 } from '../../services/EntityManager/types'
-import type { LoggerService } from '../../services/Logger'
 import { decodeHashId, encodeHashId } from '../../utils/hashId'
 import { parseParams } from '../../utils/parseParams'
-import { retry3 } from '../../utils/retry'
 import {
   Configuration,
   PlaylistsApi as GeneratedPlaylistsApi,
@@ -56,7 +55,8 @@ import {
   EntityManagerUpdatePlaylistRequest,
   type UpdatePlaylistRequestWithImage,
   type CreatePlaylistRequestWithFiles,
-  type UploadPlaylistRequest
+  type UploadPlaylistRequest,
+  type PlaylistsApiServicesConfig
 } from './types'
 
 // Returns current timestamp in seconds, which is the expected
@@ -66,19 +66,21 @@ const getCurrentTimestamp = () => {
 }
 
 export class PlaylistsApi extends GeneratedPlaylistsApi {
-  private readonly trackUploadHelper: TrackUploadHelper
+  private readonly storage: StorageService
+  private readonly entityManager?: EntityManagerService
 
+  private readonly trackUploadHelper: TrackUploadHelper
   private readonly tracksApi: TracksApi
+
   constructor(
     configuration: Configuration,
-    private readonly storage: StorageService,
-    private readonly entityManager: EntityManagerService,
-    private readonly logger: LoggerService
+    services: PlaylistsApiServicesConfig
   ) {
     super(configuration)
+    this.storage = services.storage
+    this.entityManager = services.entityManager
     this.tracksApi = new TracksApi(configuration)
     this.trackUploadHelper = new TrackUploadHelper(configuration)
-    this.logger = logger.createPrefixedLogger('[playlists-api]')
   }
 
   /** @hidden
@@ -373,6 +375,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       UpdatePlaylistSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId: parsedParameters.userId,
       entityType: EntityType.PLAYLIST,
@@ -432,6 +437,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       DeletePlaylistSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.PLAYLIST,
@@ -464,6 +472,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       FavoritePlaylistSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.PLAYLIST,
@@ -497,6 +508,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       UnfavoritePlaylistSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.PLAYLIST,
@@ -529,6 +543,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       RepostPlaylistSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.PLAYLIST,
@@ -568,6 +585,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       UnrepostPlaylistSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.PLAYLIST,
@@ -600,6 +620,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       SharePlaylistSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.PLAYLIST,
@@ -723,21 +746,15 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     // Upload cover art to storage node
     const coverArtResponse =
       imageFile &&
-      (await retry3(
-        async () =>
-          await this.storage
-            .uploadFile({
-              file: imageFile,
-              onProgress,
-              metadata: {
-                template: 'img_square'
-              }
-            })
-            .start(),
-        (e) => {
-          this.logger.info('Retrying uploadPlaylistCoverArt', e)
-        }
-      ))
+      (await this.storage
+        .uploadFile({
+          file: imageFile,
+          onProgress,
+          metadata: {
+            template: 'img_square'
+          }
+        })
+        .start())
 
     const playlistId = providedPlaylistId || (await this.generatePlaylistId())
     const timestamp = getCurrentTimestamp()
@@ -752,6 +769,9 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       playlistImageSizesMultihash: coverArtResponse?.orig_file_cid
     }
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     // Write playlist metadata to chain
     const response = await this.entityManager.manageEntity({
       userId,

--- a/packages/sdk/src/sdk/api/playlists/types.ts
+++ b/packages/sdk/src/sdk/api/playlists/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import type { EntityManagerService, StorageService } from '../../services'
 import { ProgressEventSchema } from '../../services/Storage/types'
 import { DDEXResourceContributor, DDEXCopyright } from '../../types/DDEX'
 import { AudioFile, ImageFile } from '../../types/File'
@@ -11,6 +12,11 @@ import {
   type UpdatePlaylistRequest
 } from '../generated/default'
 import { UploadTrackMetadataSchema } from '../tracks/types'
+
+export type PlaylistsApiServicesConfig = {
+  entityManager?: EntityManagerService
+  storage: StorageService
+}
 
 const CreatePlaylistMetadataSchema = z
   .object({

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -2,6 +2,7 @@ import { USDC } from '@audius/fixed-decimal'
 import { TransactionInstruction } from '@solana/web3.js'
 import snakecaseKeys from 'snakecase-keys'
 
+import { UninitializedEntityManagerError } from '../../errors'
 import type {
   EntityManagerService,
   ClaimableTokensClient,
@@ -13,7 +14,7 @@ import {
   EntityType,
   AdvancedOptions
 } from '../../services/EntityManager/types'
-import type { LoggerService } from '../../services/Logger'
+import { Logger, type LoggerService } from '../../services/Logger'
 import type { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import type { StorageService, UploadHandle } from '../../services/Storage'
 import { decodeHashId, encodeHashId } from '../../utils/hashId'
@@ -70,26 +71,34 @@ import {
   type UpdateTrackRequestWithFiles,
   type CreateTrackRequestWithFiles,
   PublishStemSchema,
-  UploadTrackSchema
+  UploadTrackSchema,
+  type TracksApiServicesConfig
 } from './types'
 
 // Extend that new class
 export class TracksApi extends GeneratedTracksApi {
   private readonly trackUploadHelper: TrackUploadHelper
 
-  constructor(
-    configuration: Configuration,
-    private readonly storage: StorageService,
-    private readonly entityManager: EntityManagerService,
-    private readonly logger: LoggerService,
-    private readonly claimableTokensClient: ClaimableTokensClient,
-    private readonly paymentRouterClient: PaymentRouterClient,
-    private readonly solanaRelay: SolanaRelayService,
-    private readonly solanaClient: SolanaClient
-  ) {
+  private readonly storage: StorageService
+  private readonly entityManager?: EntityManagerService
+  private readonly logger: LoggerService
+  private readonly claimableTokensClient: ClaimableTokensClient
+  private readonly paymentRouterClient: PaymentRouterClient
+  private readonly solanaRelay: SolanaRelayService
+  private readonly solanaClient: SolanaClient
+
+  constructor(configuration: Configuration, services: TracksApiServicesConfig) {
     super(configuration)
     this.trackUploadHelper = new TrackUploadHelper(configuration)
-    this.logger = logger.createPrefixedLogger('[tracks-api]')
+    this.logger = (services.logger ?? new Logger()).createPrefixedLogger(
+      '[tracks-api]'
+    )
+    this.storage = services.storage
+    this.entityManager = services.entityManager
+    this.claimableTokensClient = services.claimableTokensClient
+    this.paymentRouterClient = services.paymentRouterClient
+    this.solanaRelay = services.solanaRelay
+    this.solanaClient = services.solanaClient
   }
 
   /**
@@ -324,6 +333,9 @@ export class TracksApi extends GeneratedTracksApi {
       throw new Error('writeTrackToChain: userId could not be decoded')
     }
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     const response = await this.entityManager.manageEntity({
       userId: decodedUserId,
       entityType: EntityType.TRACK,
@@ -410,6 +422,9 @@ export class TracksApi extends GeneratedTracksApi {
       UpdateTrackSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     // Write metadata to chain
     return await this.entityManager.manageEntity({
       userId,
@@ -516,6 +531,9 @@ export class TracksApi extends GeneratedTracksApi {
       DeleteTrackSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TRACK,
@@ -552,6 +570,9 @@ export class TracksApi extends GeneratedTracksApi {
       FavoriteTrackSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TRACK,
@@ -589,6 +610,9 @@ export class TracksApi extends GeneratedTracksApi {
       UnfavoriteTrackSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TRACK,
@@ -625,6 +649,9 @@ export class TracksApi extends GeneratedTracksApi {
       ShareTrackSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TRACK,
@@ -661,6 +688,9 @@ export class TracksApi extends GeneratedTracksApi {
       RepostTrackSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TRACK,
@@ -703,6 +733,9 @@ export class TracksApi extends GeneratedTracksApi {
       UnrepostTrackSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TRACK,
@@ -740,6 +773,10 @@ export class TracksApi extends GeneratedTracksApi {
       RecordTrackDownloadSchema
     )(params)
     const location = await getLocation({ logger: this.logger })
+
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TRACK,

--- a/packages/sdk/src/sdk/api/tracks/types.ts
+++ b/packages/sdk/src/sdk/api/tracks/types.ts
@@ -1,8 +1,19 @@
 import type { WalletAdapter } from '@solana/wallet-adapter-base'
 import { z } from 'zod'
 
+import type {
+  ClaimableTokensClient,
+  EntityManagerService,
+  LoggerService,
+  PaymentRouterClient,
+  SolanaClient,
+  SolanaRelayService
+} from '../../services'
 import { PublicKeySchema } from '../../services/Solana'
-import { ProgressEventSchema } from '../../services/Storage/types'
+import {
+  ProgressEventSchema,
+  type StorageService
+} from '../../services/Storage/types'
 import {
   DDEXResourceContributor,
   DDEXCopyright,
@@ -25,6 +36,16 @@ const messages = {
   artworkRequiredError: 'Artwork is required',
   genreRequiredError: 'Genre is required',
   genreAllError: 'Genre cannot be set to "All Genres"'
+}
+
+export type TracksApiServicesConfig = {
+  storage: StorageService
+  entityManager?: EntityManagerService
+  logger?: LoggerService
+  claimableTokensClient: ClaimableTokensClient
+  paymentRouterClient: PaymentRouterClient
+  solanaRelay: SolanaRelayService
+  solanaClient: SolanaClient
 }
 
 export const EthCollectibleGatedConditions = z

--- a/packages/sdk/src/sdk/api/users/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.ts
@@ -1,6 +1,7 @@
 import { wAUDIO } from '@audius/fixed-decimal'
 import snakecaseKeys from 'snakecase-keys'
 
+import { UninitializedEntityManagerError } from '../../errors'
 import type { StorageService } from '../../services'
 import { EmailEncryptionService } from '../../services/Encryption'
 import {
@@ -53,19 +54,24 @@ import {
   type UpdateUserRequestWithFiles,
   type CreateUserRequestWithFiles,
   type UserFileUploadParams,
-  type EntityManagerPlaylistLibraryContents
+  type EntityManagerPlaylistLibraryContents,
+  type UsersApiServicesConfig
 } from './types'
 
 export class UsersApi extends GeneratedUsersApi {
-  constructor(
-    configuration: Configuration,
-    private readonly storage: StorageService,
-    private readonly entityManager: EntityManagerService,
-    private readonly claimableTokens: ClaimableTokensClient,
-    private readonly solanaClient: SolanaClient,
-    private readonly emailEncryption: EmailEncryptionService
-  ) {
+  private readonly storage: StorageService
+  private readonly entityManager?: EntityManagerService
+  private readonly claimableTokens: ClaimableTokensClient
+  private readonly solanaClient: SolanaClient
+  private readonly emailEncryption: EmailEncryptionService
+
+  constructor(configuration: Configuration, services: UsersApiServicesConfig) {
     super(configuration)
+    this.storage = services.storage
+    this.entityManager = services.entityManager
+    this.claimableTokens = services.claimableTokensClient
+    this.solanaClient = services.solanaClient
+    this.emailEncryption = services.emailEncryptionService
   }
 
   /** @hidden
@@ -107,6 +113,9 @@ export class UsersApi extends GeneratedUsersApi {
 
     const cid = (await generateMetadataCidV1(entityMetadata)).toString()
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     // Write metadata to chain
     const { blockHash, blockNumber } = await this.entityManager.manageEntity({
       userId,
@@ -159,6 +168,9 @@ export class UsersApi extends GeneratedUsersApi {
       userId
     }
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     // Write metadata to chain
     const { blockHash, blockNumber } = await this.entityManager.manageEntity({
       userId,
@@ -189,6 +201,9 @@ export class UsersApi extends GeneratedUsersApi {
     )(params)
     const cid = (await generateMetadataCidV1(metadata)).toString()
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     // Write metadata to chain
     return await this.entityManager.manageEntity({
       userId,
@@ -317,6 +332,9 @@ export class UsersApi extends GeneratedUsersApi {
       FollowUserSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.USER,
@@ -355,6 +373,9 @@ export class UsersApi extends GeneratedUsersApi {
       UnfollowUserSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.USER,
@@ -393,6 +414,9 @@ export class UsersApi extends GeneratedUsersApi {
       SubscribeToUserSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.USER,
@@ -431,6 +455,9 @@ export class UsersApi extends GeneratedUsersApi {
       UnsubscribeFromUserSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.USER,
@@ -613,6 +640,9 @@ export class UsersApi extends GeneratedUsersApi {
       SendTipReactionRequestSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.TIP,
@@ -746,6 +776,9 @@ export class UsersApi extends GeneratedUsersApi {
       access_grants: accessGrants
     }
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId: emailOwnerUserId,
       entityType,
@@ -775,6 +808,9 @@ export class UsersApi extends GeneratedUsersApi {
       AddAssociatedWalletSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.ASSOCIATED_WALLET,
@@ -804,6 +840,9 @@ export class UsersApi extends GeneratedUsersApi {
       RemoveAssociatedWalletSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.ASSOCIATED_WALLET,
@@ -828,6 +867,9 @@ export class UsersApi extends GeneratedUsersApi {
       UpdateCollectiblesSchema
     )(params)
 
+    if (!this.entityManager) {
+      throw new UninitializedEntityManagerError()
+    }
     return await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.COLLECTIBLES,

--- a/packages/sdk/src/sdk/api/users/types.ts
+++ b/packages/sdk/src/sdk/api/users/types.ts
@@ -1,12 +1,27 @@
 import { z } from 'zod'
 
-import type { CreateUserRequest, UpdateUserRequest } from '../..'
+import type {
+  ClaimableTokensClient,
+  EmailEncryptionService,
+  EntityManagerService,
+  SolanaClient,
+  StorageService
+} from '../../services'
 import { ProgressHandler } from '../../services/Storage/types'
 import { EthAddressSchema } from '../../types/EthAddress'
 import { ImageFile } from '../../types/File'
 import { HashId } from '../../types/HashId'
 import { SolanaAddressSchema } from '../../types/SolanaAddress'
 import { getReaction, reactionsMap } from '../../utils/reactionsMap'
+import type { CreateUserRequest, UpdateUserRequest } from '../generated/default'
+
+export type UsersApiServicesConfig = {
+  storage: StorageService
+  entityManager?: EntityManagerService
+  claimableTokensClient: ClaimableTokensClient
+  solanaClient: SolanaClient
+  emailEncryptionService: EmailEncryptionService
+}
 
 export const UserEventsSchema = z.object({
   referrer: z.optional(HashId),

--- a/packages/sdk/src/sdk/createSdkWithApiSecret.ts
+++ b/packages/sdk/src/sdk/createSdkWithApiSecret.ts
@@ -434,45 +434,11 @@ const initializeApis = ({
     basePath
   })
 
-  const tracks = new TracksApi(
-    apiClientConfig,
-    services.storage,
-    services.entityManager,
-    services.logger,
-    services.claimableTokensClient,
-    services.paymentRouterClient,
-    services.solanaRelay,
-    services.solanaClient
-  )
-  const users = new UsersApi(
-    apiClientConfig,
-    services.storage,
-    services.entityManager,
-    services.claimableTokensClient,
-    services.solanaClient,
-    services.emailEncryptionService
-  )
-  const albums = new AlbumsApi(
-    apiClientConfig,
-    services.storage,
-    services.entityManager,
-    services.logger,
-    services.claimableTokensClient,
-    services.paymentRouterClient,
-    services.solanaRelay,
-    services.solanaClient
-  )
-  const playlists = new PlaylistsApi(
-    apiClientConfig,
-    services.storage,
-    services.entityManager,
-    services.logger
-  )
-  const comments = new CommentsApi(
-    apiClientConfig,
-    services.entityManager,
-    services.logger
-  )
+  const tracks = new TracksApi(apiClientConfig, services)
+  const users = new UsersApi(apiClientConfig, services)
+  const albums = new AlbumsApi(apiClientConfig, services)
+  const playlists = new PlaylistsApi(apiClientConfig, services)
+  const comments = new CommentsApi(apiClientConfig, services)
   const challenges = new ChallengesApi(apiClientConfig)
   const coins = new CoinsApi(apiClientConfig)
   const wallets = new WalletApi(apiClientConfig)
@@ -492,28 +458,18 @@ const initializeApis = ({
     services.logger
   )
 
-  const grants = new GrantsApi(apiClientConfig, services.entityManager, users)
+  const grants = new GrantsApi(apiClientConfig, services)
 
-  const developerApps = new DeveloperAppsApi(
-    apiClientConfig,
-    services.entityManager
-  )
+  const developerApps = new DeveloperAppsApi(apiClientConfig, services)
 
   const dashboardWalletUsers = new DashboardWalletUsersApi(
     apiClientConfig,
-    services.entityManager
+    services
   )
 
-  const notifications = new NotificationsApi(
-    apiClientConfig,
-    services.entityManager
-  )
+  const notifications = new NotificationsApi(apiClientConfig, services)
 
-  const events = new EventsApi(
-    apiClientConfig,
-    services.entityManager,
-    services.logger
-  )
+  const events = new EventsApi(apiClientConfig, services)
   const explore = new ExploreApi(apiClientConfig)
   const search = new SearchApi(apiClientConfig)
 

--- a/packages/sdk/src/sdk/errors.ts
+++ b/packages/sdk/src/sdk/errors.ts
@@ -1,0 +1,8 @@
+export class UninitializedEntityManagerError extends Error {
+  constructor() {
+    super(
+      'Entity manager is uninitialized. This can happen when calling an API method that requires an API secret in the SDK configuration. Please ensure that you have initialized the SDK with the appropriate credentials for Entity Manager operations.'
+    )
+    this.name = 'UninitializedEntityManagerError'
+  }
+}

--- a/packages/sdk/src/sdk/types.ts
+++ b/packages/sdk/src/sdk/types.ts
@@ -41,7 +41,7 @@ export type ServicesContainer = {
   /**
    * Service used to write and update entities on chain
    */
-  entityManager: EntityManagerService
+  entityManager?: EntityManagerService
 
   /**
    * Service used to store and retrieve content e.g. tracks and images


### PR DESCRIPTION
- Makes entity manager an optional service in the API constructor since the POST endpoints exist
- Adds a special error that throws when the entityManager variants are called when entityManager isn't initialized
- Makes services arg to constructors of APIs an object arg instead of positional args