### PR TITLE
Shrinking sidebar

### DIFF
--- a/packages/web/src/app/web-player/WebPlayer.module.css
+++ b/packages/web/src/app/web-player/WebPlayer.module.css
@@ -12,6 +12,13 @@
   align-items: stretch;
 }
 
+/* Register --nav-width as an animatable length so consumers (margin-left, left) transition */
+@property --nav-width {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 240px;
+}
+
 .app {
   --nav-width: 240px;
   --nav-width-minus-border: 239px;
@@ -22,6 +29,12 @@
   height: 100%;
   display: flex;
   overflow: hidden;
+  transition: --nav-width 0.2s ease;
+}
+
+/* Suppress --nav-width transition during drag so snaps stay instant */
+.app[data-nav-dragging='true'] {
+  transition: none;
 }
 
 .app.mobileApp {

--- a/packages/web/src/app/web-player/WebPlayer.module.css
+++ b/packages/web/src/app/web-player/WebPlayer.module.css
@@ -31,7 +31,7 @@
 
 .notificationWrapper {
   position: absolute;
-  left: 256px;
+  left: calc(var(--nav-width) + 16px);
   top: 56px;
   z-index: 5;
 }

--- a/packages/web/src/app/web-player/WebPlayer.module.css
+++ b/packages/web/src/app/web-player/WebPlayer.module.css
@@ -12,16 +12,10 @@
   align-items: stretch;
 }
 
-/* Register --nav-width as an animatable length so consumers (margin-left, left) transition */
-@property --nav-width {
-  syntax: '<length>';
-  inherits: true;
-  initial-value: 240px;
-}
-
 .app {
   --nav-width: 240px;
   --nav-width-minus-border: 239px;
+  --nav-shift: 0px;
   --mobile-min-width: 280px;
   --play-bar-height: 88px;
   position: relative;
@@ -29,12 +23,6 @@
   height: 100%;
   display: flex;
   overflow: hidden;
-  transition: --nav-width 0.2s ease;
-}
-
-/* Suppress --nav-width transition during drag so snaps stay instant */
-.app[data-nav-dragging='true'] {
-  transition: none;
 }
 
 .app.mobileApp {
@@ -47,12 +35,16 @@
   left: calc(var(--nav-width) + 16px);
   top: 56px;
   z-index: 5;
+  transform: translateX(var(--nav-shift));
+  transition: transform 0.2s ease;
 }
 
 .mainContentWrapper {
   margin-left: var(--nav-width);
   margin-bottom: 88px;
   width: 100%;
+  transform: translateX(var(--nav-shift));
+  transition: transform 0.2s ease;
   /* Use theme background - ensures classic-dark/default-dark etc. apply correctly */
   background-color: var(--harmony-background);
   /* Show scrollbar always so the page doesn't jump around. */

--- a/packages/web/src/app/web-player/WebPlayer.tsx
+++ b/packages/web/src/app/web-player/WebPlayer.tsx
@@ -745,7 +745,7 @@ const WebPlayer = (props: WebPlayerProps) => {
       </AppBannerWrapper>
       <ChatListener />
       <USDCBalanceFetcher />
-      <div className={cn(styles.app, { [styles.mobileApp]: isMobile })}>
+      <div id='webPlayer' className={cn(styles.app, { [styles.mobileApp]: isMobile })}>
         {showCookieBanner ? <CookieBanner /> : null}
         <Notice shouldPadTop={false} />
         <Navigator />

--- a/packages/web/src/app/web-player/WebPlayer.tsx
+++ b/packages/web/src/app/web-player/WebPlayer.tsx
@@ -751,7 +751,10 @@ const WebPlayer = (props: WebPlayerProps) => {
       </AppBannerWrapper>
       <ChatListener />
       <USDCBalanceFetcher />
-      <div id='webPlayer' className={cn(styles.app, { [styles.mobileApp]: isMobile })}>
+      <div
+        id='webPlayer'
+        className={cn(styles.app, { [styles.mobileApp]: isMobile })}
+      >
         {showCookieBanner ? <CookieBanner /> : null}
         <Notice shouldPadTop={false} />
         <Navigator />

--- a/packages/web/src/components/nav/Navigator.module.css
+++ b/packages/web/src/components/nav/Navigator.module.css
@@ -16,8 +16,15 @@
   bottom: 0;
   margin-bottom: 88px;
   /* Width is managed via inline style in Navigator.tsx */
-  overflow: visible;
+  overflow-x: clip;
+  overflow-y: visible;
   flex-shrink: 0;
+  transition: width 0.2s ease;
+}
+
+/* Suppress width transition during drag so snaps stay instant */
+.leftNavWrapper.isDragging {
+  transition: none;
 }
 
 /* Suppress text selection during drag */
@@ -35,8 +42,8 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  right: -3px;
-  width: 6px;
+  right: -4px;
+  width: 8px;
   z-index: 15;
   transition: background-color 0.15s ease;
 }

--- a/packages/web/src/components/nav/Navigator.module.css
+++ b/packages/web/src/components/nav/Navigator.module.css
@@ -42,8 +42,8 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  right: -4px;
-  width: 8px;
+  right: -6px;
+  width: 12px;
   z-index: 15;
   transition: background-color 0.15s ease;
 }

--- a/packages/web/src/components/nav/Navigator.module.css
+++ b/packages/web/src/components/nav/Navigator.module.css
@@ -15,12 +15,33 @@
   top: 0;
   bottom: 0;
   margin-bottom: 88px;
-  width: var(--nav-width);
-  /* Keep bottom of album art shadow from getting cut off */
+  /* Width is managed via inline style in Navigator.tsx */
   overflow: visible;
+  flex-shrink: 0;
+}
+
+/* Suppress text selection during drag */
+.isDragging {
+  user-select: none;
 }
 
 /* Position the navbar over any banners on electron/desktop app */
 .isElectron {
   position: fixed;
+}
+
+/* Drag handle on the right edge of the sidebar */
+.resizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -3px;
+  width: 6px;
+  z-index: 15;
+  transition: background-color 0.15s ease;
+}
+
+.resizeHandle:hover,
+.isDragging .resizeHandle {
+  background-color: var(--harmony-n-100);
 }

--- a/packages/web/src/components/nav/Navigator.tsx
+++ b/packages/web/src/components/nav/Navigator.tsx
@@ -26,7 +26,8 @@ interface OwnProps {
 
 const EXPANDED_WIDTH = 240
 const COLLAPSED_WIDTH = 64
-const SNAP_DELTA = 20 // px of drag needed to commit a state change
+// px of drag needed to commit to the other state on release
+const SNAP_DELTA = 15
 const STORAGE_KEY = 'nav-sidebar-collapsed'
 
 const Navigator = ({ className }: OwnProps) => {
@@ -41,7 +42,6 @@ const Navigator = ({ className }: OwnProps) => {
       return false
     }
   })
-  const [dragWidth, setDragWidth] = useState<number | null>(null)
   const [isDragging, setIsDragging] = useState(false)
 
   const dragStartX = useRef(0)
@@ -54,7 +54,9 @@ const Navigator = ({ className }: OwnProps) => {
     } catch {}
   }, [])
 
