### PR TITLE
claude/fix-bottom-bar-clickable-GRpUy

### DIFF
--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
@@ -110,7 +110,6 @@ export const BottomTabBar = (props: BottomTabBarProps) => {
         backgroundColor='surface1'
         wrap='nowrap'
         justifyContent='space-evenly'
-        pt='s'
         pb={insets.bottom}
       >
         {routes.map(({ name, key }, index) => {

--- a/packages/mobile/src/components/bottom-tab-bar/bottom-tab-bar-buttons/BottomTabBarButton.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/bottom-tab-bar-buttons/BottomTabBarButton.tsx
@@ -8,7 +8,10 @@ import { Pressable, StyleSheet } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import { usePrevious } from 'react-use'
 
-import { BOTTOM_BAR_BUTTON_HEIGHT } from '../constants'
+import {
+  BOTTOM_BAR_BUTTON_HEIGHT,
+  BOTTOM_BAR_TOP_PADDING
+} from '../constants'
 
 export type BaseBottomTabBarButtonProps = {
   name: string
@@ -27,7 +30,8 @@ export type BottomTabBarButtonProps = BaseBottomTabBarButtonProps & {
 const styles = StyleSheet.create({
   root: {
     width: '20%',
-    alignItems: 'center'
+    alignItems: 'center',
+    paddingTop: BOTTOM_BAR_TOP_PADDING
   },
   iconWrapper: {
     width: 28,
@@ -35,7 +39,7 @@ const styles = StyleSheet.create({
   },
   underlay: {
     width: '100%',
-    height: BOTTOM_BAR_BUTTON_HEIGHT,
+    height: BOTTOM_BAR_BUTTON_HEIGHT + BOTTOM_BAR_TOP_PADDING,
     position: 'absolute'
   }
 })

--- a/packages/mobile/src/components/bottom-tab-bar/constants.ts
+++ b/packages/mobile/src/components/bottom-tab-bar/constants.ts
@@ -3,3 +3,4 @@ export const BOTTOM_BAR_HEIGHT = 41
 // Accounting for border
 // see: https://github.com/facebook/react-native/issues/23994
 export const BOTTOM_BAR_BUTTON_HEIGHT = 32
+export const BOTTOM_BAR_TOP_PADDING = 8


### PR DESCRIPTION
The 8px top padding was on the Flex container outside the Pressable,
so taps in that band produced no press feedback. Move the padding
into each button's Pressable and extend the underlay to match.

https://claude.ai/code/session_0157mPHyHPt95nGnGPbwEMji