### PR TITLE
fix(web): Trending page not loading after sign-in

### DIFF
--- a/packages/web/src/common/store/pages/trending/lineups/trending/sagas.ts
+++ b/packages/web/src/common/store/pages/trending/lineups/trending/sagas.ts
@@ -4,12 +4,15 @@ import {
   trendingPageLineupActions,
   trendingPageSelectors
 } from '@audius/common/store'
-import { call, select } from 'typed-redux-saga'
+import { call, delay, race, select } from 'typed-redux-saga'
 
 import { LineupSagas } from 'common/store/lineup/sagas'
 import { waitForRead } from 'utils/sagaHelpers'
 
 import { retrieveTrending } from './retrieveTrending'
+
+/** Max wait for userId; avoid blocking trending load when account query stalls after sign-in */
+const QUERY_USER_ID_TIMEOUT_MS = 3000
 const { getTrendingGenre } = trendingPageSelectors
 const {
   TRENDING_WEEK_PREFIX,
@@ -24,7 +27,10 @@ function getTracks(timeRange: TimeRange) {
   return function* ({ offset, limit }: { offset: number; limit: number }) {
     yield* waitForRead()
     const genreAtStart = yield* select(getTrendingGenre)
-    const userId = yield* call(queryCurrentUserId)
+    const { userId } = yield* race({
+      userId: call(queryCurrentUserId),
+      timeout: call(delay, QUERY_USER_ID_TIMEOUT_MS)
+    })
     try {
       const tracks = yield* retrieveTrending({
         timeRange,

--- a/packages/web/src/pages/trending-page/hooks/useTrendingPageCleanup.ts
+++ b/packages/web/src/pages/trending-page/hooks/useTrendingPageCleanup.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { TimeRange } from '@audius/common/models'
 
@@ -18,19 +18,23 @@ export const useTrendingPageCleanup = ({
 }: UseTrendingPageCleanupProps): void => {
   const { isMobile, hasAccount } = trendingPageState
   const { resetTrendingLineup, makeResetTrending } = actions
+  const hasAccountRef = useRef(hasAccount)
+  hasAccountRef.current = hasAccount
 
-  // Cleanup on unmount
+  // Cleanup on unmount only. Use ref for hasAccount so we read current value
+  // at unmount time and avoid resetting when hasAccount flips after sign-in.
   useEffect(() => {
     return () => {
+      const currentHasAccount = hasAccountRef.current
       // Only reset if we're not on mobile (mobile should
       // preserve the current tab + state) or there was no
       // account (because the lineups could contain stale content).
-      if (!isMobile || !hasAccount) {
+      if (!isMobile || !currentHasAccount) {
         resetTrendingLineup()
         makeResetTrending(TimeRange.WEEK)()
         makeResetTrending(TimeRange.MONTH)()
         makeResetTrending(TimeRange.ALL_TIME)()
       }
     }
-  }, [isMobile, hasAccount, resetTrendingLineup, makeResetTrending])
+  }, [isMobile, resetTrendingLineup, makeResetTrending])
 }


### PR DESCRIPTION
## Problem
Trending page doesn't load (or loads then disappears) when signing in and navigating to it.

## Root Causes
1. **queryCurrentUserId blocks** – After sign-in, the account query can stall, causing the trending fetch to never complete.
2. **useTrendingPageCleanup resets on hasAccount flip** – When hasAccount transitions false→true, the effect cleanup runs with stale closure and calls resetTrendingLineup(), clearing loaded content.

## Solution
1. Race queryCurrentUserId with 3s timeout; proceed with undefined if it stalls.
2. Use ref for hasAccount in cleanup; remove from effect deps so cleanup only runs on unmount.