### PR TITLE
Fix missing USDC splits on track edit

### DIFF
--- a/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
@@ -18,6 +18,7 @@ import { TrackMetadataForUpload } from '~/store/upload'
 
 import { TQTrack } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
+import { addPremiumMetadata } from '../upload/usePublishTracks'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { handleStemUpdates } from '../utils/handleStemUpdates'
 import { primeTrackData } from '../utils/primeTrackData'
@@ -58,9 +59,14 @@ export const useUpdateTrack = () => {
       const previousMetadata = queryClient.getQueryData(
         getTrackQueryKey(trackId)
       )
-      const sdkMetadata = trackMetadataForUploadToSdk(
+      if (!userId) {
+        throw new Error('useUpdateTrack: missing current userId')
+      }
+      const metadataWithSplits = addPremiumMetadata(
+        userId,
         metadata as TrackMetadataForUpload
       )
+      const sdkMetadata = trackMetadataForUploadToSdk(metadataWithSplits)
 
       const response = await sdk.tracks.updateTrack({
         audioFile,


### PR DESCRIPTION
## Summary
- Editing a track to turn on USDC-gated downloads (or stream) was failing indexing with `Track {id} usdc_purchase does not contain splits`.
- Root cause: `useUpdateTrack` (tan-query) sent form metadata straight to the SDK without running `addPremiumMetadata`, so the payload had `usdc_purchase: { price }` with no splits. `accessConditionsToSDK` then shipped an empty splits array, and `validate_access_conditions` in discovery rejected it. Indexing's `convert_legacy_purchase_access_gate` only reshapes existing splits — it does not synthesize them.
- Fix mirrors the upload path (`usePublishTracks`): call `addPremiumMetadata(userId, metadata)` before `trackMetadataForUploadToSdk`, which fills in `splits: [{ user_id, percentage: 100 }]` for the owner.
- Affects both web `EditTrackPage` and mobile edit screens, which share this hook. The legacy redux-saga edit path already did this via `addPremiumMetadata` in `sagaHelpers`, which is why edits through the old flow worked.

## Test plan
- [ ] Edit an existing track and toggle downloads to premium at $1 → save succeeds and indexes
- [ ] Edit an existing track and toggle stream to premium at $1 → save succeeds and indexes
- [ ] Edit a non-gated field on an already-gated track → splits remain intact, no regression
- [ ] Mobile: same three scenarios via `EditTrackModalScreen` / `EditTrackForm`
- [ ] Verify track price history row is written with the expected owner split

🤖 Generated with [Claude Code](https://claude.com/claude-code)