### PR TITLE
Fix profile image mirroring

### DIFF
--- a/packages/sdk/src/sdk/api/generated/default/models/CoverArt.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/CoverArt.ts
@@ -38,6 +38,12 @@ export interface CoverArt {
      * @memberof CoverArt
      */
     _1000x1000?: string;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof CoverArt
+     */
+    mirrors?: Array<string>;
 }
 
 /**
@@ -62,6 +68,7 @@ export function CoverArtFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         '_150x150': !exists(json, '150x150') ? undefined : json['150x150'],
         '_480x480': !exists(json, '480x480') ? undefined : json['480x480'],
         '_1000x1000': !exists(json, '1000x1000') ? undefined : json['1000x1000'],
+        'mirrors': !exists(json, 'mirrors') ? undefined : json['mirrors'],
     };
 }
 
@@ -77,6 +84,7 @@ export function CoverArtToJSON(value?: CoverArt | null): any {
         '150x150': value._150x150,
         '480x480': value._480x480,
         '1000x1000': value._1000x1000,
+        'mirrors': value.mirrors,
     };
 }
 

--- a/packages/sdk/src/sdk/api/generated/default/models/DecodedUserToken.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/DecodedUserToken.ts
@@ -116,7 +116,7 @@ export function DecodedUserTokenFromJSONTyped(json: any, ignoreDiscriminator: bo
         'name': json['name'],
         'handle': json['handle'],
         'verified': json['verified'],
-        'profilePicture': !exists(json, 'profilePicture') ? undefined : ProfilePictureFromJSON(json['profilePicture']),
+        'profilePicture': !exists(json, 'profile_picture') ? undefined : ProfilePictureFromJSON(json['profile_picture']),
         'sub': json['sub'],
         'iat': json['iat'],
     };
@@ -137,7 +137,7 @@ export function DecodedUserTokenToJSON(value?: DecodedUserToken | null): any {
         'name': value.name,
         'handle': value.handle,
         'verified': value.verified,
-        'profilePicture': ProfilePictureToJSON(value.profilePicture),
+        'profile_picture': ProfilePictureToJSON(value.profilePicture),
         'sub': value.sub,
         'iat': value.iat,
     };

--- a/packages/sdk/src/sdk/api/generated/default/models/ProfilePicture.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/ProfilePicture.ts
@@ -38,6 +38,12 @@ export interface ProfilePicture {
      * @memberof ProfilePicture
      */
     _1000x1000?: string;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof ProfilePicture
+     */
+    mirrors?: Array<string>;
 }
 
 /**
@@ -62,6 +68,7 @@ export function ProfilePictureFromJSONTyped(json: any, ignoreDiscriminator: bool
         '_150x150': !exists(json, '150x150') ? undefined : json['150x150'],
         '_480x480': !exists(json, '480x480') ? undefined : json['480x480'],
         '_1000x1000': !exists(json, '1000x1000') ? undefined : json['1000x1000'],
+        'mirrors': !exists(json, 'mirrors') ? undefined : json['mirrors'],
     };
 }
 
@@ -77,6 +84,7 @@ export function ProfilePictureToJSON(value?: ProfilePicture | null): any {
         '150x150': value._150x150,
         '480x480': value._480x480,
         '1000x1000': value._1000x1000,
+        'mirrors': value.mirrors,
     };
 }
 


### PR DESCRIPTION
Fixes weird issue where generated sdk types for profile image does not include mirrors field, despite it's presence in the swagger. adding a post-generation hotfix.