### PR TITLE
Fix two pre-existing failing comment indexer tests

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
@@ -799,7 +799,7 @@ def test_comment_reaction(app, mocker):
 
     reaction_entities = {
         **entities,
-        "comments": [{"comment_id": 1, "user_id": 2}],
+        "comments": [{"comment_id": 1, "user_id": 2, "entity_id": 1}],
     }
 
     tx_receipts = {

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -241,8 +241,11 @@ def create_comment(params: ManageEntityParameters):
 
     comment_id = params.entity_id
     # Only fan club posts can be members-only; track comments are never gated.
+    # Note: parse_metadata normalizes missing fields to None (not absent), so we can't
+    # rely on dict.get's default — we must explicitly treat None as "field omitted".
+    is_members_only_meta = metadata.get("is_members_only")
     is_members_only = (
-        bool(metadata.get("is_members_only", True))
+        (True if is_members_only_meta is None else bool(is_members_only_meta))
         if entity_type == FAN_CLUB_ENTITY_TYPE
         else False
     )


### PR DESCRIPTION
test_comment_reaction: the test seeded a Comment row via populate_mock_db with only {comment_id, user_id}, causing populate_mock_db's default entity_id=i (loop index 0) to be stored. react_comment then looked up TRACK[0] in existing_records and blew up with KeyError: 0. Pin the seeded comment to entity_id=1 so it matches the track referenced by the React tx.

test_fan_club_comment_is_members_only_default: parse_metadata runs incoming payloads through get_metadata_from_json, which populates every key in comment_metadata_format. Missing fields become literal None values instead of being absent, so metadata.get("is_members_only", True) returned None (key present) rather than the True default. Fan-club comments that omit is_members_only ended up with False. Explicitly treat None as "omitted" and default to True for fan-club comments.