### PR TITLE
fix(sdk): use src/index.ts as browser ESM entry to export sdk alias

### DIFF
--- a/packages/sdk/rollup.config.ts
+++ b/packages/sdk/rollup.config.ts
@@ -68,7 +68,7 @@ export const outputConfigs = {
    * Used by the Audius React Native client
    */
   sdkConfigReactNative: {
-    input: 'src/index.native.ts',
+    input: { index: 'src/index.native.ts' },
     output: [
       {
         dir: 'dist',


### PR DESCRIPTION
SERIOUS DEJAVU

AI accidentally reverted our changes here. it's still terrible at resolving merge conflicts: https://github.com/AudiusProject/apps/commit/671fa83e96ef50a16e1aa6a4fd36b94ce86a7a69