### PR TITLE
Restore Meteora DAMM swap quote via getQuote2

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/meteora/swap_coin_quote.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/meteora/swap_coin_quote.ts
@@ -1,4 +1,4 @@
-import { CpAmm } from '@meteora-ag/cp-amm-sdk'
+import { CpAmm, SwapMode as DammSwapMode } from '@meteora-ag/cp-amm-sdk'
 import {
   DynamicBondingCurveClient,
   SwapMode
@@ -97,13 +97,17 @@ const getDammPoolQuote = async (
   const inputTokenMint =
     swapDirection === 'audioToCoin' ? audioMintPubkey : coinMintPubkey
 
-  const quote = await cpAmm.getQuote({
-    inAmount: inputAmountBN,
+  const currentSlot = await connection.getSlot()
+  const currentPoint = poolState.activationType
+    ? new BN(new Date().getTime())
+    : new BN(currentSlot)
+
+  const quote = cpAmm.getQuote2({
+    amountIn: inputAmountBN,
     inputTokenMint,
     slippage: 2,
     poolState,
-    currentTime: new Date().getTime(),
-    currentSlot: await connection.getSlot(),
+    currentPoint,
     inputTokenInfo: {
       mint: tokenAMintInfo,
       currentEpoch
@@ -113,10 +117,12 @@ const getDammPoolQuote = async (
       currentEpoch
     },
     tokenADecimal: tokenAMintInfo.decimals,
-    tokenBDecimal: tokenBMintInfo.decimals
+    tokenBDecimal: tokenBMintInfo.decimals,
+    swapMode: DammSwapMode.PartialFill,
+    hasReferral: false
   })
 
-  return quote.swapOutAmount.toString()
+  return quote.outputAmount.toString()
 }
 /**
  * Gets a quote for swapping AUDIO to/from an artist coin using Meteora's DBC


### PR DESCRIPTION
## Summary
- Re-applies the swap quote logic that was removed on `main` by commit `35f68aafe7` (“Revert dbc changes”).
- Restores DAMM (`CpAmm`) quoting to use `getQuote2` with `SwapMode.PartialFill`, activation-type-aware `currentPoint`, and `outputAmount` (vs. `getQuote` / `swapOutAmount`).

## Notes
The revert commit message referred to “dbc” but the diff only touched `getDammPoolQuote` in `swap_coin_quote.ts`.

## Test plan
- [ ] CI / typecheck for `solana-relay`

Made with [Cursor](https://cursor.com)