### PR TITLE
docs: show operation path and ID in Scalar API reference

### DIFF
--- a/docs/docs/components/ApiReference.jsx
+++ b/docs/docs/components/ApiReference.jsx
@@ -58,6 +58,8 @@ export default function ApiReference() {
         configuration={{
           url: '/openapi.yaml',
           darkMode,
+          operationTitleSource: 'path',
+          showOperationId: true,
           authentication: {
             preferredSecurityScheme: 'OAuth2',
             securitySchemes: {


### PR DESCRIPTION
## Summary

- `operationTitleSource: 'path'` — displays the URL path as the operation title instead of the summary
- `showOperationId: true` — surfaces the operationId for each endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)