### PR TITLE
claude/add-likes-reposts-collection-oocDV

### DIFF
--- a/.changeset/collection-likes-reposts-album.md
+++ b/.changeset/collection-likes-reposts-album.md
@@ -1,0 +1,5 @@
+---
+"@audius/web": patch
+---
+
+Show likes and reposts counts on album collection pages (desktop)

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -91,7 +91,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
   const [filterText, setFilterText] = useState('')
 
   const hasStreamAccess = access?.stream
-  const shouldShowStats = type !== 'album' && (!isPrivate || isOwner)
+  const shouldShowStats = !isPrivate || isOwner
   const shouldShowScheduledRelease =
     isScheduledRelease && releaseDate && dayjs(releaseDate).isAfter(dayjs())
 


### PR DESCRIPTION
Album collection pages were hiding the repost/favorite stats due to a
`type !== 'album'` condition that excluded albums, while the mobile
header already shows stats for both playlists and albums. Remove the
album exclusion so desktop matches mobile behavior.