### PR TITLE
Fix SelectablePill theme reactivity by using color values in deps

### DIFF
--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -46,13 +46,7 @@ export const SelectablePill = (props: SelectablePillProps) => {
   const isIconOnly = !('label' in props) && !!Icon
   const displayLabel = label
   const a11yLabel = ariaLabel ?? accessibilityLabelProp
-  const {
-    color,
-    motion,
-    cornerRadius,
-    typography,
-    type: themeType
-  } = useTheme()
+  const { color, motion, cornerRadius, typography } = useTheme()
   const [isPressing, setIsPressing] = useState(false)
   const [isSelected, setIsSelected] = useControlled({
     controlledProp: isSelectedProp,
@@ -123,12 +117,6 @@ export const SelectablePill = (props: SelectablePillProps) => {
     disableUnselectAnimation
   ])
 
-  // Force animated styles to re-evaluate when theme changes
-  // by re-setting the selected shared value with the current state
-  useEffect(() => {
-    selected.value = isSelected ? 1 : 0
-  }, [themeType, selected, isSelected])
-
   const animatedRootStyles = useAnimatedStyle(
     () => ({
       opacity: withTiming(disabled ? 0.45 : 1, motion.press),
@@ -144,7 +132,12 @@ export const SelectablePill = (props: SelectablePillProps) => {
       ),
       transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.95]) }]
     }),
-    [disabled, themeType]
+    [
+      disabled,
+      color.background.white,
+      color.secondary.s400,
+      color.border.strong
+    ]
   )
 
   const animatedTextStyles = useAnimatedStyle(
@@ -155,7 +148,7 @@ export const SelectablePill = (props: SelectablePillProps) => {
         [color.text.default, color.static.white]
       )
     }),
-    [themeType]
+    [color.text.default, color.static.white]
   )
 
   return (


### PR DESCRIPTION
## Summary
Refactored the SelectablePill component to properly track theme changes through color value dependencies instead of relying on a theme type change effect.

## Key Changes
- Removed `themeType` from the `useTheme()` destructuring as it's no longer needed
- Deleted the `useEffect` hook that was force-resetting the selected shared value when theme changed
- Updated `animatedRootStyles` dependency array to include specific color values (`color.background.white`, `color.secondary.s400`, `color.border.strong`) instead of `themeType`
- Updated `animatedTextStyles` dependency array to include specific color values (`color.text.default`, `color.static.white`) instead of `themeType`

## Implementation Details
This change improves the reactivity pattern by making animated styles re-evaluate when the actual color values they depend on change, rather than using a theme type proxy. This is a more direct and maintainable approach that:
- Eliminates the need for a separate effect to manually reset animation state
- Makes dependencies explicit and tied to the actual values used in the animations
- Ensures animations properly respond to theme changes through the dependency array mechanism

https://claude.ai/code/session_01BRsrYnrSeWVqe6zJtV6uzi