### PR TITLE
Fix gray bar between NavBar and Header on mobile web

### DIFF
--- a/packages/web/src/app/web-player/WebPlayer.module.css
+++ b/packages/web/src/app/web-player/WebPlayer.module.css
@@ -64,4 +64,7 @@
   overflow-x: visible;
   margin-top: calc(env(safe-area-inset-top, 0px) + 40px);
   margin-bottom: 0;
+  /* Avoid creating a containing block for the fixed mobile Header */
+  transform: none;
+  transition: none;
 }


### PR DESCRIPTION
The Shrinking Sidebar PR added `transform: translateX(var(--nav-shift))` to
`.mainContentWrapper`. Because `transform` creates a new containing block for
fixed-position descendants, the mobile Header (rendered via
`HeaderContextConsumer` inside `mainContentWrapper`) now positions its
`top: 40px` relative to `mainContentWrapper` — which already has
`margin-top: 40px` — doubling the offset and exposing the wrapper's gray
background as a ~40px bar between the NavBar and the Header.

`--nav-shift` is always 0 on mobile, so we can safely disable the transform
there.