-  const navWidth = dragWidth ?? (isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH)
+  // Width is always the committed state — no intermediate values during drag.
+  // The sidebar stays put while dragging; on release it animates to the new state.
+  const navWidth = isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH
 
   // Update --nav-width on the app element before paint to avoid flash
   useLayoutEffect(() => {
@@ -77,32 +79,17 @@ const Navigator = ({ className }: OwnProps) => {
   useEffect(() => {
     if (!isDragging) return
 
-    const handleMouseMove = (e: MouseEvent) => {
-      const newWidth = Math.max(
-        COLLAPSED_WIDTH,
-        Math.min(EXPANDED_WIDTH, e.clientX)
-      )
-      setDragWidth(newWidth)
-    }
-
     const handleMouseUp = (e: MouseEvent) => {
-      setIsDragging(false)
-      setDragWidth(null)
-
       const delta = e.clientX - dragStartX.current
-      if (dragStartCollapsed.current) {
-        // Was collapsed: expand if dragged right far enough
-        if (delta > SNAP_DELTA) setIsCollapsed(false)
-      } else {
-        // Was expanded: collapse if dragged left far enough
-        if (delta < -SNAP_DELTA) setIsCollapsed(true)
-      }
+      const commit = dragStartCollapsed.current
+        ? delta <= SNAP_DELTA   // was collapsed: stay unless dragged right past threshold
+        : delta < -SNAP_DELTA  // was expanded: collapse only if dragged left past threshold
+      setIsCollapsed(commit)
+      setIsDragging(false)
     }
 
-    document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
     }
   }, [isDragging, setIsCollapsed])
@@ -119,14 +106,7 @@ const Navigator = ({ className }: OwnProps) => {
           [styles.isElectron]: isElectron,
           [styles.isDragging]: isDragging
         })}
-        style={
-          !isMobile
-            ? {
-                width: navWidth,
-                overflow: isDragging ? 'hidden' : undefined
-              }
-            : undefined
-        }
+        style={!isMobile ? { width: navWidth } : undefined}
       >
         {isMobile ? (
           <ConnectedNavBar />

--- a/packages/web/src/components/nav/Navigator.tsx
+++ b/packages/web/src/components/nav/Navigator.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+
 import { Client } from '@audius/common/models'
 import cn from 'classnames'
 
@@ -5,6 +7,7 @@ import { useIsMobile } from 'hooks/useIsMobile'
 import { getClient } from 'utils/clientUtil'
 
 import styles from './Navigator.module.css'
+import { NavSidebarContext } from './desktop/NavSidebarContext'
 import { LeftNav } from './desktop/LeftNav'
 import ConnectedNavBar from './mobile/ConnectedNavBar'
 
@@ -21,35 +24,124 @@ interface OwnProps {
   className?: string
 }
 
-// Navigation component that renders the NavBar for mobile
-// and LeftNav for desktop
+const EXPANDED_WIDTH = 240
+const COLLAPSED_WIDTH = 64
+const SNAP_DELTA = 20 // px of drag needed to commit a state change
+const STORAGE_KEY = 'nav-sidebar-collapsed'
+
 const Navigator = ({ className }: OwnProps) => {
   const client = getClient()
   const isMobile = useIsMobile()
-
   const isElectron = client === Client.ELECTRON
 
-  // Hide navigation when in a React Native WebView (e.g., mobile app WebView)
+  const [isCollapsed, setIsCollapsedState] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true'
+    } catch {
+      return false
+    }
+  })
+  const [dragWidth, setDragWidth] = useState<number | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const dragStartX = useRef(0)
+  const dragStartCollapsed = useRef(false)
+
+  const setIsCollapsed = useCallback((collapsed: boolean) => {
+    setIsCollapsedState(collapsed)
+    try {
+      localStorage.setItem(STORAGE_KEY, String(collapsed))
+    } catch {}
+  }, [])
+
+  const navWidth = dragWidth ?? (isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH)
+
+  // Update --nav-width on the app element before paint to avoid flash
+  useLayoutEffect(() => {
+    const appEl = document.getElementById('webPlayer')
+    if (!appEl) return
+    appEl.style.setProperty('--nav-width', `${navWidth}px`)
+    appEl.style.setProperty('--nav-width-minus-border', `${navWidth - 1}px`)
+  }, [navWidth])
+
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      dragStartX.current = e.clientX
+      dragStartCollapsed.current = isCollapsed
+      setIsDragging(true)
+    },
+    [isCollapsed]
+  )
+
+  useEffect(() => {
+    if (!isDragging) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const newWidth = Math.max(
+        COLLAPSED_WIDTH,
+        Math.min(EXPANDED_WIDTH, e.clientX)
+      )
+      setDragWidth(newWidth)
+    }
+
+    const handleMouseUp = (e: MouseEvent) => {
+      setIsDragging(false)
+      setDragWidth(null)
+
+      const delta = e.clientX - dragStartX.current
+      if (dragStartCollapsed.current) {
+        // Was collapsed: expand if dragged right far enough
+        if (delta > SNAP_DELTA) setIsCollapsed(false)
+      } else {
+        // Was expanded: collapse if dragged left far enough
+        if (delta < -SNAP_DELTA) setIsCollapsed(true)
+      }
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isDragging, setIsCollapsed])
+
   const isInWebView =
     typeof window !== 'undefined' && window.ReactNativeWebView !== undefined
-
-  if (isInWebView) {
-    return null
-  }
+  if (isInWebView) return null
 
   return (
-    <div
-      className={cn(styles.navWrapper, className, {
-        [styles.leftNavWrapper]: !isMobile,
-        [styles.isElectron]: isElectron
-      })}
-    >
-      {isMobile ? (
-        <ConnectedNavBar />
-      ) : (
-        <LeftNav isElectron={client === Client.ELECTRON} />
-      )}
-    </div>
+    <NavSidebarContext.Provider value={{ isCollapsed, setIsCollapsed }}>
+      <div
+        className={cn(styles.navWrapper, className, {
+          [styles.leftNavWrapper]: !isMobile,
+          [styles.isElectron]: isElectron,
+          [styles.isDragging]: isDragging
+        })}
+        style={
+          !isMobile
+            ? {
+                width: navWidth,
+                overflow: isDragging ? 'hidden' : undefined
+              }
+            : undefined
+        }
+      >
+        {isMobile ? (
+          <ConnectedNavBar />
+        ) : (
+          <>
+            <LeftNav isElectron={isElectron} />
+            <div
+              className={styles.resizeHandle}
+              style={{ cursor: isCollapsed ? 'e-resize' : 'w-resize' }}
+              onMouseDown={handleDragStart}
+            />
+          </>
+        )}
+      </div>
+    </NavSidebarContext.Provider>
   )
 }
 

--- a/packages/web/src/components/nav/Navigator.tsx
+++ b/packages/web/src/components/nav/Navigator.tsx
@@ -81,9 +81,16 @@ const Navigator = ({ className }: OwnProps) => {
 
     const handleMouseUp = (e: MouseEvent) => {
       const delta = e.clientX - dragStartX.current
-      const commit = dragStartCollapsed.current
-        ? delta <= SNAP_DELTA   // was collapsed: stay unless dragged right past threshold
-        : delta < -SNAP_DELTA  // was expanded: collapse only if dragged left past threshold
+      const absDelta = Math.abs(delta)
+      let commit: boolean
+      if (absDelta < SNAP_DELTA) {
+        // Treat as a click — toggle the sidebar
+        commit = !dragStartCollapsed.current
+      } else {
+        commit = dragStartCollapsed.current
+          ? delta <= SNAP_DELTA   // was collapsed: stay unless dragged right past threshold
+          : delta < -SNAP_DELTA  // was expanded: collapse only if dragged left past threshold
+      }
       setIsCollapsed(commit)
       setIsDragging(false)
     }

--- a/packages/web/src/components/nav/Navigator.tsx
+++ b/packages/web/src/components/nav/Navigator.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react'
 
 import { Client } from '@audius/common/models'
 import cn from 'classnames'
@@ -7,8 +13,8 @@ import { useIsMobile } from 'hooks/useIsMobile'
 import { getClient } from 'utils/clientUtil'
 
 import styles from './Navigator.module.css'
-import { NavSidebarContext } from './desktop/NavSidebarContext'
 import { LeftNav } from './desktop/LeftNav'
+import { NavSidebarContext } from './desktop/NavSidebarContext'
 import ConnectedNavBar from './mobile/ConnectedNavBar'
 
 // Extend Window interface for React Native WebView
@@ -44,8 +50,13 @@ const Navigator = ({ className }: OwnProps) => {
   })
   const [isDragging, setIsDragging] = useState(false)
 
