### PR TITLE
fix: Feature flag isLoaded respects local override read

### DIFF
--- a/packages/common/src/hooks/useFeatureFlag.ts
+++ b/packages/common/src/hooks/useFeatureFlag.ts
@@ -93,24 +93,31 @@ export const createUseFeatureFlagHook =
     )
 
     const [isLocallyEnabled, setIsLocallyOverriden] = useState<Maybe<boolean>>()
+    const [hasReadOverride, setHasReadOverride] = useState(
+      () => getLocalStorageItem == null
+    )
 
     useEffectOnce(() => {
-      const getOverride = async () => {
-        const override = await getLocalStorageItem?.(overrideKey)
-        if (override === 'enabled') {
-          setIsLocallyOverriden(true)
-        }
-        if (override === 'disabled') {
-          setIsLocallyOverriden(false)
-        }
-
-        return undefined
+      if (!getLocalStorageItem) {
+        return
       }
-      getOverride()
+      const getOverride = async () => {
+        try {
+          const override = await getLocalStorageItem(overrideKey)
+          if (override === 'enabled') {
+            setIsLocallyOverriden(true)
+          } else if (override === 'disabled') {
+            setIsLocallyOverriden(false)
+          }
+        } finally {
+          setHasReadOverride(true)
+        }
+      }
+      void getOverride()
     })
 
     return {
-      isLoaded: configLoaded,
+      isLoaded: configLoaded && hasReadOverride,
       isEnabled: isLocallyEnabled ?? isEnabled,
       setOverride
     }
@@ -143,21 +150,26 @@ export const useFeatureFlag = (
   )
 
   const [isLocallyEnabled, setIsLocallyOverriden] = useState<Maybe<boolean>>()
+  const [hasReadOverride, setHasReadOverride] = useState(false)
 
   useEffectOnce(() => {
     const getOverride = async () => {
-      const override = await localStorage.getItem(overrideKey)
-      if (override === 'enabled') {
-        setIsLocallyOverriden(true)
-      } else if (override === 'disabled') {
-        setIsLocallyOverriden(false)
+      try {
+        const override = await localStorage.getItem(overrideKey)
+        if (override === 'enabled') {
+          setIsLocallyOverriden(true)
+        } else if (override === 'disabled') {
+          setIsLocallyOverriden(false)
+        }
+      } finally {
+        setHasReadOverride(true)
       }
     }
-    getOverride()
+    void getOverride()
   })
 
   return {
-    isLoaded: configLoaded,
+    isLoaded: configLoaded && hasReadOverride,
     isEnabled: isLocallyEnabled ?? isEnabled,
     setOverride
   }

--- a/packages/web/src/pages/contest-page/ContestPage.test.tsx
+++ b/packages/web/src/pages/contest-page/ContestPage.test.tsx
@@ -4,7 +4,7 @@ import { FeatureFlags } from '@audius/common/services'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { describe, expect, vi, beforeEach } from 'vitest'
 
-import { render, screen, it } from 'test/test-utils'
+import { render, screen, it, waitFor } from 'test/test-utils'
 
 // Import the page AFTER all the mocks are registered.
 import ContestPage from './ContestPage'
@@ -273,15 +273,19 @@ describe('ContestPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('redirects home when the CONTESTS feature flag is OFF', () => {
+  it('redirects home when the CONTESTS feature flag is OFF', async () => {
     // Matches the ContestsPage (discovery) behaviour: once the flag is
     // loaded and disabled, <Navigate to='/' replace /> kicks in so the
     // contest URL is never reachable in a gated rollout.
     renderContestPage({ featureFlags: { [FeatureFlags.CONTESTS]: false } })
 
+    // `useFeatureFlag` sets isLoaded only after the async localStorage
+    // override read finishes, so the redirect is not synchronous.
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    })
     // The placeholder element on the '/' route should be visible;
     // none of the ContestPage sections should render.
-    expect(screen.getByTestId('home-page')).toBeInTheDocument()
     expect(screen.queryByTestId('details-tab')).not.toBeInTheDocument()
     expect(screen.queryByTestId('prizes-tab')).not.toBeInTheDocument()
     expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`useFeatureFlag` marked `isLoaded` true as soon as remote config finished loading, but the local `FeatureFlagOverride:*` value from `localStorage` is read asynchronously. On a fast first paint, pages such as `ContestsPage` saw `isLoaded && !isEnabled` (remote off) and redirected home before the override was applied.

`isLoaded` is now `configLoaded && hasReadOverride`, where `hasReadOverride` flips to true after the async override read completes (or immediately when no localStorage getter exists in the factory hook).

## Test updates
`ContestPage` redirect test now `waitFor` the home route: the redirect runs after the async localStorage read completes, not on the first synchronous paint.

## Testing
- Not run in this environment (missing local vitest/vite deps in PATH).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33313d53-2212-41b5-9dc8-5e07aab64652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33313d53-2212-41b5-9dc8-5e07aab64652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

