### PR TITLE
Fix Android letter-spacing clipping in Text component

### DIFF
--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -69,10 +69,16 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
       // On Android, letterSpacing adds trailing space after the last character
       // that isn't accounted for in text measurement, clipping the final letter.
       ...(Platform.OS === 'android' &&
-        'css' in variantStyles &&
-        variantStyles.css?.letterSpacing && {
-          paddingRight: variantStyles.css.letterSpacing
-        })
+      'css' in variantStyles &&
+      typeof variantStyles.css === 'object' &&
+      variantStyles.css !== null &&
+      'letterSpacing' in variantStyles.css &&
+      (variantStyles.css as { letterSpacing?: number }).letterSpacing
+        ? {
+            paddingRight: (variantStyles.css as { letterSpacing: number })
+              .letterSpacing
+          }
+        : {})
     }),
     ...(color && { color }),
     ...(shadow && t.shadow[shadow]),


### PR DESCRIPTION
## Summary

- On Android, `letterSpacing` adds trailing space after the last character that isn't accounted for in text measurement, clipping the final letter
- Adds `paddingRight` equal to the `letterSpacing` value to compensate
- Tightens the conditional with proper TS type narrowing to avoid a type error with the updated style shape

## Test plan

- [ ] Verify text with `letterSpacing` styles renders without clipping on Android
- [ ] Verify no visual regression on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)