### PR TITLE
Align mobile web navigation with native app

### DIFF
--- a/packages/web/src/components/bottom-bar/BottomBar.module.css
+++ b/packages/web/src/components/bottom-bar/BottomBar.module.css
@@ -1,13 +1,8 @@
 .bottomBar {
   user-select: none;
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  width: 100%;
   border-top: 1px solid var(--harmony-n-100);
   background: var(--harmony-n-25);
-  /* Above the play bar so it can slide up from underneath */
-  z-index: 12;
 
   padding: 0px;
   padding: 0px env(safe-area-inset-right, 0px) 0px

--- a/packages/web/src/components/bottom-bar/BottomBar.tsx
+++ b/packages/web/src/components/bottom-bar/BottomBar.tsx
@@ -7,7 +7,7 @@ import { RouterContext } from 'components/animated-switch/RouterContextProvider'
 import ExploreButton from 'components/bottom-bar/buttons/ExploreButton'
 import FeedButton from 'components/bottom-bar/buttons/FeedButton'
 import LibraryButton from 'components/bottom-bar/buttons/LibraryButton'
-import ProfileButton from 'components/bottom-bar/buttons/ProfileButton'
+import NotificationsButton from 'components/bottom-bar/buttons/NotificationsButton'
 import TrendingButton from 'components/bottom-bar/buttons/TrendingButton'
 
 import styles from './BottomBar.module.css'
@@ -20,29 +20,33 @@ declare global {
   }
 }
 
