### PR TITLE
Add lint to SDK CI and fix import order

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Cache for Turbo
         uses: rharkor/caching-for-turbo@v2.2.1
 
+      - name: Lint
+        run: npx turbo run lint --filter=@audius/sdk
+
       - name: Typecheck
         run: npx turbo run typecheck --filter=@audius/sdk
 

--- a/packages/sdk/src/sdk/createSdk.ts
+++ b/packages/sdk/src/sdk/createSdk.ts
@@ -31,9 +31,9 @@ import {
   addTokenRefreshMiddleware
 } from './middleware'
 import { OAuth } from './oauth'
-import { SolanaWallet } from './solanaWallet'
 import { TokenStoreLocalStorage } from './oauth/TokenStoreLocalStorage'
 import { Logger, Storage, StorageNodeSelector } from './services'
+import { SolanaWallet } from './solanaWallet'
 import { SdkConfigSchema, type SdkConfig } from './types'
 
 export const createSdk = (config: SdkConfig) => {


### PR DESCRIPTION
## Summary
- Adds a `lint` step to the SDK CI workflow (`.github/workflows/sdk.yml`) so linting errors are caught before merge
- Fixes import ordering in `createSdk.ts`

## Test plan
- [ ] Verify SDK CI workflow runs lint, typecheck, and test steps on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)