+  // Width is always the committed state — no intermediate values during drag.
+  // The sidebar stays put while dragging; on release it animates to the new state.
+  const navWidth = isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH
+
   const dragStartX = useRef(0)
   const dragStartCollapsed = useRef(false)
+  const previousNavWidth = useRef(navWidth)
 
   const setIsCollapsed = useCallback((collapsed: boolean) => {
     setIsCollapsedState(collapsed)
@@ -54,17 +65,30 @@ const Navigator = ({ className }: OwnProps) => {
     } catch {}
   }, [])
 
-  // Width is always the committed state — no intermediate values during drag.
-  // The sidebar stays put while dragging; on release it animates to the new state.
-  const navWidth = isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH
-
-  // Update --nav-width on the app element before paint to avoid flash
+  // Update app-level nav vars before paint. When nav width changes, use FLIP:
+  // commit the new layout width once, then animate a transform back to zero.
   useLayoutEffect(() => {
     const appEl = document.getElementById('webPlayer')
     if (!appEl) return
+
+    const previousWidth = previousNavWidth.current
+    const didWidthChange = previousWidth !== navWidth
+    const shiftDelta = previousWidth - navWidth
+
     appEl.style.setProperty('--nav-width', `${navWidth}px`)
     appEl.style.setProperty('--nav-width-minus-border', `${navWidth - 1}px`)
-  }, [navWidth])
+
+    if (!isMobile && didWidthChange) {
+      appEl.style.setProperty('--nav-shift', `${shiftDelta}px`)
+      // Flush the starting transform before animating back to zero.
+      appEl.getBoundingClientRect()
+      appEl.style.setProperty('--nav-shift', '0px')
+    } else {
+      appEl.style.setProperty('--nav-shift', '0px')
+    }
+
+    previousNavWidth.current = navWidth
+  }, [isMobile, navWidth])
 
   const handleDragStart = useCallback(
     (e: React.MouseEvent) => {
@@ -87,9 +111,11 @@ const Navigator = ({ className }: OwnProps) => {
         // Treat as a click — toggle the sidebar
         commit = !dragStartCollapsed.current
       } else {
+        // was collapsed: stay unless dragged right past threshold
+        // was expanded: collapse only if dragged left past threshold
         commit = dragStartCollapsed.current
-          ? delta <= SNAP_DELTA   // was collapsed: stay unless dragged right past threshold
-          : delta < -SNAP_DELTA  // was expanded: collapse only if dragged left past threshold
+          ? delta <= SNAP_DELTA
+          : delta < -SNAP_DELTA
       }
       setIsCollapsed(commit)
       setIsDragging(false)

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -114,7 +114,8 @@ const SignedInAccountDetails = ({
   const { isCollapsed } = useNavSidebar()
   const { color } = useTheme()
   const profileLink = profilePage(handle)
-  const [isAccountSwitcherVisible, setIsAccountSwitcherVisible] = useState(false)
+  const [isAccountSwitcherVisible, setIsAccountSwitcherVisible] =
+    useState(false)
 
   return (
     <Flex direction='column' pb='unit1' w='100%'>

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -98,63 +98,107 @@ const AccountInfo = ({ children }: AccountInfoProps) => (
   </Flex>
 )
 
-type SignedInViewProps = {
+// Unified signed-in component — Avatar stays mounted across collapse/expand so
+// the image never reloads.
+type SignedInAccountDetailsProps = {
   userId: number
   handle: string
   isManagedAccount: boolean
 }
 
-const SignedInView = ({
+const SignedInAccountDetails = ({
   userId,
   handle,
   isManagedAccount
-}: SignedInViewProps) => {
+}: SignedInAccountDetailsProps) => {
+  const { isCollapsed } = useNavSidebar()
   const { color } = useTheme()
   const profileLink = profilePage(handle)
-
-  const [isAccountSwitcherVisible, setIsAccountSwitcherVisible] =
-    useState(false)
+  const [isAccountSwitcherVisible, setIsAccountSwitcherVisible] = useState(false)
 
   return (
-    <AccountContentWrapper>
-      <Avatar userId={userId} h={48} w={48} />
-      <AccountInfo>
-        <Flex alignItems='center' justifyContent='space-between' gap='s' h={20}>
-          <Flex
-            css={{
-              maxWidth: isAccountSwitcherVisible ? '85%' : '100%',
-              overflow: 'hidden'
-            }}
-          >
-            <UserLink
-              popover
-              textVariant='title'
-              size='s'
-              userId={userId}
-              badgeSize='xs'
-              ellipses
-              css={{
-                ...(isManagedAccount && {
-                  color: color.secondary.s500,
-                  '&:hover': { color: color.secondary.s500 }
+    <Flex direction='column' pb='unit1' w='100%'>
+      {isManagedAccount && !isCollapsed ? (
+        <Box pv='xs' ph='m' backgroundColor='accent'>
+          <Text variant='label' size='xs' color='white'>
+            {messages.managedAccount}
+          </Text>
+        </Box>
+      ) : null}
+      <Flex
+        pv='s'
+        pr={isCollapsed ? undefined : 's'}
+        pl={isCollapsed ? undefined : 'm'}
+        alignItems='center'
+        w={isCollapsed ? '64px' : undefined}
+        justifyContent={isCollapsed ? 'center' : 'flex-start'}
+        gap={isCollapsed ? undefined : 's'}
+        {...(isManagedAccount
+          ? {
+              borderTop: isCollapsed ? 'strong' : undefined,
+              borderBottom: 'strong',
+              css: {
+                ...backgroundOverlay({
+                  color: color.background.accent,
+                  opacity: 0.03
                 })
-              }}
-            />
-          </Flex>
-          <AccountSwitcher onVisibilityChange={setIsAccountSwitcherVisible} />
-        </Flex>
-        <TextLink
-          size='s'
-          to={profileLink}
-          css={
-            isManagedAccount && {
-              color: color.secondary.s500,
-              '&:hover': { color: color.secondary.s500 }
+              }
             }
-          }
-        >{`@${handle}`}</TextLink>
-      </AccountInfo>
-    </AccountContentWrapper>
+          : undefined)}
+      >
+        {/* Avatar is always at position 0 here — never remounts on collapse/expand */}
+        <Avatar userId={userId} h={48} w={48} />
+        {!isCollapsed ? (
+          <AccountInfo>
+            <Flex
+              alignItems='center'
+              justifyContent='space-between'
+              gap='s'
+              h={20}
+            >
+              <Flex
+                css={{
+                  maxWidth: isAccountSwitcherVisible ? '85%' : '100%',
+                  overflow: 'hidden'
+                }}
+              >
+                <UserLink
+                  popover
+                  textVariant='title'
+                  size='s'
+                  userId={userId}
+                  badgeSize='xs'
+                  ellipses
+                  css={
+                    isManagedAccount
+                      ? {
+                          color: color.secondary.s500,
+                          '&:hover': { color: color.secondary.s500 }
+                        }
+                      : undefined
+                  }
+                />
+              </Flex>
+              <AccountSwitcher
+                onVisibilityChange={setIsAccountSwitcherVisible}
+              />
+            </Flex>
+            <TextLink
+              size='s'
+              to={profileLink}
+              css={
+                isManagedAccount
+                  ? {
+                      color: color.secondary.s500,
+                      '&:hover': { color: color.secondary.s500 }
+                    }
+                  : undefined
+              }
+            >{`@${handle}`}</TextLink>
+          </AccountInfo>
+        ) : null}
+      </Flex>
+    </Flex>
   )
 }
 
@@ -216,8 +260,6 @@ const CollapsedAccountDetails = ({
 }: CollapsedAccountDetailsProps) => {
   const { color } = useTheme()
 
-  // When userId is present, Avatar already renders a UserLink internally —
-  // wrapping in another Link would create nested <a> tags.
   const inner = (
     <Flex
       w='64px'
@@ -239,7 +281,6 @@ const CollapsedAccountDetails = ({
     </Flex>
   )
 
-  // Only wrap in a Link when the Avatar won't provide its own (signed-out/guest)
   return linkTo && !userId ? <Link to={linkTo}>{inner}</Link> : inner
 }
 
@@ -261,16 +302,19 @@ export const AccountDetails = () => {
   })
   const isManagedAccount = useIsManagedAccount()
 
+  // Signed-in: single component handles both collapsed/expanded so Avatar stays mounted
+  if (userId && accountHandle) {
+    return (
+      <SignedInAccountDetails
+        userId={userId}
+        handle={accountHandle}
+        isManagedAccount={isManagedAccount}
+      />
+    )
+  }
+
+  // Non-signed-in collapsed states
   if (isCollapsed) {
-    if (userId && accountHandle) {
-      return (
-        <CollapsedAccountDetails
-          userId={userId}
-          linkTo={profilePage(accountHandle)}
-          isManagedAccount={isManagedAccount}
-        />
-      )
-    }
     if (!hasCompletedAccount && guestEmail) {
       return <CollapsedAccountDetails userId={null} linkTo={SIGN_UP_PAGE} />
     }
@@ -284,19 +328,7 @@ export const AccountDetails = () => {
     return <CollapsedAccountDetails userId={null} linkTo={SIGN_IN_PAGE} />
   }
 
-  // Determine which state to show
-  if (userId && accountHandle) {
-    return (
-      <AccountDetailsContainer isManagedAccount={isManagedAccount}>
-        <SignedInView
-          userId={userId}
-          handle={accountHandle}
-          isManagedAccount={isManagedAccount}
-        />
-      </AccountDetailsContainer>
-    )
-  }
-
+  // Non-signed-in expanded states
   if (!hasCompletedAccount && guestEmail) {
     return (
       <AccountDetailsContainer>
@@ -305,7 +337,6 @@ export const AccountDetails = () => {
     )
   }
 
-  // Only shows briefly when the account is currently being loaded in during sign in
   if (accountStatus === Status.LOADING || accountStatus === Status.SUCCESS) {
     return (
       <AccountDetailsContainer>

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -10,12 +10,14 @@ import { useIsManagedAccount } from '@audius/common/hooks'
 import { Status } from '@audius/common/models'
 import { route } from '@audius/common/utils'
 import { Box, Flex, Skeleton, Text, useTheme } from '@audius/harmony'
+import { Link } from 'react-router'
 
 import { Avatar } from 'components/avatar/Avatar'
 import { TextLink, UserLink } from 'components/link'
 import { backgroundOverlay } from 'utils/styleUtils'
 
 import { AccountSwitcher } from './AccountSwitcher/AccountSwitcher'
+import { useNavSidebar } from './NavSidebarContext'
 
 const { SIGN_IN_PAGE, SIGN_UP_PAGE, profilePage } = route
 const messages = {
@@ -201,7 +203,48 @@ const LoadingView = () => {
   )
 }
 
+type CollapsedAccountDetailsProps = {
+  userId: number | null
+  linkTo?: string
+  isManagedAccount?: boolean
+}
+
+const CollapsedAccountDetails = ({
+  userId,
+  linkTo,
+  isManagedAccount
+}: CollapsedAccountDetailsProps) => {
+  const { color } = useTheme()
+
+  // When userId is present, Avatar already renders a UserLink internally —
+  // wrapping in another Link would create nested <a> tags.
+  const inner = (
+    <Flex
+      w='64px'
+      alignItems='center'
+      justifyContent='center'
+      pv='s'
+      css={
+        isManagedAccount
+          ? {
+              ...backgroundOverlay({
+                color: color.background.accent,
+                opacity: 0.03
+              })
+            }
+          : undefined
+      }
+    >
+      <Avatar userId={userId} h={48} w={48} disableLink={!!linkTo && !userId} />
+    </Flex>
+  )
+
+  // Only wrap in a Link when the Avatar won't provide its own (signed-out/guest)
+  return linkTo && !userId ? <Link to={linkTo}>{inner}</Link> : inner
+}
+
 export const AccountDetails = () => {
+  const { isCollapsed } = useNavSidebar()
   const { data: user } = useCurrentAccountUser({
     select: (user) => ({
       userId: user?.user_id,
@@ -217,6 +260,29 @@ export const AccountDetails = () => {
     select: selectIsAccountComplete
   })
   const isManagedAccount = useIsManagedAccount()
+
+  if (isCollapsed) {
+    if (userId && accountHandle) {
+      return (
+        <CollapsedAccountDetails
+          userId={userId}
+          linkTo={profilePage(accountHandle)}
+          isManagedAccount={isManagedAccount}
+        />
+      )
+    }
+    if (!hasCompletedAccount && guestEmail) {
+      return <CollapsedAccountDetails userId={null} linkTo={SIGN_UP_PAGE} />
+    }
+    if (accountStatus === Status.LOADING || accountStatus === Status.SUCCESS) {
+      return (
+        <Flex w='64px' alignItems='center' justifyContent='center' pv='s'>
+          <Skeleton w={48} h={48} css={{ borderRadius: '50%' }} />
+        </Flex>
+      )
+    }
+    return <CollapsedAccountDetails userId={null} linkTo={SIGN_IN_PAGE} />
+  }
 
   // Determine which state to show
   if (userId && accountHandle) {

--- a/packages/web/src/components/nav/desktop/CollapsedNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/CollapsedNavItem.tsx
@@ -1,5 +1,4 @@
 import { Flex, NotificationCount, useTheme } from '@audius/harmony'
-
 import type { IconComponent } from '@audius/harmony'
 
 type CollapsedNavItemProps = {
@@ -30,7 +29,10 @@ export const CollapsedNavItem = ({
       alignItems='center'
       justifyContent='center'
       pv='xs'
-      css={{ cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.5 : 1 }}
+      css={{
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.5 : 1
+      }}
       onClick={onClick}
     >
       <Flex

--- a/packages/web/src/components/nav/desktop/CollapsedNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/CollapsedNavItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, useTheme } from '@audius/harmony'
+import { Flex, NotificationCount, useTheme } from '@audius/harmony'
 
 import type { IconComponent } from '@audius/harmony'
 
@@ -6,6 +6,7 @@ type CollapsedNavItemProps = {
   icon: IconComponent
   isSelected?: boolean
   disabled?: boolean
+  hasNotification?: boolean
   onClick?: () => void
 }
 
@@ -13,6 +14,7 @@ export const CollapsedNavItem = ({
   icon: Icon,
   isSelected = false,
   disabled = false,
+  hasNotification = false,
   onClick
 }: CollapsedNavItemProps) => {
   const { color, motion } = useTheme()
@@ -50,7 +52,13 @@ export const CollapsedNavItem = ({
           }
         }}
       >
-        <Icon size='l' color={isSelected ? 'white' : 'default'} />
+        {hasNotification ? (
+          <NotificationCount size='s' isSelected={isSelected}>
+            <Icon size='l' color={isSelected ? 'white' : 'default'} />
+          </NotificationCount>
+        ) : (
+          <Icon size='l' color={isSelected ? 'white' : 'default'} />
+        )}
       </Flex>
     </Flex>
   )

--- a/packages/web/src/components/nav/desktop/CollapsedNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/CollapsedNavItem.tsx
@@ -1,0 +1,57 @@
+import { Flex, useTheme } from '@audius/harmony'
+
+import type { IconComponent } from '@audius/harmony'
+
+type CollapsedNavItemProps = {
+  icon: IconComponent
+  isSelected?: boolean
+  disabled?: boolean
+  onClick?: () => void
+}
+
+export const CollapsedNavItem = ({
+  icon: Icon,
+  isSelected = false,
+  disabled = false,
+  onClick
+}: CollapsedNavItemProps) => {
+  const { color, motion } = useTheme()
+
+  const backgroundColor = isSelected ? color.secondary.s400 : undefined
+  const insetBorderColor = isSelected
+    ? 'none'
+    : `inset 0 0 0 1px ${color.border.default}`
+
+  return (
+    <Flex
+      w='64px'
+      alignItems='center'
+      justifyContent='center'
+      pv='xs'
+      css={{ cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.5 : 1 }}
+      onClick={onClick}
+    >
+      <Flex
+        alignItems='center'
+        justifyContent='center'
+        borderRadius='m'
+        css={{
+          width: 40,
+          height: 40,
+          backgroundColor,
+          transition: `background-color ${motion.hover}`,
+          '&:hover': {
+            backgroundColor: isSelected ? undefined : color.background.surface2,
+            boxShadow: insetBorderColor
+          },
+          '&:active': {
+            opacity: !isSelected ? 0.8 : undefined,
+            transition: `opacity ${motion.quick}`
+          }
+        }}
+      >
+        <Icon size='l' color={isSelected ? 'white' : 'default'} />
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -76,8 +76,10 @@ export const LeftNav = (props: OwnProps) => {
       h='100%'
       css={{
         width: isCollapsed ? LEFT_NAV_COLLAPSED_WIDTH : LEFT_NAV_WIDTH,
+        transition: 'width 0.2s ease',
         userSelect: 'none',
-        overflow: 'visible',
+        overflowX: 'clip',
+        overflowY: 'visible',
         flexShrink: 0
       }}
     >
@@ -106,6 +108,7 @@ export const LeftNav = (props: OwnProps) => {
             scrollbarRef.current = el
           }}
           isHidden
+          options={{ suppressScrollX: true }}
         >
           <DragAutoscroller
             containerBoundaries={navBodyContainerBoundaries}
@@ -141,17 +144,17 @@ export const LeftNav = (props: OwnProps) => {
           </DragAutoscroller>
         </Scrollbar>
       </Flex>
-      {navLoaded && !isCollapsed ? (
-        <Flex direction='column' alignItems='center' gap='s'>
-          <ProfileCompletionPanel />
-          <LeftNavCTA />
-          <NowPlayingArtworkTile />
-        </Flex>
-      ) : null}
-      {navLoaded && isCollapsed ? (
-        <Flex direction='column' alignItems='center' gap='s' pb='s'>
-          <NowPlayingArtworkTile size={48} />
-          <LeftNavCTA />
+      {navLoaded ? (
+        <Flex
+          direction='column'
+          alignItems='center'
+          gap='s'
+          pb={isCollapsed ? 's' : undefined}
+        >
+          {!isCollapsed ? <ProfileCompletionPanel /> : null}
+          {!isCollapsed ? <LeftNavCTA /> : null}
+          <NowPlayingArtworkTile size={isCollapsed ? 56 : undefined} />
+          {isCollapsed ? <LeftNavCTA /> : null}
         </Flex>
       ) : null}
     </Flex>

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -43,7 +43,8 @@ export const LeftNav = (props: OwnProps) => {
   const { isCollapsed } = useNavSidebar()
   const { data: accountStatus } = useAccountStatus()
   const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure({
-    polyfill: ResizeObserver
+    polyfill: ResizeObserver,
+    debounce: { scroll: 0, resize: 80 }
   })
   const scrollbarRef = useRef<HTMLElement | null>(null)
   const [dragScrollingDirection, setDragScrollingDirection] = useState<

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -12,6 +12,7 @@ import { ProfileCompletionPanel } from 'components/profile-progress/ProfileCompl
 import { AccountDetails } from './AccountDetails'
 import { LeftNavCTA } from './LeftNavCTA'
 import { NavHeader } from './NavHeader'
+import { useNavSidebar } from './NavSidebarContext'
 import { NowPlayingArtworkTile } from './NowPlayingArtworkTile'
 import { RouteNav } from './RouteNav'
 import {
@@ -30,6 +31,7 @@ import {
 } from './nav-items'
 
 export const LEFT_NAV_WIDTH = 240
+export const LEFT_NAV_COLLAPSED_WIDTH = 64
 
 type OwnProps = {
   isElectron: boolean
@@ -37,6 +39,7 @@ type OwnProps = {
 
 export const LeftNav = (props: OwnProps) => {
   const { isElectron } = props
+  const { isCollapsed } = useNavSidebar()
   const { data: accountStatus } = useAccountStatus()
   const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure({
     polyfill: ResizeObserver
@@ -71,10 +74,11 @@ export const LeftNav = (props: OwnProps) => {
       id='leftNav'
       direction='column'
       h='100%'
-      w='100%'
       css={{
+        width: isCollapsed ? LEFT_NAV_COLLAPSED_WIDTH : LEFT_NAV_WIDTH,
         userSelect: 'none',
-        overflow: 'visible'
+        overflow: 'visible',
+        flexShrink: 0
       }}
     >
       {isElectron ? <RouteNav /> : null}
@@ -101,6 +105,7 @@ export const LeftNav = (props: OwnProps) => {
           containerRef={(el: HTMLElement) => {
             scrollbarRef.current = el
           }}
+          isHidden
         >
           <DragAutoscroller
             containerBoundaries={navBodyContainerBoundaries}
@@ -124,19 +129,29 @@ export const LeftNav = (props: OwnProps) => {
               <DashboardNavItem />
               <UploadNavItem />
               <DevToolsNavItem />
-              <Box mv='s'>
-                <Divider />
-              </Box>
-              <PlaylistsNavItem />
+              {!isCollapsed ? (
+                <>
+                  <Box mv='s'>
+                    <Divider />
+                  </Box>
+                  <PlaylistsNavItem />
+                </>
+              ) : null}
             </Flex>
           </DragAutoscroller>
         </Scrollbar>
       </Flex>
-      {navLoaded ? (
+      {navLoaded && !isCollapsed ? (
         <Flex direction='column' alignItems='center' gap='s'>
           <ProfileCompletionPanel />
           <LeftNavCTA />
           <NowPlayingArtworkTile />
+        </Flex>
+      ) : null}
+      {navLoaded && isCollapsed ? (
+        <Flex direction='column' alignItems='center' gap='s' pb='s'>
+          <NowPlayingArtworkTile size={48} />
+          <LeftNavCTA />
         </Flex>
       ) : null}
     </Flex>

--- a/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
@@ -15,17 +15,22 @@ import { Link } from 'react-router'
 import { make, useRecord } from 'common/store/analytics/actions'
 import { SignOnLink } from 'components/SignOnLink'
 
+import { useNavSidebar } from './NavSidebarContext'
+
 const { SIGN_UP_PAGE } = route
 
 const messages = {
   signUp: 'Sign up',
   uploadTrack: 'Upload Track',
   uploading: 'Uploading...',
-  finishSignUp: 'Finish Signing Up'
+  finishSignUp: 'Finish Signing Up',
+  signUpLabel: 'Create an account',
+  finishSignUpLabel: 'Finish signing up'
 }
 
 export const LeftNavCTA = () => {
   const record = useRecord()
+  const { isCollapsed } = useNavSidebar()
   const isSignedIn = useHasAccount()
   const { data: accountStatus } = useAccountStatus()
   const { data: hasCompletedAccount } = useCurrentAccountUser({
@@ -44,48 +49,70 @@ export const LeftNavCTA = () => {
     record(make(Name.CREATE_ACCOUNT_OPEN, { source: 'nav button' }))
   }, [record])
 
-  let button
-  switch (status) {
-    case 'signedIn':
-    case 'uploading':
-      button = null
-      break
-    case 'loading':
-      button = null
-      break
-    case 'guest':
-      button = (
-        <Box p='l' w='100%'>
+  if (status === 'signedIn' || status === 'uploading' || status === 'loading') {
+    return null
+  }
+
+  if (isCollapsed) {
+    if (status === 'guest') {
+      return (
+        <Box ph='xs' pb='s' w='100%'>
           <Button
             variant='primary'
-            size='small'
+            size='xs'
             asChild
-            iconRight={IconArrowRight}
             fullWidth
+            css={{ fontSize: 12 }}
           >
             <SignOnLink signUp>{messages.finishSignUp}</SignOnLink>
           </Button>
         </Box>
       )
-      break
-    case 'signedOut':
-    default:
-      button = (
-        <Box p='l' w='100%'>
-          <Button
-            variant='primary'
-            size='small'
-            asChild
-            iconRight={IconArrowRight}
-            fullWidth
-            onClick={handleSignup}
-          >
-            <Link to={SIGN_UP_PAGE}>{messages.signUp}</Link>
-          </Button>
-        </Box>
-      )
-      break
+    }
+    return (
+      <Box ph='xs' pb='s' w='100%'>
+        <Button
+          variant='primary'
+          size='xs'
+          asChild
+          fullWidth
+          onClick={handleSignup}
+          css={{ fontSize: 12 }}
+        >
+          <Link to={SIGN_UP_PAGE}>{messages.signUp}</Link>
+        </Button>
+      </Box>
+    )
   }
 
-  return button
+  if (status === 'guest') {
+    return (
+      <Box p='l' w='100%'>
+        <Button
+          variant='primary'
+          size='small'
+          asChild
+          iconRight={IconArrowRight}
+          fullWidth
+        >
+          <SignOnLink signUp>{messages.finishSignUp}</SignOnLink>
+        </Button>
+      </Box>
+    )
+  }
+
+  return (
+    <Box p='l' w='100%'>
+      <Button
+        variant='primary'
+        size='small'
+        asChild
+        iconRight={IconArrowRight}
+        fullWidth
+        onClick={handleSignup}
+      >
+        <Link to={SIGN_UP_PAGE}>{messages.signUp}</Link>
+      </Button>
+    </Box>
+  )
 }

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -61,6 +61,7 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
     additionalPathMatches = [],
     leftIcon,
     rightIcon,
+    hasNotification,
     ...other
   } = props
   const location = useLocation()
@@ -97,7 +98,7 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
   if (isCollapsed && leftIcon) {
     return (
       <NavLink to={to ?? ''} onClick={requiresAccountOnClick} draggable={false}>
-        <CollapsedNavItem icon={leftIcon} isSelected={isSelected} disabled={disabled} />
+        <CollapsedNavItem icon={leftIcon} isSelected={isSelected} disabled={disabled} hasNotification={hasNotification} />
       </NavLink>
     )
   }
@@ -108,6 +109,7 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
         {...other}
         leftIcon={leftIcon}
         rightIcon={rightIcon}
+        hasNotification={hasNotification}
         isSelected={isSelected}
         css={{
           opacity: disabled ? 0.5 : 1,

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -12,6 +12,9 @@ import {
 } from 'hooks/useRequiresAccount'
 import { removeNullable } from 'utils/typeUtils'
 
+import { CollapsedNavItem } from './CollapsedNavItem'
+import { useNavSidebar } from './NavSidebarContext'
+
 /**
  * Helper function to check if the current path matches any of the provided paths
  * @param params - Object containing path matching parameters
@@ -56,10 +59,13 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
     restriction,
     exact = false,
     additionalPathMatches = [],
+    leftIcon,
+    rightIcon,
     ...other
   } = props
   const location = useLocation()
   const dispatch = useDispatch()
+  const { isCollapsed } = useNavSidebar()
   const isSelected = useMemo(() => {
     const pathsToMatch = [to, ...additionalPathMatches].filter(removeNullable)
     return isPathMatch({
@@ -88,10 +94,20 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
     restriction
   )
 
+  if (isCollapsed && leftIcon) {
+    return (
+      <NavLink to={to ?? ''} onClick={requiresAccountOnClick} draggable={false}>
+        <CollapsedNavItem icon={leftIcon} isSelected={isSelected} disabled={disabled} />
+      </NavLink>
+    )
+  }
+
   return (
     <NavLink to={to ?? ''} onClick={requiresAccountOnClick} draggable={false}>
       <NavItem
         {...other}
+        leftIcon={leftIcon}
+        rightIcon={rightIcon}
         isSelected={isSelected}
         css={{
           opacity: disabled ? 0.5 : 1,

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -98,7 +98,12 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
   if (isCollapsed && leftIcon) {
     return (
       <NavLink to={to ?? ''} onClick={requiresAccountOnClick} draggable={false}>
-        <CollapsedNavItem icon={leftIcon} isSelected={isSelected} disabled={disabled} hasNotification={hasNotification} />
+        <CollapsedNavItem
+          icon={leftIcon}
+          isSelected={isSelected}
+          disabled={disabled}
+          hasNotification={hasNotification}
+        />
       </NavLink>
     )
   }

--- a/packages/web/src/components/nav/desktop/NavHeader.tsx
+++ b/packages/web/src/components/nav/desktop/NavHeader.tsx
@@ -8,6 +8,7 @@ import {
 import { route } from '@audius/common/utils'
 import {
   Flex,
+  IconAudiusLogo,
   IconAudiusLogoHorizontalNew,
   IconSettings
 } from '@audius/harmony'
@@ -17,6 +18,7 @@ import { RestrictionType, useRequiresAccountFn } from 'hooks/useRequiresAccount'
 
 import { NavHeaderButton } from './NavHeaderButton'
 import { NotificationsButton } from './NotificationsButton'
+import { useNavSidebar } from './NavSidebarContext'
 
 const { HOME_PAGE, SETTINGS_PAGE } = route
 
@@ -70,6 +72,46 @@ const RestrictedLink = ({
 }
 
 export const NavHeader = () => {
+  const { isCollapsed } = useNavSidebar()
+
+  if (isCollapsed) {
+    return (
+      <Flex
+        direction='column'
+        backgroundColor='surface1'
+        flex={0}
+        css={{ minHeight: 58 }}
+      >
+        {/* Row 1: actions (settings + bell) */}
+        <Flex
+          alignItems='center'
+          justifyContent='space-around'
+          ph='xs'
+          css={{ height: 26, paddingTop: 4 }}
+        >
+          <RestrictedLink to={SETTINGS_PAGE} restriction='account'>
+            <NavHeaderButton
+              icon={IconSettings}
+              aria-label={messages.settingsLabel}
+              isActive={location.pathname === SETTINGS_PAGE}
+            />
+          </RestrictedLink>
+          <NotificationsButton />
+        </Flex>
+        {/* Row 2: Audius triangle logo */}
+        <Flex
+          alignItems='center'
+          justifyContent='center'
+          css={{ height: 32 }}
+        >
+          <Link to={HOME_PAGE} aria-label={messages.homeLink}>
+            <IconAudiusLogo color='subdued' size='m' />
+          </Link>
+        </Flex>
+      </Flex>
+    )
+  }
+
   return (
     <Flex
       alignItems='center'

--- a/packages/web/src/components/nav/desktop/NavHeader.tsx
+++ b/packages/web/src/components/nav/desktop/NavHeader.tsx
@@ -17,10 +17,12 @@ import { Link, useLocation } from 'react-router'
 import { RestrictionType, useRequiresAccountFn } from 'hooks/useRequiresAccount'
 
 import { NavHeaderButton } from './NavHeaderButton'
-import { NotificationsButton } from './NotificationsButton'
 import { useNavSidebar } from './NavSidebarContext'
+import { NotificationsButton } from './NotificationsButton'
 
 const { HOME_PAGE, SETTINGS_PAGE } = route
+const EXPANDED_HEADER_WIDTH = 240
+const COLLAPSED_HEADER_WIDTH = 64
 
 const messages = {
   homeLink: 'Go to Home',
@@ -81,13 +83,13 @@ export const NavHeader = () => {
         direction='column'
         backgroundColor='surface1'
         flex={0}
-        css={{ minHeight: 58 }}
+        css={{ minHeight: 58, width: COLLAPSED_HEADER_WIDTH, flexShrink: 0 }}
       >
         {/* Row 1: actions (settings + bell) */}
         <Flex
           alignItems='center'
-          justifyContent='space-around'
-          ph='xs'
+          justifyContent='center'
+          gap='xs'
           css={{ height: 26, paddingTop: 4 }}
         >
           <RestrictedLink to={SETTINGS_PAGE} restriction='account'>
@@ -101,11 +103,7 @@ export const NavHeader = () => {
           <NotificationsButton size='m' />
         </Flex>
         {/* Row 2: Audius triangle logo */}
-        <Flex
-          alignItems='center'
-          justifyContent='center'
-          css={{ height: 32 }}
-        >
+        <Flex alignItems='center' justifyContent='center' css={{ height: 32 }}>
           <Link to={HOME_PAGE} aria-label={messages.homeLink}>
             <IconAudiusLogo color='subdued' size='m' />
           </Link>
@@ -122,7 +120,7 @@ export const NavHeader = () => {
       pv='l'
       ph='m'
       flex={0}
-      css={{ minHeight: 58 }}
+      css={{ minHeight: 58, width: EXPANDED_HEADER_WIDTH, flexShrink: 0 }}
     >
       <Link to={HOME_PAGE} aria-label={messages.homeLink}>
         <IconAudiusLogoHorizontalNew color='subdued' size='m' width='auto' />

--- a/packages/web/src/components/nav/desktop/NavHeader.tsx
+++ b/packages/web/src/components/nav/desktop/NavHeader.tsx
@@ -94,9 +94,10 @@ export const NavHeader = () => {
               icon={IconSettings}
               aria-label={messages.settingsLabel}
               isActive={location.pathname === SETTINGS_PAGE}
+              size='m'
             />
           </RestrictedLink>
-          <NotificationsButton />
+          <NotificationsButton size='m' />
         </Flex>
         {/* Row 2: Audius triangle logo */}
         <Flex

--- a/packages/web/src/components/nav/desktop/NavHeader.tsx
+++ b/packages/web/src/components/nav/desktop/NavHeader.tsx
@@ -12,7 +12,7 @@ import {
   IconAudiusLogoHorizontalNew,
   IconSettings
 } from '@audius/harmony'
-import { Link } from 'react-router'
+import { Link, useLocation } from 'react-router'
 
 import { RestrictionType, useRequiresAccountFn } from 'hooks/useRequiresAccount'
 
@@ -73,6 +73,7 @@ const RestrictedLink = ({
 
 export const NavHeader = () => {
   const { isCollapsed } = useNavSidebar()
+  const { pathname } = useLocation()
 
   if (isCollapsed) {
     return (
@@ -93,7 +94,7 @@ export const NavHeader = () => {
             <NavHeaderButton
               icon={IconSettings}
               aria-label={messages.settingsLabel}
-              isActive={location.pathname === SETTINGS_PAGE}
+              isActive={pathname === SETTINGS_PAGE}
               size='m'
             />
           </RestrictedLink>
@@ -131,7 +132,7 @@ export const NavHeader = () => {
           <NavHeaderButton
             icon={IconSettings}
             aria-label={messages.settingsLabel}
-            isActive={location.pathname === SETTINGS_PAGE}
+            isActive={pathname === SETTINGS_PAGE}
           />
         </RestrictedLink>
         <NotificationsButton />

--- a/packages/web/src/components/nav/desktop/NavSidebarContext.tsx
+++ b/packages/web/src/components/nav/desktop/NavSidebarContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react'
+
+type NavSidebarContextType = {
+  isCollapsed: boolean
+  setIsCollapsed: (collapsed: boolean) => void
+}
+
+export const NavSidebarContext = createContext<NavSidebarContextType>({
+  isCollapsed: false,
+  setIsCollapsed: () => {}
+})
+
+export const useNavSidebar = () => useContext(NavSidebarContext)

--- a/packages/web/src/components/nav/desktop/NotificationsButton.tsx
+++ b/packages/web/src/components/nav/desktop/NotificationsButton.tsx
@@ -98,7 +98,8 @@ export const NotificationsButton = ({ size }: NotificationsButtonProps) => {
     handleToggleNotificationPanel,
     isOpen,
     shouldShowCount,
-    onOpen
+    onOpen,
+    size
   ])
 
   return (

--- a/packages/web/src/components/nav/desktop/NotificationsButton.tsx
+++ b/packages/web/src/components/nav/desktop/NotificationsButton.tsx
@@ -23,7 +23,11 @@ const messages = {
   label: (count: number) => `${count} unread notifications`
 }
 
-export const NotificationsButton = () => {
+type NotificationsButtonProps = {
+  size?: 'xs' | 's' | 'm' | 'l' | 'xl'
+}
+
+export const NotificationsButton = ({ size }: NotificationsButtonProps) => {
   const { data: notificationCount = 0 } = useNotificationUnreadCount()
   const hasAccount = useHasAccount()
   const { data: isAccountComplete = false } = useCurrentAccountUser({
@@ -76,6 +80,7 @@ export const NotificationsButton = () => {
         icon={IconNotificationOn}
         aria-label={messages.label(notificationCount)}
         isActive={isOpen}
+        size={size}
       />
     )
     if (shouldShowCount) {

--- a/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
+++ b/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useCallback } from 'react'
+import { MouseEvent, useCallback, useRef } from 'react'
 
 import { useCurrentUserId, useTrack } from '@audius/common/api'
 import { SquareSizes } from '@audius/common/models'
@@ -38,7 +38,11 @@ const messages = {
 
 const AnimatedPaper = animated(Paper)
 
-export const NowPlayingArtworkTile = () => {
+type NowPlayingArtworkTileProps = {
+  size?: number
+}
+
+export const NowPlayingArtworkTile = ({ size = 208 }: NowPlayingArtworkTileProps) => {
   const dispatch = useDispatch()
   const location = useLocation()
   const { pathname } = location
@@ -79,12 +83,25 @@ export const NowPlayingArtworkTile = () => {
     trackId: trackId ?? undefined
   })
 
+  const isTrackVisible = !!(permalink && trackId)
+  const prevIsTrackVisible = useRef(isTrackVisible)
+  const trackVisibilityChanged = prevIsTrackVisible.current !== isTrackVisible
+  prevIsTrackVisible.current = isTrackVisible
+
+  // `from` seeds the spring on mount. If the track is already playing when this
+  // component mounts (e.g. sidebar toggled), start at the visible state so there
+  // is no flash. `from` is ignored on subsequent renders — the spring continues
+  // from its current animated value.
   const slideInProps = useSpring({
-    from: { opacity: 0, height: 0 },
-    to:
-      permalink && trackId
-        ? { opacity: 1, height: 208 }
-        : { opacity: 0, height: 0 }
+    from: {
+      opacity: isTrackVisible ? 1 : 0,
+      height: isTrackVisible ? size : 0
+    },
+    to: {
+      opacity: isTrackVisible ? 1 : 0,
+      height: isTrackVisible ? size : 0
+    },
+    immediate: !trackVisibilityChanged
   })
 
   if (!permalink || !trackId) return null
@@ -138,15 +155,17 @@ export const NowPlayingArtworkTile = () => {
                   onClick={handleShowVisualizer}
                 >
                   <IconVisualizer className={styles.visualizerPillIcon} />
-                  <Text
-                    tag='span'
-                    variant='body'
-                    size='xs'
-                    strength='strong'
-                    className={styles.visualizerPillLabel}
-                  >
-                    {messages.visualizer}
-                  </Text>
+                  {size >= 100 ? (
+                    <Text
+                      tag='span'
+                      variant='body'
+                      size='xs'
+                      strength='strong'
+                      className={styles.visualizerPillLabel}
+                    >
+                      {messages.visualizer}
+                    </Text>
+                  ) : null}
                 </button>
               )}
             </div>
@@ -157,7 +176,7 @@ export const NowPlayingArtworkTile = () => {
   }
 
   const content = (
-    <Box mh='auto' mb={0} css={{ position: 'relative' }} h={208} w={208}>
+    <Box mh='auto' mb={0} css={{ position: 'relative' }} h={size} w={size}>
       <TrackDogEar trackId={trackId} />
       {renderCoverArt()}
     </Box>

--- a/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
+++ b/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
@@ -44,7 +44,9 @@ type NowPlayingArtworkTileProps = {
 
 const isSmall = (size: number) => size < 100
 
-export const NowPlayingArtworkTile = ({ size = 208 }: NowPlayingArtworkTileProps) => {
+export const NowPlayingArtworkTile = ({
+  size = 208
+}: NowPlayingArtworkTileProps) => {
   const dispatch = useDispatch()
   const location = useLocation()
   const { pathname } = location

--- a/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
+++ b/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
@@ -42,6 +42,8 @@ type NowPlayingArtworkTileProps = {
   size?: number
 }
 
+const isSmall = (size: number) => size < 100
+
 export const NowPlayingArtworkTile = ({ size = 208 }: NowPlayingArtworkTileProps) => {
   const dispatch = useDispatch()
   const location = useLocation()
@@ -110,6 +112,7 @@ export const NowPlayingArtworkTile = ({ size = 208 }: NowPlayingArtworkTileProps
     return (
       <AnimatedPaper
         border='default'
+        borderRadius={isSmall(size) ? 's' : 'm'}
         css={{
           display: 'block',
           transition: `opacity ${motion.quick}, box-shadow ${motion.quick}`,
@@ -147,7 +150,7 @@ export const NowPlayingArtworkTile = ({ size = 208 }: NowPlayingArtworkTileProps
                   <IconImage width={48} height={48} />
                 </Box>
               ) : null}
-              {NO_VISUALIZER_ROUTES.has(pathname) ? null : (
+              {!isSmall(size) && !NO_VISUALIZER_ROUTES.has(pathname) ? (
                 <button
                   type='button'
                   className={styles.visualizerPill}
@@ -155,19 +158,17 @@ export const NowPlayingArtworkTile = ({ size = 208 }: NowPlayingArtworkTileProps
                   onClick={handleShowVisualizer}
                 >
                   <IconVisualizer className={styles.visualizerPillIcon} />
-                  {size >= 100 ? (
-                    <Text
-                      tag='span'
-                      variant='body'
-                      size='xs'
-                      strength='strong'
-                      className={styles.visualizerPillLabel}
-                    >
-                      {messages.visualizer}
-                    </Text>
-                  ) : null}
+                  <Text
+                    tag='span'
+                    variant='body'
+                    size='xs'
+                    strength='strong'
+                    className={styles.visualizerPillLabel}
+                  >
+                    {messages.visualizer}
+                  </Text>
                 </button>
-              )}
+              ) : null}
             </div>
           </DynamicImage>
         </Link>
@@ -177,7 +178,22 @@ export const NowPlayingArtworkTile = ({ size = 208 }: NowPlayingArtworkTileProps
 
   const content = (
     <Box mh='auto' mb={0} css={{ position: 'relative' }} h={size} w={size}>
-      <TrackDogEar trackId={trackId} />
+      {isSmall(size) ? (
+        <Box
+          css={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            transform: 'scale(0.5)',
+            transformOrigin: 'top left',
+            zIndex: 11
+          }}
+        >
+          <TrackDogEar trackId={trackId} />
+        </Box>
+      ) : (
+        <TrackDogEar trackId={trackId} />
+      )}
       {renderCoverArt()}
     </Box>
   )

--- a/packages/web/src/components/profile-progress/ProfileCompletionPanel.tsx
+++ b/packages/web/src/components/profile-progress/ProfileCompletionPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { useHasAccount, useIsAccountLoaded } from '@audius/common/api'
 import {
@@ -45,7 +45,7 @@ export const ProfileCompletionPanel = () => {
   })
   const [isTooltipDisabled, setIsTooltipDisabled] = useState(false)
 
-  const onDismiss = () => {
+  const onDismiss = useCallback(() => {
     // disable the tooltip before we dismiss,
     // otherwise it gets scaled in the dismiss animation
     // and looks super jenk
@@ -56,7 +56,7 @@ export const ProfileCompletionPanel = () => {
         localStorage.setItem('profile-completion-panel-dismissed', 'true')
       } catch {}
     }, 200)
-  }
+  }, [])
 
   const { isHidden, didCompleteThisSession, shouldNeverShow } =
     useProfileCompletionDismissal({

--- a/packages/web/src/components/profile-progress/ProfileCompletionPanel.tsx
+++ b/packages/web/src/components/profile-progress/ProfileCompletionPanel.tsx
@@ -38,7 +38,9 @@ export const ProfileCompletionPanel = () => {
 
   const [isDismissed, setIsDismissed] = useState(() => {
     try {
-      return localStorage.getItem('profile-completion-panel-dismissed') === 'true'
+      return (
+        localStorage.getItem('profile-completion-panel-dismissed') === 'true'
+      )
     } catch {
       return false
     }

--- a/packages/web/src/components/profile-progress/ProfileCompletionPanel.tsx
+++ b/packages/web/src/components/profile-progress/ProfileCompletionPanel.tsx
@@ -36,7 +36,13 @@ export const ProfileCompletionPanel = () => {
   const isAccountLoaded = useIsAccountLoaded()
   const isLoggedIn = useHasAccount()
 
-  const [isDismissed, setIsDismissed] = useState(false)
+  const [isDismissed, setIsDismissed] = useState(() => {
+    try {
+      return localStorage.getItem('profile-completion-panel-dismissed') === 'true'
+    } catch {
+      return false
+    }
+  })
   const [isTooltipDisabled, setIsTooltipDisabled] = useState(false)
 
   const onDismiss = () => {
@@ -46,6 +52,9 @@ export const ProfileCompletionPanel = () => {
     setIsTooltipDisabled(true)
     setTimeout(() => {
       setIsDismissed(true)
+      try {
+        localStorage.setItem('profile-completion-panel-dismissed', 'true')
+      } catch {}
     }, 200)
   }
 


### PR DESCRIPTION
Kept the interaction pretty subtle, but hover over the edge of the sidebar and you'll see a resize handle. You can drag or click to resize. 

This should work for authenticated and unauthenticated users, includes a minimal layout for manager mode visibility, and a small artwork view in the corner.

I also hid some of the controls for simplicity (no playlists in collapsed state, no manger mode toggle, no visualizer button)