-const { FEED_PAGE, TRENDING_PAGE, EXPLORE_PAGE, FAVORITES_PAGE, LIBRARY_PAGE } =
-  route
+const {
+  FEED_PAGE,
+  TRENDING_PAGE,
+  EXPLORE_PAGE,
+  FAVORITES_PAGE,
+  LIBRARY_PAGE,
+  NOTIFICATION_PAGE
+} = route
 
 type Props = {
   currentPage: string
-  userProfilePageRoute: string | null
   onClickFeed: () => void
   onClickTrending: () => void
   onClickExplore: () => void
   onClickLibrary: () => void
-  onClickProfile: () => void
+  onClickNotifications: () => void
   isDarkMode: boolean
   isMatrixMode: boolean
 }
 
 const BottomBar = ({
   currentPage,
-  userProfilePageRoute,
   onClickFeed,
   onClickTrending,
   onClickExplore,
   onClickLibrary,
-  onClickProfile,
+  onClickNotifications,
   isDarkMode,
   isMatrixMode
 }: Props) => {
@@ -98,13 +102,13 @@ const BottomBar = ({
         isMatrixMode={isMatrixMode}
         aria-label='Library Page'
       />
-      <ProfileButton
-        isActive={currentPage === userProfilePageRoute}
+      <NotificationsButton
+        isActive={currentPage === NOTIFICATION_PAGE}
         darkMode={isDarkMode}
-        onClick={onClick(onClickProfile, userProfilePageRoute)}
-        href={userProfilePageRoute || undefined}
+        onClick={onClick(onClickNotifications, NOTIFICATION_PAGE)}
+        href={NOTIFICATION_PAGE}
         isMatrixMode={isMatrixMode}
-        aria-label='Profile Page'
+        aria-label='Notifications Page'
       />
     </div>
   )

--- a/packages/web/src/components/bottom-bar/buttons/LibraryButton.tsx
+++ b/packages/web/src/components/bottom-bar/buttons/LibraryButton.tsx
@@ -1,28 +1,24 @@
 import { memo } from 'react'
 
-import AnimatedBottomButton from './AnimatedBottomButton'
+import { IconLibrary } from '@audius/harmony'
+
+import StaticBottomButton from './StaticBottomButton'
 import { ButtonProps } from './types'
 
 const LibraryButton = ({
-  darkMode,
+  darkMode: _darkMode,
+  isMatrixMode: _isMatrixMode,
   onClick,
   href,
   isActive,
-  isMatrixMode,
   ...buttonProps
 }: ButtonProps) => {
   return (
-    <AnimatedBottomButton
-      uniqueKey='library-button'
+    <StaticBottomButton
+      icon={IconLibrary}
       isActive={isActive}
-      isMatrix={isMatrixMode}
       onClick={onClick}
       href={href}
-      iconJSON={() =>
-        import('../../../assets/animations/iconFavoriteLight.json').then(
-          (m) => m.default
-        )
-      }
       {...buttonProps}
     />
   )

--- a/packages/web/src/components/bottom-bar/buttons/NotificationsButton.tsx
+++ b/packages/web/src/components/bottom-bar/buttons/NotificationsButton.tsx
@@ -1,0 +1,54 @@
+import { memo } from 'react'
+
+import { useNotificationUnreadCount } from '@audius/common/api'
+import { formatCount } from '@audius/common/utils'
+import { Flex, IconNotificationOn } from '@audius/harmony'
+
+import StaticBottomButton from './StaticBottomButton'
+import { ButtonProps } from './types'
+
+const NotificationsButton = ({
+  darkMode: _darkMode,
+  isMatrixMode: _isMatrixMode,
+  onClick,
+  href,
+  isActive,
+  ...buttonProps
+}: ButtonProps) => {
+  const { data: notificationCount = 0 } = useNotificationUnreadCount()
+
+  const badge =
+    notificationCount > 0 ? (
+      <Flex
+        css={{
+          position: 'absolute',
+          top: -4,
+          right: -8,
+          backgroundColor: 'var(--harmony-red)',
+          color: 'var(--harmony-white)',
+          fontSize: '11px',
+          fontWeight: 'bold',
+          letterSpacing: '0.07px',
+          lineHeight: '14px',
+          padding: '0px 6px',
+          borderRadius: '8px',
+          pointerEvents: 'none'
+        }}
+      >
+        {formatCount(notificationCount)}
+      </Flex>
+    ) : null
+
+  return (
+    <StaticBottomButton
+      icon={IconNotificationOn}
+      isActive={isActive}
+      onClick={onClick}
+      href={href}
+      badge={badge}
+      {...buttonProps}
+    />
+  )
+}
+
+export default memo(NotificationsButton)

--- a/packages/web/src/components/bottom-bar/buttons/StaticBottomButton.tsx
+++ b/packages/web/src/components/bottom-bar/buttons/StaticBottomButton.tsx
@@ -1,0 +1,69 @@
+import { MouseEvent, ReactNode, useCallback } from 'react'
+
+import { IconComponent } from '@audius/harmony'
+
+import { SeoLink } from 'components/link'
+
+import styles from './AnimatedBottomButton.module.css'
+
+type StaticBottomButtonProps = {
+  icon: IconComponent
+  onClick: () => void
+  href?: string
+  isActive: boolean
+  badge?: ReactNode
+  'aria-label'?: string
+}
+
+const StaticBottomButton = ({
+  icon: Icon,
+  onClick,
+  href,
+  isActive,
+  badge,
+  ...buttonProps
+}: StaticBottomButtonProps) => {
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      e.preventDefault()
+      onClick()
+    },
+    [onClick]
+  )
+
+  const rootProps = {
+    onClick: handleClick,
+    className: styles.animatedButton
+  }
+
+  const content = (
+    <div
+      className={styles.iconWrapper}
+      style={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+    >
+      <Icon
+        width={28}
+        height={28}
+        color={isActive ? 'active' : 'default'}
+      />
+      {badge}
+    </div>
+  )
+
+  return href ? (
+    <SeoLink to={href} {...rootProps} {...buttonProps}>
+      {content}
+    </SeoLink>
+  ) : (
+    <button {...rootProps} {...buttonProps}>
+      {content}
+    </button>
+  )
+}
+
+export default StaticBottomButton

--- a/packages/web/src/components/nav/mobile/ConnectedBottomBar.tsx
+++ b/packages/web/src/components/nav/mobile/ConnectedBottomBar.tsx
@@ -12,8 +12,13 @@ import {
 import BottomBar from 'components/bottom-bar/BottomBar'
 import { getPathname } from 'utils/route'
 import { useIsDarkMode, useIsMatrix } from 'utils/theme/theme'
-const { FEED_PAGE, TRENDING_PAGE, EXPLORE_PAGE, profilePage, LIBRARY_PAGE } =
-  route
+const {
+  FEED_PAGE,
+  TRENDING_PAGE,
+  EXPLORE_PAGE,
+  LIBRARY_PAGE,
+  NOTIFICATION_PAGE
+} = route
 
 const ConnectedBottomBar = () => {
   const location = useLocation()
@@ -28,17 +33,17 @@ const ConnectedBottomBar = () => {
     })
   })
   const { handle, isGuestAccount } = accountData ?? {}
-  const userProfilePage = handle ? profilePage(handle) : null
 
   // Memoize navRoutes to avoid recreating Set on every render
-  // Filter out null values to ensure Set stability
   const navRoutes = useMemo(() => {
-    const routes = [TRENDING_PAGE, FEED_PAGE, EXPLORE_PAGE, LIBRARY_PAGE]
-    if (userProfilePage) {
-      routes.push(userProfilePage)
-    }
-    return new Set(routes)
-  }, [userProfilePage])
+    return new Set([
+      TRENDING_PAGE,
+      FEED_PAGE,
+      EXPLORE_PAGE,
+      LIBRARY_PAGE,
+      NOTIFICATION_PAGE
+    ])
+  }, [])
 
   // Use ref to track last nav route synchronously (avoids render loops)
   // This is critical for React Router v7 compatibility where location updates
