### PR TITLE
Move Community Playlists section above Artist Coin Exclusives on explore page

### DIFF
--- a/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
@@ -28,11 +28,11 @@ export const ExploreContent = () => {
   return (
     <Flex gap='2xl' pt='s' pb={150} ph='l'>
       {showTrackContent && showUserContextualContent && <ForYouTracks />}
+      {showPlaylistContent && <FeaturedPlaylists />}
       {showTrackContent && <FeaturedArtistCoinTracks />}
       {showTrackContent && showUserContextualContent && (
         <RecentlyPlayedTracks />
       )}
-      {showPlaylistContent && <FeaturedPlaylists />}
       {showTrackContent && <FeaturedRemixContests />}
       {showUserContent && <ArtistSpotlight />}
       {showUserContent && <LabelSpotlight />}

--- a/packages/web/src/pages/search-explore-page/components/desktop/SearchExplorePage.tsx
+++ b/packages/web/src/pages/search-explore-page/components/desktop/SearchExplorePage.tsx
@@ -313,11 +313,11 @@ const SearchExplorePage = ({
             {showTrackContent && showUserContextualContent && (
               <RecommendedTracksSection />
             )}
+            {showPlaylistContent && <FeaturedPlaylistsSection />}
             {showTrackContent && <ArtistCoinTracksSection />}
             {showTrackContent && showUserContextualContent && (
               <RecentlyPlayedSection />
             )}
-            {showPlaylistContent && <FeaturedPlaylistsSection />}
             {showTrackContent && <FeaturedRemixContestsSection />}
             {showUserContent && <ArtistSpotlightSection />}
             {showUserContent && <LabelSpotlightSection />}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Reordered sections on the explore page to position 'Community Playlists' above 'Artist Coin Exclusives' for both web and mobile platforms.

## Changes
- **Web**: Updated section order in `SearchExplorePage.tsx` 
- **Mobile**: Updated section order in `ExploreContent.tsx`

## Testing
- [ ] Verify section order on web explore page
- [ ] Verify section order on mobile explore page
- [ ] Check that sections render correctly in all filter views (All, Tracks, Playlists, etc.)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://audius-internal.slack.com/archives/C0459T4UX4J/p1773851453505789?thread_ts=1773851453.505789&cid=C0459T4UX4J)

<div><a href="https://cursor.com/agents/bc-3d5b1960-cdb5-5f86-b99e-c82dbb5b32eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d5b1960-cdb5-5f86-b99e-c82dbb5b32eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

