### PR TITLE
Auto-follow artist on coin purchase

### DIFF
--- a/.changeset/auto-follow-artist-coin-purchase.md
+++ b/.changeset/auto-follow-artist-coin-purchase.md
@@ -1,0 +1,7 @@
+---
+"@audius/common": patch
+"@audius/mobile": patch
+"@audius/web": patch
+---
+
+Automatically follow an artist when a user successfully purchases their artist coin

--- a/packages/common/src/api/tan-query/jupiter/useSwapCoins.ts
+++ b/packages/common/src/api/tan-query/jupiter/useSwapCoins.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useDispatch } from 'react-redux'
 
+import { coinFromSdk } from '~/adapters/coin'
 import {
   getUserCoinQueryKey,
   getUserQueryKey,
@@ -12,10 +14,15 @@ import {
 import { QUERY_KEYS } from '~/api/tan-query/queryKeys'
 import type { QueryContextType } from '~/api/tan-query/utils/QueryContext'
 import { Feature } from '~/models'
+import { FollowSource } from '~/models/Analytics'
 import type { User } from '~/models/User'
 import { JupiterQuoteResult } from '~/services/Jupiter'
+import { NON_ARTIST_COIN_MINTS } from '~/store/ui/shared/tokenConstants'
 
+import { getArtistCoinQueryFn } from '../coins/useArtistCoin'
 import { useTradeableCoins } from '../coins/useTradeableCoins'
+import { useFollowUser } from '../users/useFollowUser'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 
 import { SwapOrchestrator } from './orchestrator'
 import {
@@ -214,6 +221,70 @@ export const optimisticallyUpdateSwapBalances = (
 }
 
 /**
+ * Auto-follows the owning artist of a coin after a successful purchase.
+ * Skips if the output mint is not an artist coin, the user already follows
+ * the artist, or the coin's owner can't be resolved.
+ */
+const autoFollowArtistOnCoinPurchase = async ({
+  outputMint,
+  queryClient,
+  audiusSdk,
+  dispatch,
+  followUser,
+  reportToSentry
+}: {
+  outputMint: string
+  queryClient: ReturnType<typeof useQueryClient>
+  audiusSdk: QueryContextType['audiusSdk']
+  dispatch: ReturnType<typeof useDispatch>
+  followUser: ReturnType<typeof useFollowUser>['mutate']
+  reportToSentry: QueryContextType['reportToSentry']
+}) => {
+  if (!outputMint || NON_ARTIST_COIN_MINTS.includes(outputMint)) {
+    return
+  }
+
+  try {
+    const coin = await queryClient.fetchQuery({
+      queryKey: getArtistCoinQueryKey(outputMint),
+      queryFn: async () => {
+        const sdk = await audiusSdk()
+        const rawCoin = await getArtistCoinQueryFn(
+          outputMint,
+          queryClient,
+          sdk,
+          dispatch
+        )
+        return coinFromSdk(rawCoin)
+      },
+      ...entityCacheOptions
+    })
+
+    if (!coin?.ownerId) {
+      return
+    }
+
+    // Skip if the current user already follows the artist
+    const artistUser = queryClient.getQueryData(getUserQueryKey(coin.ownerId))
+    if (artistUser?.does_current_user_follow) {
+      return
+    }
+
+    followUser({
+      followeeUserId: coin.ownerId,
+      source: FollowSource.ARTIST_COIN_PURCHASE
+    })
+  } catch (error) {
+    reportToSentry({
+      name: 'AutoFollowArtistOnCoinPurchaseError',
+      error: error as Error,
+      feature: Feature.TanQuery,
+      additionalInfo: { outputMint }
+    })
+  }
+}
+
+/**
  * Hook for executing coin swaps using Jupiter.
  * Swaps any supported SPL token (or SOL) for another.
  */
@@ -223,6 +294,8 @@ export const useSwapCoins = () => {
     useQueryContext()
   const { data: user } = useCurrentAccountUser()
   const { coins } = useTradeableCoins()
+  const dispatch = useDispatch()
+  const { mutate: followUser } = useFollowUser()
 
   return useMutation<SwapTokensResult, Error, SwapTokensParams>({
     mutationFn: async (params): Promise<SwapTokensResult> => {
@@ -304,6 +377,15 @@ export const useSwapCoins = () => {
     },
     onSuccess: (result, params) => {
       optimisticallyUpdateSwapBalances(params, result, queryClient, user, env)
+      // Auto-follow the artist whose coin was just purchased
+      autoFollowArtistOnCoinPurchase({
+        outputMint: params.outputMint,
+        queryClient,
+        audiusSdk,
+        dispatch,
+        followUser,
+        reportToSentry
+      })
     },
     onMutate: () => {
       return { status: SwapStatus.SENDING_TRANSACTION }

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -969,7 +969,8 @@ export enum FollowSource {
   EMPTY_FEED = 'empty feed',
   HOW_TO_UNLOCK_TRACK_PAGE = 'how to unlock track page',
   HOW_TO_UNLOCK_MODAL = 'how to unlock modal',
-  SIGN_UP = 'sign up'
+  SIGN_UP = 'sign up',
+  ARTIST_COIN_PURCHASE = 'artist coin purchase'
 }
 
 type Share = {


### PR DESCRIPTION
## Summary
This PR adds functionality to automatically follow an artist when a user purchases their coin through the Jupiter swap interface.

## Key Changes
- Added `autoFollowArtistOnCoinPurchase` function that:
  - Fetches the artist coin metadata after a successful swap
  - Resolves the coin's owner (artist)
  - Automatically follows the artist if the user isn't already following them
  - Gracefully handles errors and skips non-artist coins
  
- Integrated auto-follow logic into the `useSwapCoins` hook's `onSuccess` callback to trigger after successful coin purchases

- Added `ARTIST_COIN_PURCHASE` to the `FollowSource` enum in Analytics to track the source of these auto-follows

- Added necessary imports and dependencies:
  - `useDispatch` from react-redux
  - `useFollowUser` hook for executing the follow action
  - `coinFromSdk` adapter for coin data transformation
  - `NON_ARTIST_COIN_MINTS` constant to filter out non-artist coins
  - `getArtistCoinQueryFn` for fetching coin metadata
  - `entityCacheOptions` for query configuration

## Implementation Details
- The auto-follow is non-blocking and wrapped in error handling to prevent swap failures
- Skips execution if the output mint is not an artist coin or if the user already follows the artist
- Uses the existing query client to fetch coin data and check follow status
- Reports any errors to Sentry for monitoring

https://claude.ai/code/session_01E5VEqdyb3VyG6cicnNRzgd