@@ -97,23 +102,22 @@ const ConnectedBottomBar = () => {
     }
   }, [goToRoute, handle, isGuestAccount, handleOpenSignOn])
 
-  const goToProfile = useCallback(() => {
+  const goToNotifications = useCallback(() => {
     if (!handle) {
       handleOpenSignOn()
     } else {
-      goToRoute(profilePage(handle))
+      goToRoute(NOTIFICATION_PAGE)
     }
   }, [goToRoute, handle, handleOpenSignOn])
 
   return (
     <BottomBar
       currentPage={currentPage}
-      userProfilePageRoute={userProfilePage}
       onClickFeed={goToFeed}
       onClickTrending={goToTrending}
       onClickExplore={goToExplore}
       onClickLibrary={goToLibrary}
-      onClickProfile={goToProfile}
+      onClickNotifications={goToNotifications}
       isDarkMode={isDarkMode}
       isMatrixMode={isMatrixMode}
     />

--- a/packages/web/src/components/nav/mobile/NavBar.tsx
+++ b/packages/web/src/components/nav/mobile/NavBar.tsx
@@ -1,6 +1,9 @@
 import { useState, useContext, useCallback } from 'react'
 
-import { useNotificationUnreadCount } from '@audius/common/api'
+import {
+  useCurrentUserId,
+  useNotificationUnreadCount
+} from '@audius/common/api'
 import { formatCount, route } from '@audius/common/utils'
 import {
   IconAudiusLogoHorizontal,
@@ -19,6 +22,7 @@ import {
   RouterContext,
   SlideDirection
 } from 'components/animated-switch/RouterContextProvider'
+import { Avatar } from 'components/avatar/Avatar'
 import NavContext, {
   LeftPreset,
   CenterPreset,
@@ -57,6 +61,7 @@ const NavBar = ({
 }: NavBarProps) => {
   const { leftElement, centerElement, rightElement } = useContext(NavContext)!
   const { data: notificationCount = 0 } = useNotificationUnreadCount()
+  const { data: currentUserId } = useCurrentUserId()
 
   const { setStackReset } = useContext(RouterContext)
 
@@ -172,14 +177,26 @@ const NavBar = ({
         })}
       >
         {rightElement === RightPreset.KEBAB ? (
-          <Flex mr='s'>
-            <IconButton
-              aria-label='menu'
-              icon={IconKebabHorizontal}
-              color-='subdued'
-              onClick={() => setIsActionDrawerOpen(true)}
-            />
-          </Flex>
+          isSignedIn && currentUserId ? (
+            <Flex mr='s' alignItems='center'>
+              <Avatar
+                userId={currentUserId}
+                onClick={() => setIsActionDrawerOpen(true)}
+                size='small'
+                disableLink
+                aria-label='menu'
+              />
+            </Flex>
+          ) : (
+            <Flex mr='s'>
+              <IconButton
+                aria-label='menu'
+                icon={IconKebabHorizontal}
+                color-='subdued'
+                onClick={() => setIsActionDrawerOpen(true)}
+              />
+            </Flex>
+          )
         ) : (
           rightElement
         )}

--- a/packages/web/src/components/nav/mobile/NavBarActionDrawer.tsx
+++ b/packages/web/src/components/nav/mobile/NavBarActionDrawer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useMemo } from 'react'
 
+import { useCurrentAccountUser } from '@audius/common/api'
 import { CLUBS_EXPLORE_PAGE, WALLET_PAGE } from '@audius/common/src/utils/route'
 import { route } from '@audius/common/utils'
 import { useDispatch } from 'react-redux'
@@ -8,7 +9,7 @@ import ActionDrawer from 'components/action-drawer/ActionDrawer'
 import { RouterContext } from 'components/animated-switch/RouterContextProvider'
 import { push } from 'utils/navigation'
 
-const { SETTINGS_PAGE, REWARDS_PAGE } = route
+const { SETTINGS_PAGE, REWARDS_PAGE, profilePage } = route
 
 type NavBarActionDrawerProps = {
   isOpen: boolean
@@ -16,6 +17,7 @@ type NavBarActionDrawerProps = {
 }
 
 const messages = {
+  profile: 'Profile',
   wallet: 'Wallet',
   rewards: 'Rewards',
   fanClubs: 'Fan Clubs',
@@ -28,6 +30,9 @@ export const NavBarActionDrawer = ({
 }: NavBarActionDrawerProps) => {
   const dispatch = useDispatch()
   const { setStackReset } = useContext(RouterContext)
+  const { data: handle } = useCurrentAccountUser({
+    select: (user) => user?.handle
+  })
 
   const goToRoute = useCallback(
     (route: string) => {
@@ -35,6 +40,12 @@ export const NavBarActionDrawer = ({
     },
     [dispatch]
   )
+
+  const goToProfilePage = useCallback(() => {
+    if (!handle) return
+    setImmediate(() => goToRoute(profilePage(handle)))
+    onClose()
+  }, [goToRoute, onClose, handle])
 
   const goToWalletPage = useCallback(() => {
     setImmediate(() => goToRoute(WALLET_PAGE))
@@ -59,6 +70,14 @@ export const NavBarActionDrawer = ({
 
   const actions = useMemo(
     () => [
+      ...(handle
+        ? [
+            {
+              text: messages.profile,
+              onClick: goToProfilePage
+            }
+          ]
+        : []),
       {
         text: messages.wallet,
         onClick: goToWalletPage
@@ -76,7 +95,14 @@ export const NavBarActionDrawer = ({
         onClick: goToSettingsPage
       }
     ],
-    [goToRewardsPage, goToSettingsPage, goToWalletPage, goToFanClubsExplorePage]
+    [
+      handle,
+      goToProfilePage,
+      goToRewardsPage,
+      goToSettingsPage,
+      goToWalletPage,
+      goToFanClubsExplorePage
+    ]
   )
 
   return <ActionDrawer actions={actions} onClose={onClose} isOpen={isOpen} />

--- a/packages/web/src/components/now-playing/NowPlayingDrawer.module.css
+++ b/packages/web/src/components/now-playing/NowPlayingDrawer.module.css
@@ -58,8 +58,16 @@
 
 .bottomBar {
   width: 100%;
+  left: 0;
+  right: 0;
   bottom: 0;
   position: fixed;
+  z-index: 12;
+  /* Promote to its own layer so iOS Safari doesn't
+     reposition the bar during elastic scroll / address bar
+     hide/show. */
+  will-change: transform;
+  background: var(--harmony-n-25);
 }
 
 .skirt {


### PR DESCRIPTION
- Replace Profile tab with Notifications in the bottom tab bar
- Swap heart/favorite icon for Harmony IconLibrary on Library tab
- Show signed-in user's avatar in top-right nav (opens nav action drawer)
- Add Profile entry to nav action drawer (wallet/rewards/settings/etc.)
- Stabilize bottom bar at viewport bottom by removing redundant nested
  position:fixed and adding will-change/z-index on the wrapper

https://claude.ai/code/session_01VDS3E1ti7hbcxC4h4fxG7W