### PR TITLE
Listening streak reward text

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -73,9 +73,9 @@ export const challengeRewardsConfig: Partial<
     id: ChallengeName.ListenStreakEndless,
     title: 'Listening Streak',
     description: () =>
-      'Listen to music on Audius daily for seven days to start a streak. After that, earn $AUDIO for each consecutive day you continue listening (Silver Tier Required).',
+      'Listen to Audius daily for a week to start a streak and earn $AUDIO for each day you keep it going.',
     fullDescription: () =>
-      'Listen to music on Audius daily for seven days to start a streak. After that, earn $AUDIO for each consecutive day you continue listening (Silver Tier Required).',
+      'Listen to Audius daily for a week to start a streak and earn $AUDIO for each day you keep it going.',
     progressLabel: '%0/%1 Days',
     completedLabel: 'Keep Listening',
     panelButtonText: 'Trending on Audius'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the title and description for the Listening Streak challenge reward tile.

---
[Slack Thread](https://audius-internal.slack.com/archives/C02JBA52NKZ/p1773093191365099?thread_ts=1773093191.365099&cid=C02JBA52NKZ)

<p><a href="https://cursor.com/agents/bc-666cea9e-c29e-5b80-be96-ee3708e8a573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-666cea9e-c29e-5b80-be96-ee3708e8a573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->