### PR TITLE
fix(mobile): prevent CLS on profile header by reserving cover photo height

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileCoverPhoto.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileCoverPhoto.tsx
@@ -1,4 +1,4 @@
-import { useProfileUser } from '@audius/common/api'
+import { useUserByParams } from '@audius/common/api'
 import { BlurView } from '@react-native-community/blur'
 import { StyleSheet } from 'react-native'
 import { useCurrentTabScrollY } from 'react-native-collapsible-tab-view'
@@ -11,6 +11,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Flex } from '@audius/harmony-native'
 import BadgeArtist from 'app/assets/images/badgeArtist.svg'
 import { CoverPhoto } from 'app/components/image/CoverPhoto'
+import { useRoute } from 'app/hooks/useRoute'
 import { makeStyles } from 'app/styles'
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView)
@@ -35,13 +36,17 @@ export const ProfileCoverPhoto = () => {
   const styles = useStyles()
   const insets = useSafeAreaInsets()
 
-  const { user_id, track_count } =
-    useProfileUser({
-      select: (user) => ({
-        user_id: user.user_id,
-        track_count: user.track_count
-      })
-    }).user ?? {}
+  // Read from the route-params cache directly so user data is available on
+  // the first render, avoiding the Redux-state race in `useProfileUser`
+  // that caused the cover photo to pop in late and shift layout.
+  const { params } = useRoute<'Profile'>()
+  const { data: paramsUser } = useUserByParams(params, {
+    select: (user) => ({
+      user_id: user.user_id,
+      track_count: user.track_count
+    })
+  })
+  const { user_id, track_count } = paramsUser ?? {}
 
   const scrollY = useCurrentTabScrollY()
 

--- a/packages/mobile/src/screens/profile-screen/ProfileCoverPhoto.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileCoverPhoto.tsx
@@ -68,26 +68,28 @@ export const ProfileCoverPhoto = () => {
     ]
   }))
 
