### PR TITLE
Re-enable contests feature (mobile only)

### DIFF
--- a/packages/common/src/hooks/useFeatureFlag.ts
+++ b/packages/common/src/hooks/useFeatureFlag.ts
@@ -116,8 +116,11 @@ export const createUseFeatureFlagHook =
       getOverride().catch(() => {})
     })
 
-    // Hard-code overrides — see `HARDCODED_ENABLED_FLAGS` below.
-    if (HARDCODED_ENABLED_FLAGS[flag]) {
+    // Hard-code overrides, mobile only — see `HARDCODED_ENABLED_FLAGS` below.
+    if (
+      HARDCODED_ENABLED_FLAGS[flag] &&
+      remoteConfigInstance.getPlatform() === 'mobile'
+    ) {
       return {
         isLoaded: true,
         isEnabled: true,
@@ -133,8 +136,9 @@ export const createUseFeatureFlagHook =
   }
 
 /**
- * Optional flags that are hard-coded to enabled (Optimizely, env defaults, and
- * local overrides are skipped). Add entries only for short-lived release
+ * Mobile-only flags that are hard-coded to enabled (Optimizely, env defaults,
+ * and local overrides are skipped on native). Web/desktop continue to honor
+ * Optimizely and env defaults. Add entries only for short-lived release
  * toggles; remove when remote config is updated.
  */
 const HARDCODED_ENABLED_FLAGS: Partial<Record<FeatureFlags, true>> = {
@@ -186,7 +190,10 @@ export const useFeatureFlag = (
     getOverride().catch(() => {})
   })
 
-  if (HARDCODED_ENABLED_FLAGS[flag]) {
+  if (
+    HARDCODED_ENABLED_FLAGS[flag] &&
+    remoteConfig.getPlatform() === 'mobile'
+  ) {
     return {
       isLoaded: true,
       isEnabled: true,

--- a/packages/common/src/hooks/useFeatureFlag.ts
+++ b/packages/common/src/hooks/useFeatureFlag.ts
@@ -137,7 +137,9 @@ export const createUseFeatureFlagHook =
  * local overrides are skipped). Add entries only for short-lived release
  * toggles; remove when remote config is updated.
  */
-const HARDCODED_ENABLED_FLAGS: Partial<Record<FeatureFlags, true>> = {}
+const HARDCODED_ENABLED_FLAGS: Partial<Record<FeatureFlags, true>> = {
+  [FeatureFlags.CONTESTS]: true
+}
 
 /** Fetches enabled status of a given feature flag with fallback. Result is memoized. */
 export const useFeatureFlag = (

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -26,12 +26,9 @@ export const environmentFlagDefaults: Record<
   Partial<FlagDefaults>
 > = {
   development: {
-    [FeatureFlags.FAN_CLUB_TEXT_POST_POSTING]: true,
-    [FeatureFlags.CONTESTS]: true
+    [FeatureFlags.FAN_CLUB_TEXT_POST_POSTING]: true
   },
-  production: {
-    [FeatureFlags.CONTESTS]: true
-  }
+  production: {}
 }
 
 /**
@@ -52,5 +49,5 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.COLLAPSED_EXPLORE_HEADER]: false,
   [FeatureFlags.LAUNCHPAD_VERIFICATION]: true,
   [FeatureFlags.FAN_CLUB_TEXT_POST_POSTING]: false,
-  [FeatureFlags.CONTESTS]: true
+  [FeatureFlags.CONTESTS]: false
 }

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -26,9 +26,12 @@ export const environmentFlagDefaults: Record<
   Partial<FlagDefaults>
 > = {
   development: {
-    [FeatureFlags.FAN_CLUB_TEXT_POST_POSTING]: true
+    [FeatureFlags.FAN_CLUB_TEXT_POST_POSTING]: true,
+    [FeatureFlags.CONTESTS]: true
   },
-  production: {}
+  production: {
+    [FeatureFlags.CONTESTS]: true
+  }
 }
 
 /**
@@ -49,5 +52,5 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.COLLAPSED_EXPLORE_HEADER]: false,
   [FeatureFlags.LAUNCHPAD_VERIFICATION]: true,
   [FeatureFlags.FAN_CLUB_TEXT_POST_POSTING]: false,
-  [FeatureFlags.CONTESTS]: false
+  [FeatureFlags.CONTESTS]: true
 }

--- a/packages/common/src/services/remote-config/remote-config.ts
+++ b/packages/common/src/services/remote-config/remote-config.ts
@@ -315,6 +315,7 @@ export const remoteConfig = <
   return {
     getFeatureEnabled,
     getRemoteVar,
+    getPlatform: () => platform,
     init,
     setUserId,
     waitForRemoteConfig,

--- a/packages/web/src/test/mocks/remote-config.ts
+++ b/packages/web/src/test/mocks/remote-config.ts
@@ -8,6 +8,7 @@ export const createMockRemoteConfig = (
       featureFlags[flag] ?? featureFlags[fallbackFlag as FeatureFlags] ?? false
     )
   },
+  getPlatform: () => 'web' as const,
   getRemoteVar: () => null,
   waitForRemoteConfig: async () => {},
   waitForUserRemoteConfig: async () => {},


### PR DESCRIPTION
## Summary
- Forces `FeatureFlags.CONTESTS` on for native mobile only; web and desktop continue to honor Optimizely and env defaults
- Exposes `getPlatform()` from the remote-config factory so hooks can check the running platform
- Gates `HARDCODED_ENABLED_FLAGS` on `platform === 'mobile'` in both `useFeatureFlag` and the deprecated `createUseFeatureFlagHook` factory
- Restores `environmentFlagDefaults` and `flagDefaults` for CONTESTS to their pre-hardcode state

This re-enables the contests nav item, contest pages, the remix-contest track section, and the featured-remix-contests section — but only on the native mobile app.

## Test plan
- [ ] Verify Contests nav item renders in the native mobile drawer
- [ ] Verify contest detail screen loads on native mobile
- [ ] Verify remix-contest section renders on the native track screen
- [ ] Verify Featured Remix Contests renders on the native explore screen
- [ ] Verify web (desktop + mobile web) does **not** show contests unless Optimizely enables it
- [ ] Verify desktop app does **not** show contests unless Optimizely enables it

https://claude.ai/code/session_01HAgF5nRqz7oFS1m2oeFKjm