### PR TITLE
claude/minimize-bottom-bar-Cy95U

### DIFF
--- a/.changeset/minimize-bottom-tab-bar.md
+++ b/.changeset/minimize-bottom-tab-bar.md
@@ -1,0 +1,5 @@
+---
+"@audius/mobile": patch
+---
+
+Reduce the mobile bottom tab bar height so it no longer feels oversized. The 28px icons are preserved; only the surrounding chrome is trimmed.

--- a/packages/mobile/src/components/bottom-tab-bar/constants.ts
+++ b/packages/mobile/src/components/bottom-tab-bar/constants.ts
@@ -1,4 +1,4 @@
-export const BOTTOM_BAR_HEIGHT = 49
+export const BOTTOM_BAR_HEIGHT = 41
 // Accounting for border
 // see: https://github.com/facebook/react-native/issues/23994
-export const BOTTOM_BAR_BUTTON_HEIGHT = 48
+export const BOTTOM_BAR_BUTTON_HEIGHT = 40


### PR DESCRIPTION
The bottom bar felt visually oversized. The 28px Lottie icons only need
modest breathing room, so trim the button container from 48 to 40 (6px
top/bottom padding around the icon). Total bar chrome shrinks from 49 to
41 before the safe-area inset.

https://claude.ai/code/session_01E1864Fi27SkqkuzxA659qt