### PR TITLE
Responsive track header with container-based breakpoints

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -301,6 +301,20 @@
     grid-column: 1;
     grid-row: 2;
     justify-self: center;
+    width: min(338px, 70cqi);
+    aspect-ratio: 1;
+  }
+
+  .artworkSection > div {
+    width: 100% !important;
+    height: 100% !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+  }
+
+  .artworkSection > div > div {
+    width: 100% !important;
+    height: 100% !important;
   }
 
   .infoSection {

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -1,3 +1,47 @@
+.topSection {
+  position: relative;
+  display: grid;
+  grid-template-columns: 338px minmax(0, 1fr);
+  column-gap: var(--harmony-unit-6);
+  row-gap: var(--harmony-unit-6);
+  padding: var(--harmony-unit-4);
+  container-type: inline-size;
+}
+
+.artworkSection {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+}
+
+.infoSection {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+}
+
+.actionsSection {
+  grid-column: 2;
+  grid-row: 2;
+  align-self: end;
+}
+
+.titleArtistSection {
+  align-items: flex-start;
+}
+
+.playSection {
+  align-items: center;
+}
+
+.badgesSection {
+  position: absolute;
+  right: var(--harmony-unit-6);
+  top: var(--harmony-unit-4);
+  display: flex;
+  gap: var(--harmony-unit-2);
+  justify-content: flex-end;
+}
+
 .gatedContent .typeLabel {
   letter-spacing: 2px;
 }
@@ -21,10 +65,6 @@
   color: var(--harmony-n-400);
   font-size: var(--harmony-unit-3);
   font-weight: 600;
-}
-
-.playSection > * {
-  margin-top: var(--harmony-unit-4);
 }
 
 .infoSection .numberOfListens {
@@ -225,5 +265,48 @@
 
   .gatedContentSectionButton {
     width: 100%;
+  }
+}
+
+@container (max-width: 740px) {
+  .topSection {
+    grid-template-columns: 1fr;
+    row-gap: var(--harmony-unit-5);
+    padding: var(--harmony-unit-6);
+  }
+
+  .artworkSection {
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: center;
+  }
+
+  .infoSection {
+    grid-column: 1;
+    grid-row: 2;
+    align-items: center;
+  }
+
+  .titleArtistSection {
+    align-items: center;
+    text-align: center;
+  }
+
+  .playSection {
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .actionsSection {
+    grid-column: 1;
+    grid-row: 3;
+    justify-self: center;
+    flex-wrap: wrap;
+    gap: var(--harmony-unit-6) !important;
+  }
+
+  .badgesSection {
+    display: none;
   }
 }

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -285,24 +285,50 @@
     grid-column: 1;
     grid-row: 2;
     align-items: center;
+    width: 100%;
   }
 
   .titleArtistSection {
     align-items: center;
     text-align: center;
+    width: 100%;
+  }
+
+  .titleHeader {
+    text-align: center !important;
+  }
+
+  .artistRow {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .trackStatsRow {
+    display: flex;
+    justify-content: center;
+    width: 100%;
   }
 
   .playSection {
     flex-wrap: wrap;
     justify-content: center;
+    align-items: center;
+    width: 100%;
+    gap: var(--harmony-unit-3) !important;
+  }
+
+  .playSection > :first-child {
+    flex: 1 0 100%;
     width: 100%;
   }
 
   .actionsSection {
     grid-column: 1;
     grid-row: 3;
-    justify-self: center;
+    justify-self: stretch;
+    width: 100%;
     flex-wrap: wrap;
+    justify-content: center;
     gap: var(--harmony-unit-6) !important;
   }
 

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -42,6 +42,14 @@
   justify-content: flex-end;
 }
 
+.typeLabelCompact {
+  display: none;
+}
+
+.typeLabelRow {
+  display: block;
+}
+
 .gatedContent .typeLabel {
   letter-spacing: 2px;
 }
@@ -275,15 +283,26 @@
     padding: var(--harmony-unit-6);
   }
 
