### PR TITLE
Fix mobile swipe-back opening left drawer inside tab stacks

### DIFF
--- a/packages/mobile/src/screens/app-drawer-screen/AppDrawerContext.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/AppDrawerContext.tsx
@@ -9,6 +9,7 @@ type AppDrawerContextType = {
   drawerNavigation?: NavigationProp<any>
   gesturesDisabled?: boolean
   setGesturesDisabled?: (gestureDisabled: boolean) => void
+  setIsAtStackRoot?: (isAtStackRoot: boolean) => void
 }
 
 type AppDrawerContextValue = AppDrawerContextType | Record<string, never>
@@ -27,7 +28,8 @@ export const AppDrawerContextProvider = (
     drawerHelpers,
     drawerNavigation,
     gesturesDisabled,
-    setGesturesDisabled
+    setGesturesDisabled,
+    setIsAtStackRoot
   } = props
 
   const context = useMemo(
@@ -35,9 +37,16 @@ export const AppDrawerContextProvider = (
       drawerHelpers,
       drawerNavigation,
       gesturesDisabled,
-      setGesturesDisabled
+      setGesturesDisabled,
+      setIsAtStackRoot
     }),
-    [drawerHelpers, drawerNavigation, gesturesDisabled, setGesturesDisabled]
+    [
+      drawerHelpers,
+      drawerNavigation,
+      gesturesDisabled,
+      setGesturesDisabled,
+      setIsAtStackRoot
+    ]
   )
   return (
     <AppDrawerContext.Provider value={context}>

--- a/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { DrawerContentComponentProps } from '@react-navigation/drawer'
 import { createDrawerNavigator } from '@react-navigation/drawer'
@@ -22,6 +22,7 @@ type AppTabScreenProps = {
   navigation: DrawerContentComponentProps['navigation']
   gesturesDisabled: boolean
   setGesturesDisabled: (gesturesDisabled: boolean) => void
+  setIsAtStackRoot: (isAtStackRoot: boolean) => void
 }
 
 /**
@@ -31,7 +32,8 @@ const AppStack = memo(function AppStack(props: AppTabScreenProps) {
   const {
     navigation: drawerHelpers,
     gesturesDisabled,
-    setGesturesDisabled
+    setGesturesDisabled,
+    setIsAtStackRoot
   } = props
 
   const drawerNavigation = useNavigation() as any
@@ -42,6 +44,7 @@ const AppStack = memo(function AppStack(props: AppTabScreenProps) {
       drawerHelpers={drawerHelpers}
       gesturesDisabled={gesturesDisabled}
       setGesturesDisabled={setGesturesDisabled}
+      setIsAtStackRoot={setIsAtStackRoot}
     >
       <AppScreen />
     </AppDrawerContextProvider>
@@ -50,10 +53,19 @@ const AppStack = memo(function AppStack(props: AppTabScreenProps) {
 
 export const AppDrawerScreen = memo(() => {
   const [gesturesDisabled, setGesturesDisabled] = useState(false)
+  const [isAtStackRoot, setIsAtStackRootState] = useState(true)
   const { isOpen: isNowPlayingDrawerOpen } = useDrawer('NowPlaying')
   const drawerHelpersRef = useRef<
     DrawerContentComponentProps['navigation'] | null
   >(null)
+
+  // Drawer swipe only when at stack root; otherwise the stack's swipe-back wins.
+  const setIsAtStackRoot = useCallback((next: boolean) => {
+    setIsAtStackRootState((prev) => (prev === next ? prev : next))
+  }, [])
+
+  const canSwipeDrawer =
+    isAtStackRoot && !gesturesDisabled && !isNowPlayingDrawerOpen
 
   const drawerScreenOptions = useMemo(
     () => ({
@@ -61,12 +73,12 @@ export const AppDrawerScreen = memo(() => {
       swipeEdgeWidth: SCREEN_WIDTH,
       drawerType: 'slide' as const,
       drawerStyle: { width: '75%' as const },
-      swipeEnabled: !gesturesDisabled && !isNowPlayingDrawerOpen,
+      swipeEnabled: canSwipeDrawer,
       gestureHandlerProps: {
-        enabled: !gesturesDisabled && !isNowPlayingDrawerOpen
+        enabled: canSwipeDrawer
       }
     }),
-    [gesturesDisabled, isNowPlayingDrawerOpen]
+    [canSwipeDrawer]
   )
 
   // Close the left nav drawer if it's open when the now-playing drawer opens
@@ -76,7 +88,11 @@ export const AppDrawerScreen = memo(() => {
     }
   }, [isNowPlayingDrawerOpen])
 
-  const gestureProps = { gesturesDisabled, setGesturesDisabled }
+  const gestureProps = {
+    gesturesDisabled,
+    setGesturesDisabled,
+    setIsAtStackRoot
+  }
 
   return (
     <>

--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/LeftNavDrawer.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/LeftNavDrawer.tsx
@@ -26,6 +26,7 @@ import {
 type AccountDrawerProps = DrawerContentComponentProps & {
   gesturesDisabled: boolean
   setGesturesDisabled: (disabled: boolean) => void
+  setIsAtStackRoot: (isAtStackRoot: boolean) => void
 }
 
 export const LeftNavDrawer = (props: AccountDrawerProps) => {

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect, useRef } from 'react'
 
 import type {
   FavoriteType,
@@ -17,6 +17,7 @@ import type {
   GetCoinsSortDirectionEnum
 } from '@audius/sdk'
 import type { EventArg, NavigationState } from '@react-navigation/native'
+import { useIsFocused } from '@react-navigation/native'
 import type { createNativeStackNavigator } from '@react-navigation/native-stack'
 
 import { FilterButtonScreen } from '@audius/harmony-native'
@@ -176,23 +177,32 @@ type AppTabScreenProps = {
  */
 export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
   const screenOptions = useAppScreenOptions()
-  const { drawerNavigation } = useContext(AppDrawerContext)
+  const { drawerNavigation, setIsAtStackRoot } = useContext(AppDrawerContext)
   const { isOpen: isNowPlayingDrawerOpen } = useDrawer('NowPlaying')
+  const isFocused = useIsFocused()
+  const isAtStackRootRef = useRef(true)
+
+  // NowPlayingDrawer calls setOptions({swipeEnabled: false}) imperatively, and
+  // imperative options beat screenOptions, so we must also re-apply imperatively.
+  const applyDrawerSwipe = useCallback(
+    (isAtRoot: boolean) => {
+      setIsAtStackRoot?.(isAtRoot)
+      drawerNavigation?.setOptions({
+        swipeEnabled: isAtRoot && !isNowPlayingDrawerOpen
+      })
+    },
+    [drawerNavigation, isNowPlayingDrawerOpen, setIsAtStackRoot]
+  )
 
   const handleChangeState = useCallback(
     (event: NavigationStateEvent) => {
-      const stackRoutes = event?.data?.state?.routes
-      const isStackUnopened = stackRoutes.length === 1
-      const isStackOpened = stackRoutes.length === 2
-
-      if (isStackUnopened) {
-        drawerNavigation?.setOptions({ swipeEnabled: true })
-      }
-      if (isStackOpened) {
-        drawerNavigation?.setOptions({ swipeEnabled: false })
-      }
+      // Nested navigator state changes bubble up; only act on the outer stack.
+      if (event?.data?.state?.type !== 'stack') return
+      const isAtRoot = event.data.state.routes.length === 1
+      isAtStackRootRef.current = isAtRoot
+      if (isFocused) applyDrawerSwipe(isAtRoot)
     },
-    [drawerNavigation]
+    [isFocused, applyDrawerSwipe]
   )
 
   /**
@@ -205,9 +215,10 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
     setLastNavAction(undefined)
   }, [])
 
+  // Re-apply on tab focus so the drawer reflects the active tab's stack depth.
   useEffect(() => {
-    drawerNavigation?.setOptions({ swipeEnabled: !isNowPlayingDrawerOpen })
-  }, [drawerNavigation, isNowPlayingDrawerOpen])
+    if (isFocused) applyDrawerSwipe(isAtStackRootRef.current)
+  }, [isFocused, applyDrawerSwipe])
 
   return (
     <Stack.Navigator


### PR DESCRIPTION
The drawer's swipeEnabled was driven by the now-playing drawer state and a
length===2 check on a single stack, so navigating deeper or between tabs
left the flag stale and the drawer kept intercepting the swipe-back
gesture. Track stack-root state per focused tab and feed it into both
screenOptions and imperative setOptions (which NowPlayingDrawer also
uses), so the drawer only opens at a tab's root.

https://claude.ai/code/session_013k2DmKvuGrQARuTPpnU367