### PR TITLE
Add OTA update check and restart on cold start

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -33,6 +33,7 @@ import { Drawers } from './Drawers'
 import ErrorBoundary from './ErrorBoundary'
 import { ThemeProvider } from './ThemeProvider'
 import { initSentry, navigationIntegration } from './sentry'
+import { useOtaStartupRestart } from './useOtaStartupRestart'
 
 initSentry()
 
@@ -52,6 +53,8 @@ if (Platform.OS === 'android') {
 incrementSessionCount()
 
 const App = () => {
+  useOtaStartupRestart()
+
   useEffectOnce(() => {
     subscribeToNetworkStatusUpdates()
     TrackPlayer.setupPlayer({ autoHandleInterruptions: true })

--- a/packages/mobile/src/app/useOtaStartupRestart.ts
+++ b/packages/mobile/src/app/useOtaStartupRestart.ts
@@ -1,11 +1,13 @@
 /**
- * Auto-applies pending OTA updates on cold start.
+ * Downloads and applies OTA updates on cold start.
  *
- * When the app is launched (including from a push notification tap), this hook
- * checks whether a CodePush update was downloaded in a previous session and is
- * waiting to be applied. If so, it restarts the JS bundle immediately — while
- * the native splash screen is still visible — so the user always launches into
- * the latest code.
+ * On every app launch (including from a push notification tap):
+ * 1. If a previously-downloaded update is pending → restart immediately
+ * 2. Otherwise, sync with the server to check/download/install a new update.
+ *    If the sync completes within a timeout window (while the splash screen is
+ *    still visible), restart to apply it. If it takes too long, the update is
+ *    staged as pending and will be applied on the next cold start (or via the
+ *    banner's Restart button).
  *
  * Push-notification deep links survive the restart because
  * `getInitialNotification()` is held at the native layer and persists across
@@ -18,6 +20,9 @@ import CodePush from '@bravemobile/react-native-code-push'
 
 import { isOtaEnabled } from './ota-updates'
 
+/** Max time (ms) to wait for an OTA download before giving up and loading normally. */
+const OTA_STARTUP_TIMEOUT_MS = 10_000
+
 export function useOtaStartupRestart() {
   const didRunRef = useRef(false)
 
@@ -25,21 +30,67 @@ export function useOtaStartupRestart() {
     if (didRunRef.current || !isOtaEnabled()) return
     didRunRef.current = true
 
+    let expired = false
+    const timer = setTimeout(() => {
+      expired = true
+      console.warn(
+        `[OTA] Cold-start sync exceeded ${OTA_STARTUP_TIMEOUT_MS}ms — update will apply on next restart`
+      )
+    }, OTA_STARTUP_TIMEOUT_MS)
+
     ;(async () => {
       try {
+        // 1. Check for an already-downloaded pending update (instant, no network)
         const pending = await CodePush.getUpdateMetadata(
           CodePush.UpdateState.PENDING
         )
         if (pending) {
+          clearTimeout(timer)
           console.warn(
             `[OTA] Pending update on cold start — restarting (appVersion=${pending.appVersion})`
           )
           CodePush.allowRestart()
           CodePush.restartApp(true)
+          return
+        }
+
+        // 2. No pending update — sync to check/download/install new updates.
+        //    Use ON_NEXT_RESTART so CodePush doesn't auto-restart at an
+        //    unpredictable time; we control the restart timing below.
+        const status = await CodePush.sync(
+          {
+            installMode: CodePush.InstallMode.ON_NEXT_RESTART,
+            mandatoryInstallMode: CodePush.InstallMode.ON_NEXT_RESTART
+          },
+          (syncStatus) => {
+            if (
+              syncStatus !== CodePush.SyncStatus.UP_TO_DATE &&
+              syncStatus !== CodePush.SyncStatus.SYNC_IN_PROGRESS
+            ) {
+              console.warn(
+                `[OTA] Cold-start sync status: ${syncStatus}`
+              )
+            }
+          }
+        )
+
+        clearTimeout(timer)
+
+        // 3. If the update was downloaded+installed before the timeout,
+        //    restart now (splash screen should still be visible).
+        if (status === CodePush.SyncStatus.UPDATE_INSTALLED && !expired) {
+          console.warn(
+            '[OTA] Update installed on cold start within timeout — restarting'
+          )
+          CodePush.allowRestart()
+          CodePush.restartApp(true)
         }
       } catch (e) {
-        console.warn('[OTA] Cold-start pending check failed', e)
+        clearTimeout(timer)
+        console.warn('[OTA] Cold-start sync failed', e)
       }
     })()
+
+    return () => clearTimeout(timer)
   }, [])
 }

--- a/packages/mobile/src/app/useOtaStartupRestart.ts
+++ b/packages/mobile/src/app/useOtaStartupRestart.ts
@@ -4,14 +4,14 @@
  * On every app launch (including from a push notification tap):
  * 1. If a previously-downloaded update is pending → restart immediately
  * 2. Otherwise, sync with the server to check/download/install a new update.
- *    If the sync completes within a timeout window (while the splash screen is
- *    still visible), restart to apply it. If it takes too long, the update is
- *    staged as pending and will be applied on the next cold start (or via the
- *    banner's Restart button).
+ *    If the sync completes within the timeout, restart to apply it. If it
+ *    takes too long, the update is staged as pending and will be applied on
+ *    the next cold start (or via the banner's Restart button).
  *
- * Push-notification deep links survive the restart because
- * `getInitialNotification()` is held at the native layer and persists across
- * JS-only CodePush restarts.
+ * The splash screen waits on `otaStartupComplete` before dismissing, so any
+ * restart happens while the splash is still visible. Push-notification deep
+ * links survive the restart because `getInitialNotification()` is held at the
+ * native layer and persists across JS-only CodePush restarts.
  */
 
 import { useEffect, useRef } from 'react'
@@ -23,16 +23,37 @@ import { isOtaEnabled } from './ota-updates'
 /** Max time (ms) to wait for an OTA download before giving up and loading normally. */
 const OTA_STARTUP_TIMEOUT_MS = 10_000
 
+let _resolveStartup: () => void
+
+/**
+ * Resolves when the cold-start OTA check is complete (no update, update
+ * applied, or timeout). The splash screen gates on this so it stays
+ * visible during any OTA restart.
+ */
+export const otaStartupComplete = new Promise<void>((resolve) => {
+  _resolveStartup = resolve
+})
+
+// Safety net: always resolve even if the hook never executes (e.g. crash
+// during provider initialization). Prevents the app from hanging forever.
+setTimeout(_resolveStartup, OTA_STARTUP_TIMEOUT_MS + 5_000)
+
 export function useOtaStartupRestart() {
   const didRunRef = useRef(false)
 
   useEffect(() => {
-    if (didRunRef.current || !isOtaEnabled()) return
+    if (didRunRef.current) return
     didRunRef.current = true
+
+    if (!isOtaEnabled()) {
+      _resolveStartup()
+      return
+    }
 
     let expired = false
     const timer = setTimeout(() => {
       expired = true
+      _resolveStartup()
       console.warn(
         `[OTA] Cold-start sync exceeded ${OTA_STARTUP_TIMEOUT_MS}ms — update will apply on next restart`
       )
@@ -51,6 +72,8 @@ export function useOtaStartupRestart() {
           )
           CodePush.allowRestart()
           CodePush.restartApp(true)
+          // If restart didn't take effect, resolve so the app isn't stuck
+          _resolveStartup()
           return
         }
 
@@ -67,9 +90,7 @@ export function useOtaStartupRestart() {
               syncStatus !== CodePush.SyncStatus.UP_TO_DATE &&
               syncStatus !== CodePush.SyncStatus.SYNC_IN_PROGRESS
             ) {
-              console.warn(
-                `[OTA] Cold-start sync status: ${syncStatus}`
-              )
+              console.warn(`[OTA] Cold-start sync status: ${syncStatus}`)
             }
           }
         )
@@ -77,16 +98,23 @@ export function useOtaStartupRestart() {
         clearTimeout(timer)
 
         // 3. If the update was downloaded+installed before the timeout,
-        //    restart now (splash screen should still be visible).
+        //    restart now (splash screen is held open via otaStartupComplete).
         if (status === CodePush.SyncStatus.UPDATE_INSTALLED && !expired) {
           console.warn(
             '[OTA] Update installed on cold start within timeout — restarting'
           )
           CodePush.allowRestart()
           CodePush.restartApp(true)
+          // If restart didn't take effect, resolve so the app isn't stuck
+          _resolveStartup()
+          return
         }
+
+        // No update found or timeout already expired — let the app load
+        _resolveStartup()
       } catch (e) {
         clearTimeout(timer)
+        _resolveStartup()
         console.warn('[OTA] Cold-start sync failed', e)
       }
     })()

--- a/packages/mobile/src/app/useOtaStartupRestart.ts
+++ b/packages/mobile/src/app/useOtaStartupRestart.ts
@@ -1,0 +1,45 @@
+/**
+ * Auto-applies pending OTA updates on cold start.
+ *
+ * When the app is launched (including from a push notification tap), this hook
+ * checks whether a CodePush update was downloaded in a previous session and is
+ * waiting to be applied. If so, it restarts the JS bundle immediately — while
+ * the native splash screen is still visible — so the user always launches into
+ * the latest code.
+ *
+ * Push-notification deep links survive the restart because
+ * `getInitialNotification()` is held at the native layer and persists across
+ * JS-only CodePush restarts.
+ */
+
+import { useEffect, useRef } from 'react'
+
+import CodePush from '@bravemobile/react-native-code-push'
+
+import { isOtaEnabled } from './ota-updates'
+
+export function useOtaStartupRestart() {
+  const didRunRef = useRef(false)
+
+  useEffect(() => {
+    if (didRunRef.current || !isOtaEnabled()) return
+    didRunRef.current = true
+
+    ;(async () => {
+      try {
+        const pending = await CodePush.getUpdateMetadata(
+          CodePush.UpdateState.PENDING
+        )
+        if (pending) {
+          console.warn(
+            `[OTA] Pending update on cold start — restarting (appVersion=${pending.appVersion})`
+          )
+          CodePush.allowRestart()
+          CodePush.restartApp(true)
+        }
+      } catch (e) {
+        console.warn('[OTA] Cold-start pending check failed', e)
+      }
+    })()
+  }, [])
+}

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -24,6 +24,7 @@ import {
 import { Platform } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { otaStartupComplete } from 'app/app/useOtaStartupRestart'
 import useAppState from 'app/hooks/useAppState'
 import { useDrawer } from 'app/hooks/useDrawer'
 import { useNavigation } from 'app/hooks/useNavigation'
@@ -76,6 +77,7 @@ export const RootScreen = () => {
   const welcomeModalShown = useSelector(getWelcomeModalShown)
   const isAndroid = Platform.OS === MobileOS.ANDROID
 
+  const [isOtaReady, setIsOtaReady] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
   const [isSplashScreenDismissed, setIsSplashScreenDismissed] = useState(false)
   const { navigate } = useNavigation()
@@ -90,9 +92,22 @@ export const RootScreen = () => {
 
   useResetNotificationBadgeCount()
 
+  // Wait for the cold-start OTA check to finish (or time out) so any
+  // restart happens while the splash screen is still visible.
+  useEffect(() => {
+    let cancelled = false
+    otaStartupComplete.then(() => {
+      if (!cancelled) setIsOtaReady(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   useEffect(() => {
     if (
       !isLoaded &&
+      isOtaReady &&
       (accountStatus === Status.SUCCESS || accountStatus === Status.ERROR)
     ) {
       // Reset the player when the app is loaded for the first time. Fixes an issue
@@ -100,7 +115,7 @@ export const RootScreen = () => {
       dispatch(reset({ shouldAutoplay: false }))
       setIsLoaded(true)
     }
-  }, [accountStatus, setIsLoaded, isLoaded, dispatch])
+  }, [accountStatus, setIsLoaded, isLoaded, isOtaReady, dispatch])
 
   // Connect to chats websockets and prefetch chats
   useEffect(() => {


### PR DESCRIPTION
## Summary
Implements automatic OTA (Over-The-Air) update checking and application on app cold start. The feature checks for pending updates and syncs with the server to download/install new updates, with intelligent restart timing that keeps the splash screen visible during the process.

## Key Changes
- **New hook `useOtaStartupRestart`**: Manages the cold-start OTA update lifecycle
  - Checks for previously-downloaded pending updates and restarts immediately if found
  - Syncs with CodePush server to check/download/install new updates with a 10-second timeout
  - Restarts the app if an update completes within the timeout window
  - Stages updates as pending if sync exceeds timeout, applying them on next cold start
  - Exports `otaStartupComplete` promise that resolves when the OTA check finishes

- **Updated `App.tsx`**: Calls `useOtaStartupRestart()` at the root level to ensure OTA checks run on every app launch

- **Updated `RootScreen.tsx`**: Gates app initialization on `otaStartupComplete`
  - Adds `isOtaReady` state that waits for the OTA startup promise to resolve
  - Delays setting `isLoaded` until both account status is ready AND OTA check is complete
  - Ensures splash screen remains visible during any OTA restart

## Implementation Details
- The splash screen is held open by gating on `otaStartupComplete`, so restarts happen seamlessly while the splash is visible
- Push notification deep links survive JS-only CodePush restarts because `getInitialNotification()` is held at the native layer
- A safety net timeout (15 seconds) prevents the app from hanging if the hook never executes
- Uses `ON_NEXT_RESTART` install mode to prevent CodePush from auto-restarting at unpredictable times
- Comprehensive logging for debugging OTA sync status and timing

https://claude.ai/code/session_0185bgoxLSH5uxDpZbxhwmEN