### PR TITLE
Mobile: remove unintended artwork opacity overlay

### DIFF
--- a/packages/mobile/src/harmony-native/components/Artwork.tsx
+++ b/packages/mobile/src/harmony-native/components/Artwork.tsx
@@ -1,11 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { useTheme } from '@emotion/react'
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming
-} from 'react-native-reanimated'
 
 import { Image } from './Image/Image'
 import type { ImageProps } from './Image/Image'
@@ -13,8 +8,6 @@ import { Skeleton } from './Skeleton'
 import { Box } from './layout/Box/Box'
 import type { BoxProps } from './layout/Box/types'
 import { Flex } from './layout/Flex/Flex'
-
-const AnimatedImage = Animated.createAnimatedComponent(Image)
 
 export type ArtworkProps = {
   isLoading?: boolean
@@ -46,7 +39,7 @@ export const Artwork = (props: ArtworkProps) => {
   } = props
   const [isLoadingState, setIsLoadingState] = useState(true)
   const isLoading = isLoadingProp ?? isLoadingState
-  const { color, cornerRadius, motion } = useTheme()
+  const { color, cornerRadius } = useTheme()
 
   const imageSource = !source
     ? source
@@ -57,23 +50,6 @@ export const Artwork = (props: ArtworkProps) => {
         : { uri: source.uri }
 
   const hasImageSource = typeof imageSource === 'number' || imageSource?.uri
-
-  // Create shared value for opacity
-  const opacity = useSharedValue(0)
-
-  // Create animated style
-  const animatedStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value
-  }))
-
-  // Animate opacity when loading state changes
-  useEffect(() => {
-    if (!isLoading) {
-      opacity.value = withTiming(1, motion.expressive)
-    } else {
-      opacity.value = 0
-    }
-  }, [isLoading, opacity, motion.expressive])
 
   return (
     <Box {...other}>
@@ -107,19 +83,16 @@ export const Artwork = (props: ArtworkProps) => {
           }}
         />
         {hasImageSource ? (
-          <AnimatedImage
+          <Image
             testID={testId}
-            style={[
-              {
-                height: '100%',
-                width: '100%',
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                borderRadius: cornerRadius[borderRadius]
-              },
-              animatedStyle
-            ]}
+            style={{
+              height: '100%',
+              width: '100%',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              borderRadius: cornerRadius[borderRadius]
+            }}
             onLoad={(event) => {
               setIsLoadingState(false)
               onLoad?.(event)
@@ -139,8 +112,6 @@ export const Artwork = (props: ArtworkProps) => {
               position: 'absolute',
               top: 0,
               left: 0,
-              backgroundColor: hasImageSource ? color.static.black : undefined,
-              opacity: hasImageSource ? 0.4 : undefined,
               zIndex: 1
             }}
           >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem
Track tile artwork was being rendered with an unintended opacity/overlay effect that made images look washed out (lightened in dark mode, darkened in light mode).

### Fix
- Updated `packages/mobile/src/harmony-native/components/Artwork.tsx` to stop applying a global animated opacity on the image.
- Removed the default semi-transparent scrim that was applied when `children` were present.

This keeps artwork fully opaque by default; any intentional dimming should be applied explicitly by the caller.

### Notes
Local tests/lint were not run in this agent VM because the repo `preinstall` script requires `pyenv` (not available here).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab6a002a-88f0-46df-bde3-3086ff3e77ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab6a002a-88f0-46df-bde3-3086ff3e77ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

