### PR TITLE
fix(mobile): remove themed backdrop behind track tile image

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileArt.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileArt.tsx
@@ -1,26 +1,9 @@
 import type { StyleProp, ViewStyle } from 'react-native'
-import { View } from 'react-native'
 
 import { TrackFlair, Size } from 'app/components/track-flair'
-import { makeStyles } from 'app/styles'
-
-import { FadeInView } from '../core'
 
 import { useStyles as useTrackTileStyles } from './styles'
 import type { RenderImage } from './types'
-
-const useStyles = makeStyles(({ palette }) => ({
-  imageRoot: {
-    position: 'relative'
-  },
-  image: {
-    position: 'absolute'
-  },
-  backdrop: {
-    position: 'absolute',
-    backgroundColor: palette.skeleton
-  }
-}))
 
 type LineupTileArtProps = {
   renderImage: RenderImage
@@ -31,16 +14,6 @@ type LineupTileArtProps = {
 export const LineupTileArt = (props: LineupTileArtProps) => {
   const { renderImage, style, trackId } = props
   const trackTileStyles = useTrackTileStyles()
-  const styles = useStyles()
-
-  const imageElement = (
-    <View style={styles.imageRoot}>
-      <View style={[trackTileStyles.image, styles.backdrop]} />
-      <FadeInView style={styles.image} startOpacity={0} duration={500}>
-        {renderImage({ style: trackTileStyles.image })}
-      </FadeInView>
-    </View>
-  )
 
   return (
     <TrackFlair
@@ -48,7 +21,7 @@ export const LineupTileArt = (props: LineupTileArtProps) => {
       size={Size.SMALL}
       style={[style, trackTileStyles.image]}
     >
-      {imageElement}
+      {renderImage({ style: trackTileStyles.image })}
     </TrackFlair>
   )
 }

--- a/packages/mobile/src/harmony-native/components/Artwork.tsx
+++ b/packages/mobile/src/harmony-native/components/Artwork.tsx
@@ -100,8 +100,9 @@ export const Artwork = (props: ArtworkProps) => {
           pt='100%'
           borderRadius={borderRadius}
           style={{
-            backgroundColor:
-              !hasImageSource && children
+            backgroundColor: hasImageSource
+              ? undefined
+              : children
                 ? color.neutral.n100
                 : color.background.surface2
           }}

--- a/packages/mobile/src/harmony-native/components/Artwork.tsx
+++ b/packages/mobile/src/harmony-native/components/Artwork.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { Children, useEffect, useState } from 'react'
 
 import { useTheme } from '@emotion/react'
 import Animated, {
@@ -57,6 +57,7 @@ export const Artwork = (props: ArtworkProps) => {
         : { uri: source.uri }
 
   const hasImageSource = typeof imageSource === 'number' || imageSource?.uri
+  const hasChildren = Children.toArray(children).length > 0
 
   // Create shared value for opacity
   const opacity = useSharedValue(0)
@@ -100,9 +101,8 @@ export const Artwork = (props: ArtworkProps) => {
           pt='100%'
           borderRadius={borderRadius}
           style={{
-            backgroundColor: hasImageSource
-              ? undefined
-              : children
+            backgroundColor:
+              !hasImageSource && hasChildren
                 ? color.neutral.n100
                 : color.background.surface2
           }}
@@ -129,7 +129,7 @@ export const Artwork = (props: ArtworkProps) => {
             source={imageSource}
           />
         ) : null}
-        {children ? (
+        {hasChildren ? (
           <Flex
             alignItems='center'
             justifyContent='center'


### PR DESCRIPTION
The LineupTileArt backdrop View used palette.skeleton, producing a theme-tinted layer visible through the image's fade-in. The Artwork component already handles its own loading/placeholder state, so the extra backdrop (and redundant FadeInView wrapper) is removed.

https://claude.ai/code/session_01RGAdtXpNHBzn21pWbZLEjs