### PR TITLE
Remove prizes available pill from mobile contest card

### DIFF
--- a/.changeset/remove-contest-card-prizes-pill.md
+++ b/.changeset/remove-contest-card-prizes-pill.md
@@ -1,0 +1,5 @@
+---
+"@audius/mobile": patch
+---
+
+Remove the "PRIZES AVAILABLE" pill from contest cards on the explore surface. Prize details are still available on the dedicated contest page.

--- a/packages/mobile/src/components/contest-card/ContestCard.tsx
+++ b/packages/mobile/src/components/contest-card/ContestCard.tsx
@@ -40,8 +40,7 @@ const messages = {
   endsToday: 'ENDS TODAY',
   ended: 'ENDED',
   daysLeft: (n: number) => `${n} ${n === 1 ? 'DAY' : 'DAYS'} LEFT`,
-  entries: (n: number) => `${n} ${n === 1 ? 'ENTRY' : 'ENTRIES'}`,
-  prizesAvailable: 'PRIZES AVAILABLE'
+  entries: (n: number) => `${n} ${n === 1 ? 'ENTRY' : 'ENTRIES'}`
 }
 
 const formatStatus = (endDate?: string | null): string => {
@@ -276,7 +275,6 @@ export const ContestCard = (props: ContestCardProps) => {
     return null
   }
 
-  const prizeInfo = remixContest.eventData?.prizeInfo
   const status = formatStatus(remixContest.endDate)
 
   return (
@@ -325,7 +323,6 @@ export const ContestCard = (props: ContestCardProps) => {
             contentContainerStyle={{ gap: 8, flexDirection: 'row' }}
           >
             <Pill label={messages.entries(entriesCount)} />
-            {prizeInfo ? <Pill label={messages.prizesAvailable} /> : null}
           </ScrollView>
         </Flex>
       </Flex>


### PR DESCRIPTION
## Summary
- Removes the "PRIZES AVAILABLE" pill from the mobile contest card on the contest explore surface.
- Web (including web-mobile) already doesn't render this pill, so this brings mobile in line.
- Drops the now-unused `prizesAvailable` message and `prizeInfo` local.

## Test plan
- [ ] Open the Explore / Contests screen in the mobile app and confirm contest cards only render the "ENTRIES" pill (no "PRIZES AVAILABLE" pill), for contests both with and without `eventData.prizeInfo`.
- [ ] Confirm prize details still appear on the dedicated contest page (Prizes tab) — only the explore-card pill was removed.
- [ ] `npm run verify` passes.

https://claude.ai/code/session_019JFysVYX7NDfysH4ZtJUPY

---
_Generated by [Claude Code](https://claude.ai/code/session_019JFysVYX7NDfysH4ZtJUPY)_