### PR TITLE
fix(ci): run SDK CI on changeset release branch

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - changeset-release/**
     paths:
       - 'packages/sdk/**'
       - 'packages/eth/**'


### PR DESCRIPTION
## Summary
- Adds `changeset-release/**` to the `push: branches:` trigger in `sdk.yml`

## Why
Bot-created PRs (via `GITHUB_TOKEN`) don't fire `pull_request` events on other workflows, so SDK CI was never running on the changeset version packages branch (`changeset-release/main`). This ensures SDK CI runs when changesets pushes version bumps to that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)