### PR TITLE
Add README for coin-gated web example

### DIFF
--- a/packages/web/examples/README.md
+++ b/packages/web/examples/README.md
@@ -10,6 +10,7 @@ Runnable examples for building Audius-style web features (Vite + React). Use the
 | [update-profile](./update-profile/) | **Vite + React + Node server**: OAuth (write scope) + server-side update of user description (mirrors mobile update-profile example). | Run server first (see example README). Then `cd packages/web/examples/update-profile && npm install && npm run dev` or `npm run web:example:update-profile`. Requires .env. |
 | [upload](./upload/) | **Vite + React + Node server**: OAuth popup + uploadTrackFiles + server create-track (mirrors mobile upload example). | Run server first. Then `cd packages/web/examples/upload && npm run dev` or `npm run web:example:upload`. Requires .env. |
 | [gated-upload](./gated-upload/) | **Vite + React + Node server**: Same as upload + geo-gated streaming (ip-api.com). Server gates /stream/:trackId by IP/country. | Run server first. Then `cd packages/web/examples/gated-upload && npm run dev` or `npm run web:example:gated-upload`. Requires .env. |
+| [coin-gated](./coin-gated/) | **Vite + React**: Browse artist coins, sign in via OAuth or Phantom wallet, stream coin-gated tracks. | `cd packages/web/examples/coin-gated && npm install && npm run dev`. Requires .env with `VITE_AUDIUS_API_KEY`. |
 
 ## Quick start
 

--- a/packages/web/examples/coin-gated/README.md
+++ b/packages/web/examples/coin-gated/README.md
@@ -1,0 +1,59 @@
+# Coin-Gated Tracks (Web)
+
+Vite + React app that lets users browse and stream **coin-gated tracks** on Audius. Use this as a reference for:
+
+- **SDK setup** in a browser / Vite app (singleton, node polyfills)
+- **Coin lookup** via `sdk.coins.getCoinByTicker()`
+- **Coin-gated track listing** via `sdk.users.getTracksByUser()` with `gateCondition: ['token']`
+- **OAuth sign-in** (PKCE popup flow) for authenticated access checks
+- **Solana wallet connection** via Phantom (`sdk.solanaWallet.auth()`)
+- **Streaming gated tracks** via `sdk.tracks.streamTrack()`
+- **Coin balance** via `sdk.users.getUserCoin()` / `sdk.wallets.getWalletCoins()`
+
+## How to run
+
+1. From the **apps repo root**, install and build the SDK if needed:
+
+   ```bash
+   npm install
+   npm run build -w @audius/sdk
+   ```
+
+2. Configure your API key:
+
+   ```bash
+   cd packages/web/examples/coin-gated
+   cp .env .env.local
+   # Edit .env.local and set VITE_AUDIUS_API_KEY to your developer app API key
+   # Get one at audius.co/settings → Developer Apps
+   ```
+
+3. Install and start:
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+4. Open `http://localhost:5178`.
+
+## Environment variables
+
+| Variable                  | Required | Description                                                                    |
+| :------------------------ | :------- | :----------------------------------------------------------------------------- |
+| `VITE_AUDIUS_API_KEY`     | Yes      | Developer app API key (enables OAuth for gated access checks)                  |
+| `VITE_AUDIUS_ENVIRONMENT` | No       | `development` to target local stack, `production` (default) for public network |
+| `VITE_DEFAULT_TICKER`     | No       | Default coin ticker to browse on load (defaults to `YAK`)                      |
+
+## Project layout
+
+| File               | Purpose                                                                                  |
+| :----------------- | :--------------------------------------------------------------------------------------- |
+| `src/App.tsx`      | Main UI — ticker search, OAuth + wallet sign-in, coin info, gated track list, streaming. |
+| `src/sdk.ts`       | Singleton `getSDK()` with `apiKey`, `redirectUri`, and `environment`.                    |
+| `src/config.ts`    | Reads env vars (`VITE_AUDIUS_API_KEY`, `VITE_AUDIUS_ENVIRONMENT`, `VITE_DEFAULT_TICKER`). |
+| `vite.config.ts`   | React plugin + node polyfills (buffer, process) for SDK.                                 |
+
+## Keywords (for search / AI)
+
+Coin-gated, token-gated, artist coin, Phantom wallet, Solana wallet, OAuth, PKCE, streaming, getCoinByTicker, getTracksByUser, streamTrack, getUserCoin, getWalletCoins, Audius SDK, web example, React Query.


### PR DESCRIPTION
## Summary
- Adds a README to `packages/web/examples/coin-gated/` covering setup, env vars, project layout, and SDK usage
- Adds coin-gated entry to the parent `packages/web/examples/README.md` table

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)