### PR TITLE
fix(lint): fix prettier and import-order violations in sdk and common

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useSendCoins.ts
+++ b/packages/common/src/api/tan-query/wallets/useSendCoins.ts
@@ -164,7 +164,11 @@ export const useSendCoins = ({ mint }: { mint: string }) => {
         }
       }
     },
-    onError: (error, { amount, recipientWallet, source, recipientHandle }, context) => {
+    onError: (
+      error,
+      { amount, recipientWallet, source, recipientHandle },
+      context
+    ) => {
       if (context?.previousBalance) {
         const userId = currentUser?.user_id ?? null
         const queryKey = getUserCoinQueryKey(mint, userId)

--- a/packages/sdk/src/sdk/oauth/OAuth.ts
+++ b/packages/sdk/src/sdk/oauth/OAuth.ts
@@ -1,4 +1,8 @@
-import { FetchError, ResponseError, UserFromJSON } from '../api/generated/default'
+import {
+  FetchError,
+  ResponseError,
+  UserFromJSON
+} from '../api/generated/default'
 import type { User } from '../api/generated/default'
 import { Logger, type LoggerService } from '../services/Logger'
 import { isOAuthScopeValid } from '../utils/oauthScope'

--- a/packages/sdk/src/sdk/types.ts
+++ b/packages/sdk/src/sdk/types.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod'
 import type { PublicClient, WalletClient } from 'viem'
+import { z } from 'zod'
 
 import type { OAuthTokenStore } from './oauth/tokenStore'
 import { AntiAbuseOracleService } from './services/AntiAbuseOracle/types'


### PR DESCRIPTION
## Summary
- Reformatted multiline import in `packages/sdk/src/sdk/oauth/OAuth.ts` (prettier)
- Reordered `viem` import before `zod` in `packages/sdk/src/sdk/types.ts` (import/order)
- Reformatted `onError` callback args to multiline in `packages/common/src/api/tan-query/wallets/useSendCoins.ts` (prettier)

## Test plan
- [x] `npm run verify --filter=!identity-service` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)