### PR TITLE
Normalize OAuth API key to handle 0x prefixes

### DIFF
--- a/packages/mobile/src/screens/oauth-screen/hooks/useParsedParams.ts
+++ b/packages/mobile/src/screens/oauth-screen/hooks/useParsedParams.ts
@@ -26,12 +26,16 @@ export const useParsedParams = (search: string): ParsedParams => {
   } = queryString.parse(search)
 
   const scope = collapseScope(rawScope)
-  const apiKey =
-    typeof api_key === 'string'
-      ? api_key
-      : typeof client_id === 'string'
-        ? client_id
-        : null
+  const apiKey = (() => {
+    const raw =
+      typeof api_key === 'string'
+        ? api_key
+        : typeof client_id === 'string'
+          ? client_id
+          : null
+    if (raw?.toLowerCase().startsWith('0x')) return raw.slice(2)
+    return raw
+  })()
   const redirectUriStr = typeof redirectUri === 'string' ? redirectUri : null
 
   let error: string | null = null

--- a/packages/mobile/src/screens/oauth-screen/utils.ts
+++ b/packages/mobile/src/screens/oauth-screen/utils.ts
@@ -7,8 +7,9 @@ import { audiusSdk } from 'app/services/sdk/audius-sdk'
 // ─── URL / key validation ─────────────────────────────────────────────────────
 
 export const isValidApiKey = (key: string) => {
-  if (key.length !== 40) return false
-  return /^[0-9a-fA-F]+$/.test(key)
+  const normalized = key.toLowerCase().startsWith('0x') ? key.slice(2) : key
+  if (normalized.length !== 40) return false
+  return /^[0-9a-fA-F]+$/.test(normalized)
 }
 
 export const getIsRedirectValid = (

--- a/packages/web/src/pages/oauth-login-page/hooks.ts
+++ b/packages/web/src/pages/oauth-login-page/hooks.ts
@@ -75,12 +75,16 @@ const useParsedQueryParams = () => {
 
   const scope = collapseScopes(rawScope)
 
-  const apiKey =
-    typeof api_key === 'string'
-      ? api_key
-      : typeof client_id === 'string'
-        ? client_id
-        : undefined
+  const apiKey = (() => {
+    const raw =
+      typeof api_key === 'string'
+        ? api_key
+        : typeof client_id === 'string'
+          ? client_id
+          : undefined
+    if (raw?.toLowerCase().startsWith('0x')) return raw.slice(2)
+    return raw
+  })()
 
   const parsedRedirectUri = useMemo<'postmessage' | URL | null>(() => {
     if (redirectUri && typeof redirectUri === 'string') {

--- a/packages/web/src/pages/oauth-login-page/utils.ts
+++ b/packages/web/src/pages/oauth-login-page/utils.ts
@@ -41,11 +41,12 @@ export const getIsRedirectValid = ({
 
 export const isValidApiKey = (key: string | string[]) => {
   if (Array.isArray(key)) return false
-  if (key.length !== 40) {
+  const normalized = key.toLowerCase().startsWith('0x') ? key.slice(2) : key
+  if (normalized.length !== 40) {
     return false
   }
   const hexadecimalRegex = /^[0-9a-fA-F]+$/
-  return hexadecimalRegex.test(key)
+  return hexadecimalRegex.test(normalized)
 }
 
 const getFormattedAppAddress = ({


### PR DESCRIPTION
## Summary
- Strips `0x` prefix from `api_key`/`client_id` query params at parse time in the OAuth consent hooks
- Updates `isValidApiKey` to accept keys with `0x` prefix

## Test plan
- [ ] Verify OAuth consent flow works with `0x`-prefixed API keys
- [ ] Verify OAuth consent flow continues to work with bare hex API keys
- [ ] Verify invalid API keys are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)