### PR TITLE
Incorrectly set redirectUri warns developer

### DIFF
--- a/packages/mobile/src/screens/oauth-screen/ImplicitFlowScreen.tsx
+++ b/packages/mobile/src/screens/oauth-screen/ImplicitFlowScreen.tsx
@@ -42,6 +42,7 @@ export const ImplicitFlowScreen = ({ params }: Props) => {
     useAppInfo({
       apiKey,
       queryParamAppName,
+      redirectUri,
       scope,
       userId: account?.user_id,
       skip: false

--- a/packages/mobile/src/screens/oauth-screen/PkceFlowScreen.tsx
+++ b/packages/mobile/src/screens/oauth-screen/PkceFlowScreen.tsx
@@ -49,6 +49,7 @@ export const PkceFlowScreen = ({ params }: Props) => {
     useAppInfo({
       apiKey,
       queryParamAppName,
+      redirectUri,
       scope,
       userId: account?.user_id,
       skip: false

--- a/packages/mobile/src/screens/oauth-screen/WriteOnceFlowScreen.tsx
+++ b/packages/mobile/src/screens/oauth-screen/WriteOnceFlowScreen.tsx
@@ -46,6 +46,7 @@ export const WriteOnceFlowScreen = ({ params }: Props) => {
   } = useAppInfo({
     apiKey,
     queryParamAppName,
+    redirectUri,
     scope: 'write_once',
     userId: account?.user_id,
     skip: false

--- a/packages/mobile/src/screens/oauth-screen/hooks/useAppInfo.ts
+++ b/packages/mobile/src/screens/oauth-screen/hooks/useAppInfo.ts
@@ -21,12 +21,14 @@ type UseAppInfoResult = {
 export const useAppInfo = ({
   apiKey,
   queryParamAppName,
+  redirectUri,
   scope,
   userId,
   skip
 }: {
   apiKey: string | null
   queryParamAppName: string | null
+  redirectUri: string | null
   scope: string | null
   userId: number | undefined
   /** Skip all fetching (e.g. when there's already a param validation error). */
@@ -59,6 +61,16 @@ export const useAppInfo = ({
               setError(messages.invalidApiKeyError)
               return
             }
+            const registeredUris = res.data.redirectUris
+            if (
+              registeredUris &&
+              registeredUris.length > 0 &&
+              redirectUri != null &&
+              !registeredUris.includes(redirectUri)
+            ) {
+              setError(messages.redirectUriNotRegisteredError(redirectUri))
+              return
+            }
             setRegisteredAppName(res.data.name)
             if (res.data.imageUrl) setAppImage(res.data.imageUrl)
           } catch {
@@ -87,7 +99,7 @@ export const useAppInfo = ({
       }
     }
     setup()
-  }, [apiKey, scope, userId, skip])
+  }, [apiKey, redirectUri, scope, userId, skip])
 
   return {
     appName: registeredAppName ?? queryParamAppName ?? undefined,

--- a/packages/mobile/src/screens/oauth-screen/messages.ts
+++ b/packages/mobile/src/screens/oauth-screen/messages.ts
@@ -30,6 +30,8 @@ export const messages = {
   scopeError: 'Whoops, this is an invalid link (scope missing or invalid).',
   missingApiKeyError: 'Whoops, this is an invalid link (app API Key missing)',
   invalidApiKeyError: 'Whoops, this is an invalid link (app API Key invalid)',
+  redirectUriNotRegisteredError: (uri: string) =>
+    `Redirect URI not registered. Add "${uri}" to your app's allowed redirect URIs in Settings on audius.co.`,
   missingCodeChallengeError:
     'Whoops, this is an invalid link (code_challenge is required for PKCE flow).',
   invalidCodeChallengeMethodError:

--- a/packages/web/src/pages/oauth-login-page/hooks.ts
+++ b/packages/web/src/pages/oauth-login-page/hooks.ts
@@ -300,11 +300,21 @@ export const useOAuthSetup = ({
         setQueryParamsError(messages.invalidApiKeyError)
         return
       }
+      const registeredUris = developerApp.redirectUris
+      if (
+        registeredUris &&
+        registeredUris.length > 0 &&
+        typeof redirectUri === 'string' &&
+        !registeredUris.includes(redirectUri)
+      ) {
+        setQueryParamsError(messages.redirectUriNotRegisteredError(redirectUri))
+        return
+      }
       setRegisteredDeveloperAppName(developerApp.name)
       setAppImage(developerApp.imageUrl)
     }
     fetchDeveloperAppName()
-  }, [apiKey, queryParamAppName, queryParamsError, scope])
+  }, [apiKey, queryParamAppName, queryParamsError, scope, redirectUri])
 
   useEffect(() => {
     const getAndSetEmail = async () => {

--- a/packages/web/src/pages/oauth-login-page/messages.ts
+++ b/packages/web/src/pages/oauth-login-page/messages.ts
@@ -51,6 +51,8 @@ export const messages = {
   signedInAs: `You’re Signed in as`,
   missingApiKeyError: 'Whoops, this is an invalid link (app API Key missing)',
   invalidApiKeyError: 'Whoops, this is an invalid link (app API Key invalid)',
+  redirectUriNotRegisteredError: (uri: string) =>
+    `Redirect URI not registered. Add "${uri}" to your app's allowed redirect URIs in Settings on audius.co.`,
   missingCodeChallengeError:
     'Whoops, this is an invalid link (code_challenge is required for PKCE flow).',
   invalidCodeChallengeMethodError:


### PR DESCRIPTION
Adds a warning to the OAuth page on load if the redirect URI set doesn't match a registered one for the app