-  .artworkSection {
+  .typeLabelCompact {
+    display: flex;
     grid-column: 1;
     grid-row: 1;
+    justify-content: center;
+  }
+
+  .typeLabelRow {
+    display: none;
+  }
+
+  .artworkSection {
+    grid-column: 1;
+    grid-row: 2;
     justify-self: center;
   }
 
   .infoSection {
     grid-column: 1;
-    grid-row: 2;
+    grid-row: 3;
     align-items: center;
     width: 100%;
   }
@@ -324,7 +343,7 @@
 
   .actionsSection {
     grid-column: 1;
-    grid-row: 3;
+    grid-row: 4;
     justify-self: stretch;
     width: 100%;
     flex-wrap: wrap;

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -1,3 +1,7 @@
+.topSectionWrapper {
+  container-type: inline-size;
+}
+
 .topSection {
   position: relative;
   display: grid;
@@ -5,7 +9,6 @@
   column-gap: var(--harmony-unit-6);
   row-gap: var(--harmony-unit-6);
   padding: var(--harmony-unit-4);
-  container-type: inline-size;
 }
 
 .artworkSection {
@@ -337,8 +340,9 @@
   }
 
   .playSection > :first-child {
-    flex: 1 0 100%;
-    width: 100%;
+    flex: 1 0 100% !important;
+    width: 100% !important;
+    min-width: 0 !important;
   }
 
   .actionsSection {

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -490,134 +490,139 @@ export const GiantTrackTile = ({
       css={{ maxWidth: 1080, textAlign: 'left' }}
     >
       <TrackDogEar trackId={trackId} borderOffset={0} />
-      <div className={styles.topSection}>
-        <div className={styles.typeLabelCompact}>
-          {renderCardTitle(cn(fadeIn))}
-        </div>
-        <div className={styles.artworkSection}>
-          <GiantArtwork
-            trackId={trackId}
-            coSign={coSign}
-            callback={onArtworkLoad}
-          />
-        </div>
-        <Flex column gap='xl' className={styles.infoSection}>
-          <Flex column gap='l' className={styles.titleArtistSection}>
-            <div className={styles.typeLabelRow}>
-              {renderCardTitle(cn(fadeIn))}
-            </div>
-            <Box>
-              <Text
-                variant='heading'
-                size='xl'
-                className={cn(fadeIn, styles.titleHeader)}
-              >
-                {trackTitle}
-              </Text>
-              {isLoading && <Skeleton width='686px' height='96px' />}
-            </Box>
-            <Flex className={styles.artistRow}>
-              {isLoading && <Skeleton width='200px' height='24px' />}
-              <Text
-                variant='title'
-                strength='weak'
-                tag='h2'
-                className={cn(fadeIn)}
-                css={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '4px'
-                }}
-              >
-                <Text color='subdued'>By </Text>
-                <UserLink userId={userId} popover />
-              </Text>
+      <div className={styles.topSectionWrapper}>
+        <div className={styles.topSection}>
+          <div className={styles.typeLabelCompact}>
+            {renderCardTitle(cn(fadeIn))}
+          </div>
+          <div className={styles.artworkSection}>
+            <GiantArtwork
+              trackId={trackId}
+              coSign={coSign}
+              callback={onArtworkLoad}
+            />
+          </div>
+          <Flex column gap='xl' className={styles.infoSection}>
+            <Flex column gap='l' className={styles.titleArtistSection}>
+              <div className={styles.typeLabelRow}>
+                {renderCardTitle(cn(fadeIn))}
+              </div>
+              <Box>
+                <Text
+                  variant='heading'
+                  size='xl'
+                  className={cn(fadeIn, styles.titleHeader)}
+                >
+                  {trackTitle}
+                </Text>
+                {isLoading && <Skeleton width='686px' height='96px' />}
+              </Box>
+              <Flex className={styles.artistRow}>
+                {isLoading && <Skeleton width='200px' height='24px' />}
+                <Text
+                  variant='title'
+                  strength='weak'
+                  tag='h2'
+                  className={cn(fadeIn)}
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '4px'
+                  }}
+                >
+                  <Text color='subdued'>By </Text>
+                  <UserLink userId={userId} popover />
+                </Text>
+              </Flex>
+              <div className={cn(fadeIn, styles.trackStatsRow)}>
+                <TrackStats
+                  trackId={trackId}
+                  scrollToCommentSection={scrollToCommentSection}
+                />
+              </div>
             </Flex>
-            <div className={cn(fadeIn, styles.trackStatsRow)}>
-              <TrackStats
-                trackId={trackId}
-                scrollToCommentSection={scrollToCommentSection}
-              />
-            </div>
-          </Flex>
 
-          <Flex
-            gap='xl'
-            alignItems='center'
-            className={cn(fadeIn, styles.playSection)}
-          >
-            {showPlay ? (
-              <PlayPauseButton
-                disabled={!hasStreamAccess}
-                playing={playing && !previewing}
-                onPlay={onPlay}
-                trackId={trackId}
-              />
-            ) : null}
-            {showPreview ? (
-              <PlayPauseButton
-                playing={playing && previewing}
-                onPlay={onPreview}
-                trackId={trackId}
-                isPreview
-              />
-            ) : null}
-            {isLongFormContent ? (
-              <GiantTrackTileProgressInfo
-                duration={duration}
-                trackId={trackId}
-              />
-            ) : (
-              renderListenCount()
-            )}
+            <Flex
+              gap='xl'
+              alignItems='center'
+              className={cn(fadeIn, styles.playSection)}
+            >
+              {showPlay ? (
+                <PlayPauseButton
+                  disabled={!hasStreamAccess}
+                  playing={playing && !previewing}
+                  onPlay={onPlay}
+                  trackId={trackId}
+                />
+              ) : null}
+              {showPreview ? (
+                <PlayPauseButton
+                  playing={playing && previewing}
+                  onPlay={onPreview}
+                  trackId={trackId}
+                  isPreview
+                />
+              ) : null}
+              {isLongFormContent ? (
+                <GiantTrackTileProgressInfo
+                  duration={duration}
+                  trackId={trackId}
+                />
+              ) : (
+                renderListenCount()
+              )}
+            </Flex>
           </Flex>
-        </Flex>
-        {isUnlisted && !isOwner ? null : (
-          <Flex
-            gap='2xl'
-            alignItems='center'
-            className={cn(fadeIn, styles.actionsSection)}
-            role='group'
-            aria-label={messages.actionGroupLabel}
-          >
-            {hasStreamAccess && renderRepostButton()}
-            {hasStreamAccess && renderFavoriteButton()}
-            {renderShareButton()}
-            {renderMakePublicButton()}
-            <span>
-              {/* prop types for overflow menu don't work correctly
+          {isUnlisted && !isOwner ? null : (
+            <Flex
+              gap='2xl'
+              alignItems='center'
+              className={cn(fadeIn, styles.actionsSection)}
+              role='group'
+              aria-label={messages.actionGroupLabel}
+            >
+              {hasStreamAccess && renderRepostButton()}
+              {hasStreamAccess && renderFavoriteButton()}
+              {renderShareButton()}
+              {renderMakePublicButton()}
+              <span>
+                {/* prop types for overflow menu don't work correctly
               so we need to cast here */}
-              <Menu {...(overflowMenu as any)}>
-                {(ref, triggerPopup) => (
-                  <div className={cn(styles.menuKebabContainer)} ref={ref}>
-                    <IconButton
-                      aria-label='More options'
-                      icon={IconKebabHorizontal}
-                      color='subdued'
-                      size='2xl'
-                      onClick={() => triggerPopup()}
-                    />
-                  </div>
-                )}
-              </Menu>
-            </span>
-          </Flex>
-        )}
-        <div className={styles.badgesSection}>
-          {trendingRank ? (
-            <MusicBadge color='blue' icon={IconTrending}>
-              {trendingRank}
-            </MusicBadge>
-          ) : null}
-          {shouldShowScheduledRelease ? (
-            <MusicBadge variant='accent' icon={IconCalendarMonth}>
-              {messages.releases(releaseDate)}
-            </MusicBadge>
-          ) : isUnlisted ? (
-            <MusicBadge icon={IconVisibilityHidden}>
-              {messages.hidden}
-            </MusicBadge>
-          ) : null}
+                <Menu {...(overflowMenu as any)}>
+                  {(ref, triggerPopup) => (
+                    <div
+                      className={cn(styles.menuKebabContainer)}
+                      ref={ref}
+                    >
+                      <IconButton
+                        aria-label='More options'
+                        icon={IconKebabHorizontal}
+                        color='subdued'
+                        size='2xl'
+                        onClick={() => triggerPopup()}
+                      />
+                    </div>
+                  )}
+                </Menu>
+              </span>
+            </Flex>
+          )}
+          <div className={styles.badgesSection}>
+            {trendingRank ? (
+              <MusicBadge color='blue' icon={IconTrending}>
+                {trendingRank}
+              </MusicBadge>
+            ) : null}
+            {shouldShowScheduledRelease ? (
+              <MusicBadge variant='accent' icon={IconCalendarMonth}>
+                {messages.releases(releaseDate)}
+              </MusicBadge>
+            ) : isUnlisted ? (
+              <MusicBadge icon={IconVisibilityHidden}>
+                {messages.hidden}
+              </MusicBadge>
+            ) : null}
+          </div>
         </div>
       </div>
 

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -590,10 +590,7 @@ export const GiantTrackTile = ({
               so we need to cast here */}
                 <Menu {...(overflowMenu as any)}>
                   {(ref, triggerPopup) => (
-                    <div
-                      className={cn(styles.menuKebabContainer)}
-                      ref={ref}
-                    >
+                    <div className={cn(styles.menuKebabContainer)} ref={ref}>
                       <IconButton
                         aria-label='More options'
                         icon={IconKebabHorizontal}

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -491,6 +491,9 @@ export const GiantTrackTile = ({
     >
       <TrackDogEar trackId={trackId} borderOffset={0} />
       <div className={styles.topSection}>
+        <div className={styles.typeLabelCompact}>
+          {renderCardTitle(cn(fadeIn))}
+        </div>
         <div className={styles.artworkSection}>
           <GiantArtwork
             trackId={trackId}
@@ -500,7 +503,9 @@ export const GiantTrackTile = ({
         </div>
         <Flex column gap='xl' className={styles.infoSection}>
           <Flex column gap='l' className={styles.titleArtistSection}>
-            {renderCardTitle(cn(fadeIn))}
+            <div className={styles.typeLabelRow}>
+              {renderCardTitle(cn(fadeIn))}
+            </div>
             <Box>
               <Text
                 variant='heading'

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -499,11 +499,7 @@ export const GiantTrackTile = ({
           />
         </div>
         <Flex column gap='xl' className={styles.infoSection}>
-          <Flex
-            column
-            gap='l'
-            className={cn(styles.titleArtistSection)}
-          >
+          <Flex column gap='l' className={styles.titleArtistSection}>
             {renderCardTitle(cn(fadeIn))}
             <Box>
               <Text

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -506,12 +506,16 @@ export const GiantTrackTile = ({
           >
             {renderCardTitle(cn(fadeIn))}
             <Box>
-              <Text variant='heading' size='xl' className={cn(fadeIn)}>
+              <Text
+                variant='heading'
+                size='xl'
+                className={cn(fadeIn, styles.titleHeader)}
+              >
                 {trackTitle}
               </Text>
               {isLoading && <Skeleton width='686px' height='96px' />}
             </Box>
-            <Flex>
+            <Flex className={styles.artistRow}>
               {isLoading && <Skeleton width='200px' height='24px' />}
               <Text
                 variant='title'
@@ -528,7 +532,7 @@ export const GiantTrackTile = ({
                 <UserLink userId={userId} popover />
               </Text>
             </Flex>
-            <div className={cn(fadeIn)}>
+            <div className={cn(fadeIn, styles.trackStatsRow)}>
               <TrackStats
                 trackId={trackId}
                 scrollToCommentSection={scrollToCommentSection}

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -490,118 +490,115 @@ export const GiantTrackTile = ({
       css={{ maxWidth: 1080, textAlign: 'left' }}
     >
       <TrackDogEar trackId={trackId} borderOffset={0} />
-      <Flex p='l' gap='xl'>
-        <GiantArtwork
-          trackId={trackId}
-          coSign={coSign}
-          callback={onArtworkLoad}
-        />
-        <Flex
-          column
-          justifyContent='space-between'
-          flex={1}
-          css={{ minWidth: '386px', flexBasis: '386px' }}
-        >
-          <Flex column gap='2xl'>
-            <Flex column gap='xl'>
-              <Flex column gap='l' alignItems='flex-start'>
-                {renderCardTitle(cn(fadeIn))}
-                <Box>
-                  <Text variant='heading' size='xl' className={cn(fadeIn)}>
-                    {trackTitle}
-                  </Text>
-                  {isLoading && <Skeleton width='686px' height='96px' />}
-                </Box>
-                <Flex>
-                  {isLoading && <Skeleton width='200px' height='24px' />}
-                  <Text
-                    variant='title'
-                    strength='weak'
-                    tag='h2'
-                    className={cn(fadeIn)}
-                    css={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '4px'
-                    }}
-                  >
-                    <Text color='subdued'>By </Text>
-                    <UserLink userId={userId} popover />
-                  </Text>
-                </Flex>
-                <div className={cn(fadeIn)}>
-                  <TrackStats
-                    trackId={trackId}
-                    scrollToCommentSection={scrollToCommentSection}
-                  />
-                </div>
-              </Flex>
-
-              <Flex gap='xl' alignItems='center' className={cn(fadeIn)}>
-                {showPlay ? (
-                  <PlayPauseButton
-                    disabled={!hasStreamAccess}
-                    playing={playing && !previewing}
-                    onPlay={onPlay}
-                    trackId={trackId}
-                  />
-                ) : null}
-                {showPreview ? (
-                  <PlayPauseButton
-                    playing={playing && previewing}
-                    onPlay={onPreview}
-                    trackId={trackId}
-                    isPreview
-                  />
-                ) : null}
-                {isLongFormContent ? (
-                  <GiantTrackTileProgressInfo
-                    duration={duration}
-                    trackId={trackId}
-                  />
-                ) : (
-                  renderListenCount()
-                )}
-              </Flex>
+      <div className={styles.topSection}>
+        <div className={styles.artworkSection}>
+          <GiantArtwork
+            trackId={trackId}
+            coSign={coSign}
+            callback={onArtworkLoad}
+          />
+        </div>
+        <Flex column gap='xl' className={styles.infoSection}>
+          <Flex
+            column
+            gap='l'
+            className={cn(styles.titleArtistSection)}
+          >
+            {renderCardTitle(cn(fadeIn))}
+            <Box>
+              <Text variant='heading' size='xl' className={cn(fadeIn)}>
+                {trackTitle}
+              </Text>
+              {isLoading && <Skeleton width='686px' height='96px' />}
+            </Box>
+            <Flex>
+              {isLoading && <Skeleton width='200px' height='24px' />}
+              <Text
+                variant='title'
+                strength='weak'
+                tag='h2'
+                className={cn(fadeIn)}
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px'
+                }}
+              >
+                <Text color='subdued'>By </Text>
+                <UserLink userId={userId} popover />
+              </Text>
             </Flex>
+            <div className={cn(fadeIn)}>
+              <TrackStats
+                trackId={trackId}
+                scrollToCommentSection={scrollToCommentSection}
+              />
+            </div>
           </Flex>
-          {isUnlisted && !isOwner ? null : (
-            <Flex
-              gap='2xl'
-              alignItems='center'
-              className={cn(fadeIn)}
-              role='group'
-              aria-label={messages.actionGroupLabel}
-            >
-              {hasStreamAccess && renderRepostButton()}
-              {hasStreamAccess && renderFavoriteButton()}
-              {renderShareButton()}
-              {renderMakePublicButton()}
-              <span>
-                {/* prop types for overflow menu don't work correctly
-              so we need to cast here */}
-                <Menu {...(overflowMenu as any)}>
-                  {(ref, triggerPopup) => (
-                    <div className={cn(styles.menuKebabContainer)} ref={ref}>
-                      <IconButton
-                        aria-label='More options'
-                        icon={IconKebabHorizontal}
-                        color='subdued'
-                        size='2xl'
-                        onClick={() => triggerPopup()}
-                      />
-                    </div>
-                  )}
-                </Menu>
-              </span>
-            </Flex>
-          )}
+
+          <Flex
+            gap='xl'
+            alignItems='center'
+            className={cn(fadeIn, styles.playSection)}
+          >
+            {showPlay ? (
+              <PlayPauseButton
+                disabled={!hasStreamAccess}
+                playing={playing && !previewing}
+                onPlay={onPlay}
+                trackId={trackId}
+              />
+            ) : null}
+            {showPreview ? (
+              <PlayPauseButton
+                playing={playing && previewing}
+                onPlay={onPreview}
+                trackId={trackId}
+                isPreview
+              />
+            ) : null}
+            {isLongFormContent ? (
+              <GiantTrackTileProgressInfo
+                duration={duration}
+                trackId={trackId}
+              />
+            ) : (
+              renderListenCount()
+            )}
+          </Flex>
         </Flex>
-        <Flex
-          gap='s'
-          justifyContent='flex-end'
-          css={{ position: 'absolute', right: 'var(--harmony-unit-6)' }}
-        >
+        {isUnlisted && !isOwner ? null : (
+          <Flex
+            gap='2xl'
+            alignItems='center'
+            className={cn(fadeIn, styles.actionsSection)}
+            role='group'
+            aria-label={messages.actionGroupLabel}
+          >
+            {hasStreamAccess && renderRepostButton()}
+            {hasStreamAccess && renderFavoriteButton()}
+            {renderShareButton()}
+            {renderMakePublicButton()}
+            <span>
+              {/* prop types for overflow menu don't work correctly
+              so we need to cast here */}
+              <Menu {...(overflowMenu as any)}>
+                {(ref, triggerPopup) => (
+                  <div className={cn(styles.menuKebabContainer)} ref={ref}>
+                    <IconButton
+                      aria-label='More options'
+                      icon={IconKebabHorizontal}
+                      color='subdued'
+                      size='2xl'
+                      onClick={() => triggerPopup()}
+                    />
+                  </div>
+                )}
+              </Menu>
+            </span>
+          </Flex>
+        )}
+        <div className={styles.badgesSection}>
           {trendingRank ? (
             <MusicBadge color='blue' icon={IconTrending}>
               {trendingRank}
@@ -616,8 +613,8 @@ export const GiantTrackTile = ({
               {messages.hidden}
             </MusicBadge>
           ) : null}
-        </Flex>
-      </Flex>
+        </div>
+      </div>
 
       {isStreamGated && streamConditions ? (
         <Box p='l' pb='xl' w='100%' backgroundColor='surface1'>


### PR DESCRIPTION
## Summary
- Apply the same container-query responsive pattern used on the collection header to the track page `GiantTrackTile`
- Convert the top section into a CSS grid (artwork / info / actions / badges) that collapses to a single stacked, centered column under a 740px container width
- Hide the absolute-positioned trending/scheduled/hidden badges on narrow widths

## Test plan
- [ ] Desktop: track page hero renders unchanged (artwork left, info + play + social right, badges top-right)
- [ ] Narrow (< 740px container): artwork centers, title/artist/stats center, play + social wrap and center, badges hidden
- [ ] Gated, unlisted, scheduled-release, and owner states still render correctly