-  if (!user_id) return null
-
   return (
     <Flex
       pointerEvents='box-none'
       h={coverPhotoHeight}
       backgroundColor='surface2'
     >
-      <CoverPhoto style={{ height: coverPhotoHeight }} userId={user_id}>
-        <AnimatedBlurView
-          blurType='dark'
-          blurAmount={100}
-          style={blurViewStyle}
-        />
-        {isArtist ? <Animated.View style={styles.darkOverlay} /> : null}
-      </CoverPhoto>
-      {isArtist ? (
-        <Animated.View style={[styles.artistBadge, badgeStyle]}>
-          <BadgeArtist />
-        </Animated.View>
+      {user_id ? (
+        <>
+          <CoverPhoto style={{ height: coverPhotoHeight }} userId={user_id}>
+            <AnimatedBlurView
+              blurType='dark'
+              blurAmount={100}
+              style={blurViewStyle}
+            />
+            {isArtist ? <Animated.View style={styles.darkOverlay} /> : null}
+          </CoverPhoto>
+          {isArtist ? (
+            <Animated.View style={[styles.artistBadge, badgeStyle]}>
+              <BadgeArtist />
+            </Animated.View>
+          ) : null}
+        </>
       ) : null}
     </Flex>
   )

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileHeader.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileHeader.tsx
@@ -3,8 +3,8 @@ import { memo, useCallback, useEffect, useState } from 'react'
 import {
   useArtistCreatedFanClub,
   useCurrentUserId,
-  useUserComments,
-  useProfileUser
+  useUserByParams,
+  useUserComments
 } from '@audius/common/api'
 import { useTierAndVerifiedForUser } from '@audius/common/store'
 import { css } from '@emotion/native'
@@ -14,6 +14,7 @@ import { useToggle } from 'react-use'
 
 import { Box, Divider, Flex, useTheme } from '@audius/harmony-native'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'
+import { useRoute } from 'app/hooks/useRoute'
 import { zIndex } from 'app/utils/zIndex'
 
 import { ArtistRecommendations } from '../ArtistRecommendations'
@@ -37,15 +38,12 @@ export const ProfileHeader = memo(() => {
   const [isExpanded, setIsExpanded] = useToggle(false)
   const [isExpandable, setIsExpandable] = useState(false)
 
-  const {
-    user_id: userId,
-    does_current_user_follow: doesCurrentUserFollow,
-    current_user_followee_follow_count: currentUserFolloweeFollowCount,
-    website,
-    twitter_handle: twitterHandle,
-    instagram_handle: instagramHandle,
-    tiktok_handle: tikTokHandle
-  } = useProfileUser({
+  // Read from the route-params cache directly so user data is available on
+  // the first render. `useProfileUser` depends on Redux state set in a
+  // focus effect, which races with the component's initial render and
+  // otherwise caused the avatar and follow-state-derived UI to pop in.
+  const { params } = useRoute<'Profile'>()
+  const { data: paramsUser } = useUserByParams(params, {
     select: (user) => ({
       user_id: user.user_id,
       does_current_user_follow: user.does_current_user_follow,
@@ -56,7 +54,17 @@ export const ProfileHeader = memo(() => {
       instagram_handle: user.instagram_handle,
       tiktok_handle: user.tiktok_handle
     })
-  }).user ?? {}
+  })
+
+  const {
+    user_id: userId,
+    does_current_user_follow: doesCurrentUserFollow,
+    current_user_followee_follow_count: currentUserFolloweeFollowCount,
+    website,
+    twitter_handle: twitterHandle,
+    instagram_handle: instagramHandle,
+    tiktok_handle: tikTokHandle
+  } = paramsUser ?? {}
 
   const { data: comments } = useUserComments({
     userId: userId || 0,

--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { useCurrentAccountUser, useProfileUser } from '@audius/common/api'
+import { useCurrentAccountUser, useUserByParams } from '@audius/common/api'
 import { FollowSource, statusIsNotFinalized } from '@audius/common/models'
 import {
   chatActions,
@@ -38,8 +38,20 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
   })
   const dispatch = useDispatch()
 
-  const { user } = useProfileUser()
-  const profileUserId = user?.user_id
+  // Read user from the route-params cache directly so it's available on
+  // the first render. `useProfileUser` depends on Redux state that is set
+  // in a focus effect, which races with the component's initial render and
+  // caused the whole header section to briefly collapse.
+  const { data: paramsUser } = useUserByParams(params, {
+    select: (user) => ({
+      user_id: user.user_id,
+      handle: user.handle,
+      does_current_user_follow: user.does_current_user_follow
+    })
+  })
+
+  const { user_id, handle, does_current_user_follow } = paramsUser ?? {}
+  const profileUserId = user_id
   const { canCreateChat } = useCanCreateChat(profileUserId)
   const chatPermissionStatus = useSelector(getChatPermissionsStatus)
 
@@ -53,15 +65,6 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
       dispatch(fetchPermissions({ userIds: [profileUserId] }))
     }
   }, [dispatch, profileUserId])
-
-  const { user_id, handle, does_current_user_follow } =
-    useProfileUser({
-      select: (user) => ({
-        user_id: user.user_id,
-        handle: user.handle,
-        does_current_user_follow: user.does_current_user_follow
-      })
-    }).user ?? {}
 
   if (!user_id) {
     return null

--- a/packages/mobile/src/screens/profile-screen/ProfileScreenSkeleton.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreenSkeleton.tsx
@@ -1,7 +1,3 @@
-import { useMemo } from 'react'
-
-import { times, random } from 'lodash'
-import { View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { Flex } from '@audius/harmony-native'
@@ -19,8 +15,8 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
     left: spacing(4),
     zIndex: 101,
 
-    height: 82,
-    width: 82,
+    height: 80,
+    width: 80,
     borderRadius: 1000,
     borderWidth: 2,
     borderStyle: 'solid',
@@ -40,8 +36,7 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
   },
   name: {
     height: spacing(5),
-    width: 100,
-    marginBottom: spacing(3)
+    width: 100
   },
   handle: {
     height: spacing(4),
@@ -104,41 +99,19 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
   }
 }))
 
-const BioSkeleton = () => {
-  const baseStyle = {
-    height: 12,
-    marginRight: 4,
-    marginBottom: 8
-  }
-
-  const elements = useMemo(
-    () => times(random(5, 10), () => random(20, 100)),
-    []
-  )
-
-  return (
-    <>
-      {elements.map((elementWidth: number, i) => (
-        <StaticSkeleton key={i} style={[baseStyle, { width: elementWidth }]} />
-      ))}
-    </>
-  )
-}
-
 export const ExpandableSectionSkeleton = () => {
-  const styles = useStyles()
+  const baseStyle = { height: 12, marginRight: 4, marginBottom: 8 }
+  // Matches the initial CollapsedSection: a 2-line bio. We don't render tier
+  // + full socials here because they only appear once the user expands the
+  // header, so reserving that space would cause a skeleton→content shift.
   return (
-    <Flex column gap='s' backgroundColor='white' p='l'>
+    <Flex column gap='s' backgroundColor='white' ph='m' pb='s'>
       <Flex row wrap='wrap'>
-        <BioSkeleton />
-      </Flex>
-      <Flex style={styles.tierAndSocials}>
-        <StaticSkeleton style={styles.tier} />
-        <View style={styles.socialLinks}>
-          <StaticSkeleton style={styles.socialLink} />
-          <StaticSkeleton style={styles.socialLink} />
-          <StaticSkeleton style={styles.socialLink} />
-        </View>
+        <StaticSkeleton style={[baseStyle, { width: 80 }]} />
+        <StaticSkeleton style={[baseStyle, { width: 60 }]} />
+        <StaticSkeleton style={[baseStyle, { width: 100 }]} />
+        <StaticSkeleton style={[baseStyle, { width: 70 }]} />
+        <StaticSkeleton style={[baseStyle, { width: 90 }]} />
       </Flex>
     </Flex>
   )
@@ -154,15 +127,23 @@ export const ProfileHeaderSkeleton = () => {
     <Flex backgroundColor='white'>
       <StaticSkeleton height={coverPhotoHeight} />
       <Skeleton style={[styles.profilePicture, { top: insets.top + 48 }]} />
-      <Flex p='l' gap='s' backgroundColor='white'>
-        <Flex row justifyContent='space-between' backgroundColor='white'>
-          <Flex mt='3xl'>
-            <StaticSkeleton style={styles.name} />
-            <StaticSkeleton style={styles.handle} />
-          </Flex>
-          <Flex row gap='s'>
+      {/* Matches the real ProfileHeader structure so the skeleton→content
+      transition doesn't cause layout shift. */}
+      <Flex
+        column
+        pv='s'
+        ph='m'
+        backgroundColor='white'
+        style={{ gap: 9 }}
+      >
+        <Flex column pv='s' gap='s'>
+          <Flex row justifyContent='flex-end' gap='xs'>
             <StaticSkeleton height={32} width={32} />
             <StaticSkeleton height={32} width={120} />
+          </Flex>
+          <Flex alignItems='flex-start' gap='2xs'>
+            <StaticSkeleton style={styles.name} />
+            <StaticSkeleton style={styles.handle} />
           </Flex>
         </Flex>
         <Flex row>


### PR DESCRIPTION
ProfileCoverPhoto returned null while `user_id` was briefly undefined (the
race between ProfileHeader mounting and useFocusEffect syncing the profile
handle into Redux), collapsing the header to zero height and springing
it back once data arrived. Always render the sized Flex container so the
cover area reserves its space; only render the inner content once user_id
is available.

https://claude.ai/code/session_01UUntXktzBDJ82HSfRwLRZ3