### PR TITLE
fix(oauth): default response_mode to query instead of fragment

### DIFF
--- a/packages/web/src/pages/oauth-login-page/hooks.ts
+++ b/packages/web/src/pages/oauth-login-page/hooks.ts
@@ -405,7 +405,7 @@ export const useOAuthSetup = ({
             }
           }
         } else {
-          if (responseMode && responseMode === 'query') {
+          if (responseMode !== 'fragment') {
             if (state != null) {
               parsedRedirectUri!.searchParams.append('state', state as string)
             }
@@ -587,7 +587,7 @@ export const useOAuthSetup = ({
           })
         }
       } else if (parsedRedirectUri) {
-        if (responseMode === 'query') {
+        if (responseMode !== 'fragment') {
           if (state != null) {
             parsedRedirectUri.searchParams.append('state', state as string)
           }


### PR DESCRIPTION
## Summary
- When `response_mode` is not explicitly set by the client, the consent page now falls through to query param delivery (`?code=&state=`) instead of fragment (`#code=&state=`)
- Explicit `response_mode=fragment` still uses fragment delivery as before
- No change to the SDK default — this is purely a server-side consent page behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

note: conform to RFC 6749 / OAuth 2.0 standard for authorization code flow