### PR TITLE
claude/fix-profile-divider-f2461

### DIFF
--- a/.changeset/fix-profile-divider.md
+++ b/.changeset/fix-profile-divider.md
@@ -1,0 +1,5 @@
+---
+"@audius/mobile": patch
+---
+
+Fix double divider on mobile profile header when the profile has no fan-club button

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileHeader.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileHeader.tsx
@@ -105,6 +105,10 @@ export const ProfileHeader = memo(() => {
   const { spacing } = useTheme()
   const insets = useSafeAreaInsets()
 
+  const hasArtistCoinButton =
+    !isArtistCoinLoading && !!userId && !!artistCoin?.mint
+  const hasBottomSection = hasUserFollowed || hasArtistCoinButton
+
   return (
     <>
       <ProfileScrollBridge />
@@ -149,15 +153,19 @@ export const ProfileHeader = memo(() => {
               onPress={handleToggleExpand}
             />
           ) : null}
-          <Divider mh={-12} />
-          {!hasUserFollowed ? null : (
-            <ArtistRecommendations onClose={handleCloseArtistRecs} />
-          )}
-          <Flex pointerEvents='box-none' mt='s' gap='s'>
-            {!isArtistCoinLoading && userId && artistCoin?.mint ? (
-              <BuyArtistCoinButton userId={userId} />
-            ) : null}
-          </Flex>
+          {hasBottomSection ? (
+            <>
+              <Divider mh={-12} />
+              {!hasUserFollowed ? null : (
+                <ArtistRecommendations onClose={handleCloseArtistRecs} />
+              )}
+              {hasArtistCoinButton ? (
+                <Flex pointerEvents='box-none' mt='s' gap='s'>
+                  <BuyArtistCoinButton userId={userId!} />
+                </Flex>
+              ) : null}
+            </>
+          ) : null}
         </OnlineOnly>
       </Flex>
     </>


### PR DESCRIPTION
The inner Divider above the BuyArtistCoinButton area used to have the
tip button to separate it from the container's borderBottom. Since the
tip button was removed, profiles without an artist coin (and without
just-followed artist recommendations) render the inner Divider with
nothing between it and the outer borderBottom, producing a double
divider. Only render the inner Divider when there is actual bottom
section content to follow it.

https://claude.ai/code/session_014b3mkM8A6UQQiYTMuS5T7E