### PR TITLE
docs: preconfigure OAuth2 defaults in Scalar API reference

### DIFF
--- a/docs/docs/components/ApiReference.jsx
+++ b/docs/docs/components/ApiReference.jsx
@@ -58,6 +58,22 @@ export default function ApiReference() {
         configuration={{
           url: '/openapi.yaml',
           darkMode,
+          authentication: {
+            preferredSecurityScheme: 'OAuth2',
+            securitySchemes: {
+              OAuth2: {
+                flows: {
+                  authorizationCode: {
+                    'x-usePkce': 'SHA-256',
+                    selectedScopes: ['read'],
+                    // Audius API key for the docs app
+                    'x-scalar-client-id': '2cc593fc814461263d282a84286fd4f72c79562e',
+                    clientSecret: '',
+                  },
+                },
+              },
+            },
+          },
         }}
       />
     </div>


### PR DESCRIPTION
## Summary

Presets the Scalar auth panel so developers can try authenticated endpoints immediately without any manual configuration:

- Selects OAuth2 authorization code flow by default
- Enables PKCE with SHA-256
- Preselects `read` scope
- Prefills the client ID with the Audius docs app API key
- Clears client secret field (unnecessary with PKCE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)