### PR TITLE
claude/fix-mobile-explore-lineup-Kn4wK

### DIFF
--- a/.changeset/explore-tracks-lineup-playback.md
+++ b/.changeset/explore-tracks-lineup-playback.md
@@ -1,0 +1,7 @@
+---
+"@audius/common": patch
+"@audius/mobile": patch
+"@audius/web": patch
+---
+
+Fix Explore page tracks to queue as a lineup so pressing next plays the next track in the section

--- a/packages/common/src/hooks/chats/useTrackPlayer.ts
+++ b/packages/common/src/hooks/chats/useTrackPlayer.ts
@@ -22,6 +22,7 @@ type UseToggleTrack = {
   isPreview?: boolean
   recordAnalytics?: RecordAnalytics
   id?: Nullable<ID>
+  entries?: Queueable[]
 }
 
 /**
@@ -122,7 +123,8 @@ export const useToggleTrack = ({
   uid,
   source,
   recordAnalytics,
-  id
+  id,
+  entries: entriesProp
 }: UseToggleTrack) => {
   const currentQueueItem = useSelector(makeGetCurrent())
   const currentTrack = useCurrentTrack()
@@ -144,10 +146,10 @@ export const useToggleTrack = ({
       playTrack({
         id,
         uid,
-        entries: [{ id, uid, source }]
+        entries: entriesProp ?? [{ id, uid, source }]
       })
     }
-  }, [playTrack, pauseTrack, isTrackPlaying, id, uid, source])
+  }, [playTrack, pauseTrack, isTrackPlaying, id, uid, source, entriesProp])
 
   return { togglePlay, isTrackPlaying }
 }

--- a/packages/common/src/hooks/chats/useTrackPlayer.ts
+++ b/packages/common/src/hooks/chats/useTrackPlayer.ts
@@ -129,15 +129,10 @@ export const useToggleTrack = ({
   const currentQueueItem = useSelector(makeGetCurrent())
   const currentTrack = useCurrentTrack()
   const playing = useSelector(getPlaying)
-  // Match by queue UID when possible (necessary for lineups with duplicate
-  // tracks), but fall back to matching by track ID so the playing indicator
-  // persists across component remounts. On remount, makeUid generates fresh
-  // UIDs via a module-level counter so the tile's UID no longer matches the
-  // queue entry's UID, even though the same track is still playing.
   const isTrackPlaying = !!(
     playing &&
     currentTrack &&
-    (currentQueueItem.uid === uid || currentTrack.track_id === id)
+    currentQueueItem.uid === uid
   )
 
   const playTrack = usePlayTrack(recordAnalytics)

--- a/packages/common/src/hooks/chats/useTrackPlayer.ts
+++ b/packages/common/src/hooks/chats/useTrackPlayer.ts
@@ -129,10 +129,15 @@ export const useToggleTrack = ({
   const currentQueueItem = useSelector(makeGetCurrent())
   const currentTrack = useCurrentTrack()
   const playing = useSelector(getPlaying)
+  // Match by queue UID when possible (necessary for lineups with duplicate
+  // tracks), but fall back to matching by track ID so the playing indicator
+  // persists across component remounts. On remount, makeUid generates fresh
+  // UIDs via a module-level counter so the tile's UID no longer matches the
+  // queue entry's UID, even though the same track is still playing.
   const isTrackPlaying = !!(
     playing &&
     currentTrack &&
-    currentQueueItem.uid === uid
+    (currentQueueItem.uid === uid || currentTrack.track_id === id)
   )
 
   const playTrack = usePlayTrack(recordAnalytics)

--- a/packages/common/src/utils/uid.ts
+++ b/packages/common/src/utils/uid.ts
@@ -105,6 +105,19 @@ export function makeUid(kind: string, id: ID, source?: string) {
 }
 
 /**
+ * Builds a deterministic UID for a given (kind, id, source). Unlike `makeUid`,
+ * this always returns the same string for the same inputs, so the UID is
+ * stable across component remounts. Use this when a track appears at most
+ * once in a single context (e.g., a section of unique recommended tracks),
+ * so that the tile's UID continues to match the queue entry's UID after
+ * remounting. Do not use for lineups that may contain the same track more
+ * than once — there, each instance must be uniquely identified by its UID.
+ */
+export function makeStableUid(kind: string, id: ID, source?: string) {
+  return new Uid(kind, id, source, 0).toString()
+}
+
+/**
  * A persistant identifier for a resource for re-use within a session.
  * Differs from a uid, which represents an instance.
  * @param kind

--- a/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react'
 import { useToggleTrack } from '@audius/common/hooks'
 import { Kind } from '@audius/common/models'
 import type { Queueable, QueueSource } from '@audius/common/store'
-import { makeUid } from '@audius/common/utils'
+import { makeStableUid } from '@audius/common/utils'
 import { ScrollView } from 'react-native'
 
 import { Flex } from '@audius/harmony-native'
@@ -57,7 +57,7 @@ export const TrackTileCarousel = ({
     if (!tracks) return []
     return tracks.map((id) => ({
       id,
-      uid: makeUid(Kind.TRACKS, id, source),
+      uid: makeStableUid(Kind.TRACKS, id, source),
       source
     }))
   }, [tracks, source])

--- a/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 
 import { useToggleTrack } from '@audius/common/hooks'
 import { Kind } from '@audius/common/models'
-import type { QueueSource } from '@audius/common/store'
+import type { Queueable, QueueSource } from '@audius/common/store'
 import { makeUid } from '@audius/common/utils'
 import { ScrollView } from 'react-native'
 
@@ -19,19 +19,22 @@ const CarouselItem = ({
   id,
   pairIndex,
   trackIndex,
-  source
+  source,
+  entries
 }: {
   id: number
   pairIndex: number
   trackIndex: number
   source: QueueSource
+  entries: Queueable[]
 }) => {
   const uid = useMemo(() => makeUid(Kind.TRACKS, id, source), [id, source])
 
   const { togglePlay } = useToggleTrack({
     id,
     uid,
-    source
+    source,
+    entries
   })
 
   return (
@@ -50,6 +53,15 @@ export const TrackTileCarousel = ({
   isLoading,
   source
 }: TrackTileCarouselProps) => {
+  const entries = useMemo(() => {
+    if (!tracks) return []
+    return tracks.map((id) => ({
+      id,
+      uid: makeUid(Kind.TRACKS, id, source),
+      source
+    }))
+  }, [tracks, source])
+
   if (isLoading || !tracks) {
     return (
       <Flex direction='row' mh={-16}>
@@ -103,6 +115,7 @@ export const TrackTileCarousel = ({
                 pairIndex={pairIndex}
                 trackIndex={trackIndex}
                 source={source}
+                entries={entries}
               />
             ))}
           </Flex>

--- a/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/TrackTileCarousel.tsx
@@ -17,19 +17,19 @@ interface TrackTileCarouselProps {
 
 const CarouselItem = ({
   id,
+  uid,
   pairIndex,
   trackIndex,
   source,
   entries
 }: {
   id: number
+  uid: string
   pairIndex: number
   trackIndex: number
   source: QueueSource
   entries: Queueable[]
 }) => {
-  const uid = useMemo(() => makeUid(Kind.TRACKS, id, source), [id, source])
-
   const { togglePlay } = useToggleTrack({
     id,
     uid,
@@ -108,16 +108,20 @@ export const TrackTileCarousel = ({
             w={343}
             mr={pairIndex < trackPairs.length - 1 ? 16 : 0}
           >
-            {pair.map((track, trackIndex) => (
-              <CarouselItem
-                key={track}
-                id={track}
-                pairIndex={pairIndex}
-                trackIndex={trackIndex}
-                source={source}
-                entries={entries}
-              />
-            ))}
+            {pair.map((track, trackIndex) => {
+              const entryIndex = pairIndex * 2 + trackIndex
+              return (
+                <CarouselItem
+                  key={track}
+                  id={track}
+                  uid={entries[entryIndex].uid}
+                  pairIndex={pairIndex}
+                  trackIndex={trackIndex}
+                  source={source}
+                  entries={entries}
+                />
+              )
+            })}
           </Flex>
         ))}
       </ScrollView>

--- a/packages/web/src/pages/search-explore-page/components/desktop/TileHelpers.tsx
+++ b/packages/web/src/pages/search-explore-page/components/desktop/TileHelpers.tsx
@@ -4,7 +4,7 @@ import { useToggleTrack } from '@audius/common/hooks'
 import { ID, Kind, UID } from '@audius/common/models'
 import type { Queueable } from '@audius/common/store'
 import { QueueSource } from '@audius/common/store'
-import { makeUid } from '@audius/common/utils'
+import { makeStableUid } from '@audius/common/utils'
 import { Flex } from '@audius/harmony'
 
 import { TrackTile as DesktopTrackTile } from 'components/track/desktop/TrackTile'
@@ -84,7 +84,7 @@ export const TilePairs = ({
     () =>
       data.map((id) => ({
         id,
-        uid: makeUid(Kind.TRACKS, id, source),
+        uid: makeStableUid(Kind.TRACKS, id, source),
         source
       })),
     [data, source]

--- a/packages/web/src/pages/search-explore-page/components/desktop/TileHelpers.tsx
+++ b/packages/web/src/pages/search-explore-page/components/desktop/TileHelpers.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react'
 
 import { useToggleTrack } from '@audius/common/hooks'
 import { ID, Kind, UID } from '@audius/common/models'
+import type { Queueable } from '@audius/common/store'
 import { QueueSource } from '@audius/common/store'
 import { makeUid } from '@audius/common/utils'
 import { Flex } from '@audius/harmony'
@@ -17,11 +18,13 @@ import { MOBILE_TILE_WIDTH, TILE_WIDTH } from './constants'
 export const PlayableTile = ({
   id,
   index,
-  source = QueueSource.EXPLORE
+  source = QueueSource.EXPLORE,
+  entries
 }: {
   id: ID
   index: number
   source?: QueueSource
+  entries?: Queueable[]
 }) => {
   const isMobile = useIsMobile()
   const Tile = isMobile ? MobileTrackTile : DesktopTrackTile
@@ -30,7 +33,8 @@ export const PlayableTile = ({
   const { togglePlay, isTrackPlaying } = useToggleTrack({
     id,
     uid,
-    source
+    source,
+    entries
   })
 
   // Create lineup-style togglePlay function that TrackTile expects
@@ -74,6 +78,17 @@ export const TilePairs = ({
   for (let i = 0; i < data.length; i += 2) {
     pairs.push(data.slice(i, i + 2))
   }
+
+  const entries = useMemo(
+    () =>
+      data.map((id) => ({
+        id,
+        uid: makeUid(Kind.TRACKS, id, source),
+        source
+      })),
+    [data, source]
+  )
+
   return (
     <>
       {pairs.map((pair, pairIndex) => (
@@ -89,6 +104,7 @@ export const TilePairs = ({
               id={id}
               index={pairIndex * 2 + idIndex}
               source={source}
+              entries={entries}
             />
           ))}
         </Flex>

--- a/packages/web/src/pages/search-explore-page/components/desktop/TileHelpers.tsx
+++ b/packages/web/src/pages/search-explore-page/components/desktop/TileHelpers.tsx
@@ -17,18 +17,19 @@ import { MOBILE_TILE_WIDTH, TILE_WIDTH } from './constants'
 // Wrapper component to make tiles playable
 export const PlayableTile = ({
   id,
+  uid,
   index,
   source = QueueSource.EXPLORE,
   entries
 }: {
   id: ID
+  uid: UID
   index: number
   source?: QueueSource
   entries?: Queueable[]
 }) => {
   const isMobile = useIsMobile()
   const Tile = isMobile ? MobileTrackTile : DesktopTrackTile
-  const uid = useMemo(() => makeUid(Kind.TRACKS, id, source), [id, source])
 
   const { togglePlay, isTrackPlaying } = useToggleTrack({
     id,
@@ -98,15 +99,19 @@ export const TilePairs = ({
           gap='m'
           css={{ minWidth: tileWidth, width: tileWidth }}
         >
-          {pair.map((id, idIndex) => (
-            <PlayableTile
-              key={id}
-              id={id}
-              index={pairIndex * 2 + idIndex}
-              source={source}
-              entries={entries}
-            />
-          ))}
+          {pair.map((id, idIndex) => {
+            const entryIndex = pairIndex * 2 + idIndex
+            return (
+              <PlayableTile
+                key={id}
+                id={id}
+                uid={entries[entryIndex].uid}
+                index={entryIndex}
+                source={source}
+                entries={entries}
+              />
+            )
+          })}
         </Flex>
       ))}
     </>


### PR DESCRIPTION
Previously, tapping a track on the Explore page only added that single
track to the queue, so pressing "next" had nowhere to go. Now all tracks
in a section are added as queue entries, enabling sequential playback.

https://claude.ai/code/session_01PQ455Hwe7MwgKtCfPkih3t