### PR TITLE
Fix Log In with Audius docs to use correct /v1/me endpoint

### DIFF
--- a/packages/docs/docs/pages/developers/guides/log-in-with-audius.mdx
+++ b/packages/docs/docs/pages/developers/guides/log-in-with-audius.mdx
@@ -262,7 +262,7 @@ Non-2xx responses include an `error` and `error_description` field in the JSON b
 ### 5. Get the user's profile
 
 ```http
-GET https://api.audius.co/v1/oauth/me
+GET https://api.audius.co/v1/me
 Authorization: Bearer ACCESS_TOKEN
 ```
 


### PR DESCRIPTION
## Summary
- Updates the \"Get the user's profile\" example in the Log In with Audius guide to use `GET /v1/me` instead of the incorrect `GET /v1/oauth/me`

## Test plan
- [ ] Verify the docs page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)