### PR TITLE
Add collectionId to PLAYBACK_PLAY analytics events

### DIFF
--- a/.changeset/playlist-play-collection-id.md
+++ b/.changeset/playlist-play-collection-id.md
@@ -1,0 +1,7 @@
+---
+"@audius/common": patch
+"@audius/mobile": patch
+"@audius/web": patch
+---
+
+Add collectionId to PLAYBACK_PLAY analytics events when a track is played from a playlist or album context

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1476,6 +1476,7 @@ type PlaybackPlay = {
   id?: string
   isPreview?: boolean
   source: PlaybackSource
+  collectionId?: string
 }
 type PlaybackPause = {
   eventName: Name.PLAYBACK_PAUSE

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -167,12 +167,19 @@ type CollectionScreenDetailsTileProps = {
   | 'contentType'
 >
 
-const recordPlay = (id: Maybe<number>, play = true) => {
+const recordPlay = (
+  id: Maybe<number>,
+  play = true,
+  collectionId?: Maybe<number>
+) => {
   track(
     make({
       eventName: play ? Name.PLAYBACK_PLAY : Name.PLAYBACK_PAUSE,
       id: String(id),
-      source: PlaybackSource.PLAYLIST_PAGE
+      source: PlaybackSource.PLAYLIST_PAGE,
+      ...(play && collectionId != null
+        ? { collectionId: String(collectionId) }
+        : {})
     })
   )
 }
@@ -337,7 +344,7 @@ export const CollectionScreenDetailsTile = ({
         recordPlay(playingTrackId, false)
       } else if (!isPlaying && isQueued) {
         dispatch(tracksActions.play())
-        recordPlay(playingTrackId)
+        recordPlay(playingTrackId, true, numericCollectionId)
         recordPlaylistPlay({
           collectionId: numericCollectionId,
           isAlbum: !!isAlbum,
@@ -347,7 +354,7 @@ export const CollectionScreenDetailsTile = ({
       } else if (trackCount > 0 && firstTrack) {
         dispatch(queueActions.clear({}))
         dispatch(tracksActions.play(firstTrack.uid, { isPreview }))
-        recordPlay(firstTrack.id)
+        recordPlay(firstTrack.id, true, numericCollectionId)
         recordPlaylistPlay({
           collectionId: numericCollectionId,
           isAlbum: !!isAlbum,
@@ -582,13 +589,13 @@ const CollectionTrackList = ({
         recordPlay(id, false)
       } else if (playingUid !== uid) {
         dispatch(tracksActions.play(uid))
-        recordPlay(id)
+        recordPlay(id, true, numericCollectionId)
       } else {
         dispatch(tracksActions.play())
-        recordPlay(id)
+        recordPlay(id, true, numericCollectionId)
       }
     },
-    [dispatch, isPlaying, playingUid]
+    [dispatch, isPlaying, playingUid, numericCollectionId]
   )
   return (
     <TrackList

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -418,13 +418,11 @@ function* watchNext() {
               playerBehavior
             })
           )
-          const queueCollectionId = yield* select(getCollectionId)
+          const collId = yield* select(getCollectionId)
           const event = make(Name.PLAYBACK_PLAY, {
             id: `${id}`,
             source: PlaybackSource.PASSIVE,
-            ...(queueCollectionId
-              ? { collectionId: queueCollectionId }
-              : {})
+            ...(collId ? { collectionId: collId } : {})
           })
           yield* put(event)
         }
@@ -512,13 +510,11 @@ function* watchPrevious() {
               playerBehavior
             })
           )
-          const queueCollectionId = yield* select(getCollectionId)
+          const collId = yield* select(getCollectionId)
           const event = make(Name.PLAYBACK_PLAY, {
             id: `${id}`,
             source: PlaybackSource.PASSIVE,
-            ...(queueCollectionId
-              ? { collectionId: queueCollectionId }
-              : {})
+            ...(collId ? { collectionId: collId } : {})
           })
           yield* put(event)
         } else {

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -51,7 +51,8 @@ const {
   getShuffle,
   getSource,
   getUid,
-  getUndershot
+  getUndershot,
+  getCollectionId
 } = queueSelectors
 
 const { getProfileUserHandle } = profilePageSelectors
@@ -417,9 +418,13 @@ function* watchNext() {
               playerBehavior
             })
           )
+          const queueCollectionId = yield* select(getCollectionId)
           const event = make(Name.PLAYBACK_PLAY, {
             id: `${id}`,
-            source: PlaybackSource.PASSIVE
+            source: PlaybackSource.PASSIVE,
+            ...(queueCollectionId
+              ? { collectionId: queueCollectionId }
+              : {})
           })
           yield* put(event)
         }
@@ -507,9 +512,13 @@ function* watchPrevious() {
               playerBehavior
             })
           )
+          const queueCollectionId = yield* select(getCollectionId)
           const event = make(Name.PLAYBACK_PLAY, {
             id: `${id}`,
-            source: PlaybackSource.PASSIVE
+            source: PlaybackSource.PASSIVE,
+            ...(queueCollectionId
+              ? { collectionId: queueCollectionId }
+              : {})
           })
           yield* put(event)
         } else {

--- a/packages/web/src/components/track/desktop/CollectionTile.tsx
+++ b/packages/web/src/components/track/desktop/CollectionTile.tsx
@@ -244,7 +244,8 @@ export const CollectionTile = ({
             record(
               make(Name.PLAYBACK_PLAY, {
                 id: `${playingTrackId}`,
-                source: PlaybackSource.PLAYLIST_TILE_TRACK
+                source: PlaybackSource.PLAYLIST_TILE_TRACK,
+                collectionId: `${id}`
               })
             )
             record(
@@ -265,7 +266,8 @@ export const CollectionTile = ({
             record(
               make(Name.PLAYBACK_PLAY, {
                 id: `${trackId}`,
-                source: PlaybackSource.PLAYLIST_TILE_TRACK
+                source: PlaybackSource.PLAYLIST_TILE_TRACK,
+                collectionId: `${id}`
               })
             )
             record(

--- a/packages/web/src/components/track/mobile/CollectionTile.tsx
+++ b/packages/web/src/components/track/mobile/CollectionTile.tsx
@@ -422,7 +422,8 @@ export const CollectionTile = ({
         record(
           make(Name.PLAYBACK_PLAY, {
             id: `${playingTrackId}`,
-            source
+            source,
+            collectionId: `${collection.playlist_id}`
           })
         )
         record(
@@ -441,7 +442,8 @@ export const CollectionTile = ({
         record(
           make(Name.PLAYBACK_PLAY, {
             id: `${trackId}`,
-            source
+            source,
+            collectionId: `${collection.playlist_id}`
           })
         )
         record(

--- a/packages/web/src/pages/collection-page/useCollectionPage.ts
+++ b/packages/web/src/pages/collection-page/useCollectionPage.ts
@@ -444,7 +444,8 @@ export const useCollectionPage = (
         dispatch(
           make(Name.PLAYBACK_PLAY, {
             id: `${trackRecord.track_id}`,
-            source: PlaybackSource.PLAYLIST_TRACK
+            source: PlaybackSource.PLAYLIST_TRACK,
+            ...(playlistId ? { collectionId: `${playlistId}` } : {})
           })
         )
       } else {
@@ -452,12 +453,13 @@ export const useCollectionPage = (
         dispatch(
           make(Name.PLAYBACK_PLAY, {
             id: `${trackRecord.track_id}`,
-            source: PlaybackSource.PLAYLIST_TRACK
+            source: PlaybackSource.PLAYLIST_TRACK,
+            ...(playlistId ? { collectionId: `${playlistId}` } : {})
           })
         )
       }
     },
-    [playing, getPlayingUid, dispatch]
+    [playing, getPlayingUid, dispatch, playlistId]
   )
 
   const onClickRepostTrack = useCallback(
@@ -545,7 +547,8 @@ export const useCollectionPage = (
           make(Name.PLAYBACK_PLAY, {
             id: `${playingId}`,
             isPreview: shouldPreview,
-            source: PlaybackSource.PLAYLIST_PAGE
+            source: PlaybackSource.PLAYLIST_PAGE,
+            ...(playlistId ? { collectionId: `${playlistId}` } : {})
           })
         )
         if (playlistId) {
@@ -570,7 +573,8 @@ export const useCollectionPage = (
           make(Name.PLAYBACK_PLAY, {
             id: `${tracks.entries[0].track_id}`,
             isPreview: shouldPreview,
-            source: PlaybackSource.PLAYLIST_PAGE
+            source: PlaybackSource.PLAYLIST_PAGE,
+            ...(playlistId ? { collectionId: `${playlistId}` } : {})
           })
         )
         if (playlistId) {


### PR DESCRIPTION
## Summary

- Adds `collectionId` to the `PlaybackPlay` Amplitude analytics event type, so every `PLAYBACK_PLAY` event fired from a playlist/album context now includes the collection ID
- Enriches all collection play surfaces: web collection page, web collection tiles (desktop + mobile), queue sagas (passive next/prev), and mobile collection screen
- Complements the `PLAYLIST_PLAY` event from #14087 — that tracks playlist-level play intent, while this tracks individual track plays attributed to a specific playlist/album

This enables Amplitude queries like:
- "How many track plays originated from playlists vs other sources?"
- "Which playlists drive the most track plays?"
- "What % of a track's plays came from playlist X?"

## Test plan

- [ ] Play a track from a playlist page on web — verify Amplitude `Playback: Play` event includes `collectionId`
- [ ] Click a track row within a playlist on web — verify `collectionId` is present
- [ ] Let a track auto-advance (next) within a playlist on web — verify passive `Playback: Play` event includes `collectionId`
- [ ] Play from a collection tile on web (desktop + mobile web) — verify `collectionId` is present
- [ ] Play a track from a collection screen on mobile — verify `collectionId` is present
- [ ] Play a track from a non-collection context (e.g. track page, trending) — verify `collectionId` is NOT present

https://claude.ai/code/session_01QszUni9cixkeUCYyViirgV