### PR TITLE
claude/fix-profile-drawer-nav-G01R3

### DIFF
--- a/.changeset/now-playing-drawer-close-on-nav.md
+++ b/.changeset/now-playing-drawer-close-on-nav.md
@@ -1,0 +1,5 @@
+---
+"@audius/mobile": patch
+---
+
+Fix now-playing drawer not closing when tapping the artist or track link while a profile screen is already open

--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -277,8 +277,8 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
     if (!trackId) {
       return
     }
-    onClose()
     navigation?.push('Track', { trackId })
+    onClose()
   }, [onClose, navigation, trackId])
 
   return (

--- a/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
@@ -61,8 +61,8 @@ export const TrackInfo = (props: TrackInfoProps) => {
 
   const handlePressArtist = useCallback(() => {
     if (user?.user_id) {
-      onClose()
       navigation?.push('Profile', { id: user.user_id })
+      onClose()
     }
   }, [navigation, user?.user_id, onClose])
 


### PR DESCRIPTION
When tapping the artist or track link in the now-playing drawer, the
close dispatch ran before navigation.push. Pushing a screen of the same
type as the currently-focused one (e.g. Profile A -> Profile B) would
interfere with the drawer's close state update, leaving the drawer open
while the navigation still committed underneath. Pushing first lets the
navigation transition begin, then the drawer close runs as a separate
state update and animates reliably.