### PR TITLE
Remove http/https-only URL validation for redirect URIs in SDK

### DIFF
--- a/packages/sdk/src/sdk/api/developer-apps/types.ts
+++ b/packages/sdk/src/sdk/api/developer-apps/types.ts
@@ -24,16 +24,7 @@ export const CreateDeveloperAppSchema = z.object({
       })
   ),
   userId: HashId,
-  redirectUris: z
-    .array(
-      z
-        .string()
-        .max(2000)
-        .refine((value) => URL_REGEX.test(value), {
-          message: 'Invalid URL'
-        })
-    )
-    .optional()
+  redirectUris: z.array(z.string().max(2000)).optional()
 })
 
 export type EntityManagerCreateDeveloperAppRequest = z.input<
@@ -55,16 +46,7 @@ export const UpdateDeveloperAppSchema = z.object({
       })
   ),
   userId: HashId,
-  redirectUris: z
-    .array(
-      z
-        .string()
-        .max(2000)
-        .refine((value) => URL_REGEX.test(value), {
-          message: 'Invalid URL'
-        })
-    )
-    .optional()
+  redirectUris: z.array(z.string().max(2000)).optional()
 })
 
 export type EntityManagerUpdateDeveloperAppRequest = z.input<


### PR DESCRIPTION
## Summary

- The SDK's `URL_REGEX` (`/^(https?):\/\//i`) was used to validate `redirectUris` in both `CreateDeveloperAppSchema` and `UpdateDeveloperAppSchema`, blocking any non-http/https scheme
- Mobile apps using custom URI schemes (e.g. `audiusupload://oauth/callback`) are valid OAuth redirect targets but were rejected before any API request could be made
- Removed the `refine` URL check from `redirectUris` in both schemas; length constraints (max 2000 chars, max 50 URIs) are preserved

## Test plan

- [x] Enter a custom scheme redirect URI (e.g. `myapp://oauth/callback`) in the dev app settings modal and verify it saves successfully
- [ ] Verify http/https redirect URIs still work
- [ ] Verify image URL validation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)