### PR TITLE
Fix mobile swipe-back regression after left-drawer gate

### DIFF
--- a/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
@@ -64,21 +64,19 @@ export const AppDrawerScreen = memo(() => {
     setIsAtStackRootState((prev) => (prev === next ? prev : next))
   }, [])
 
-  const canSwipeDrawer =
-    isAtStackRoot && !gesturesDisabled && !isNowPlayingDrawerOpen
-
+  // Shrink the drawer's swipe area to zero (instead of disabling the gesture
+  // handler) so the native stack's fullScreenGestureEnabled back gesture keeps
+  // responding across the whole screen; fully disabling the drawer's
+  // PanGestureHandler narrows swipe-back to the left edge.
   const drawerScreenOptions = useMemo(
     () => ({
       headerShown: false,
-      swipeEdgeWidth: SCREEN_WIDTH,
+      swipeEdgeWidth: isAtStackRoot ? SCREEN_WIDTH : 0,
       drawerType: 'slide' as const,
       drawerStyle: { width: '75%' as const },
-      swipeEnabled: canSwipeDrawer,
-      gestureHandlerProps: {
-        enabled: canSwipeDrawer
-      }
+      swipeEnabled: !gesturesDisabled && !isNowPlayingDrawerOpen
     }),
-    [canSwipeDrawer]
+    [isAtStackRoot, gesturesDisabled, isNowPlayingDrawerOpen]
   )
 
   // Close the left nav drawer if it's open when the now-playing drawer opens

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -19,10 +19,10 @@ import type {
 import type { EventArg, NavigationState } from '@react-navigation/native'
 import { useIsFocused } from '@react-navigation/native'
 import type { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { Dimensions } from 'react-native'
 
 import { FilterButtonScreen } from '@audius/harmony-native'
 import type { FilterButtonScreenParams } from '@audius/harmony-native'
-import { useDrawer } from 'app/hooks/useDrawer'
 import { setLastNavAction } from 'app/hooks/useNavigation'
 import { AppDrawerContext } from 'app/screens/app-drawer-screen'
 import { AudioScreen } from 'app/screens/audio-screen'
@@ -71,6 +71,8 @@ import { FanClubSortScreen } from '../fan-club-sort-screen/FanClubSortScreen'
 import { FanClubsExploreScreen } from '../fan-clubs-explore-screen/FanClubsExploreScreen'
 
 import { useAppScreenOptions } from './useAppScreenOptions'
+
+const SCREEN_WIDTH = Dimensions.get('window').width
 
 export type AppTabScreenParamList = {
   Track: {
@@ -181,20 +183,22 @@ type AppTabScreenProps = {
 export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
   const screenOptions = useAppScreenOptions()
   const { drawerNavigation, setIsAtStackRoot } = useContext(AppDrawerContext)
-  const { isOpen: isNowPlayingDrawerOpen } = useDrawer('NowPlaying')
   const isFocused = useIsFocused()
   const isAtStackRootRef = useRef(true)
 
-  // NowPlayingDrawer calls setOptions({swipeEnabled: false}) imperatively, and
-  // imperative options beat screenOptions, so we must also re-apply imperatively.
+  // NowPlayingDrawer calls setOptions imperatively, and imperative options beat
+  // screenOptions, so we must also re-apply imperatively. We gate on
+  // swipeEdgeWidth rather than swipeEnabled to keep the drawer's
+  // PanGestureHandler registered — fully disabling it narrows the native
+  // stack's fullScreenGesture back-swipe to the left edge.
   const applyDrawerSwipe = useCallback(
     (isAtRoot: boolean) => {
       setIsAtStackRoot?.(isAtRoot)
       drawerNavigation?.setOptions({
-        swipeEnabled: isAtRoot && !isNowPlayingDrawerOpen
+        swipeEdgeWidth: isAtRoot ? SCREEN_WIDTH : 0
       })
     },
-    [drawerNavigation, isNowPlayingDrawerOpen, setIsAtStackRoot]
+    [drawerNavigation, setIsAtStackRoot]
   )
 
   const handleChangeState = useCallback(


### PR DESCRIPTION
## Summary
- Fixes a regression from #14139 where swipe-back only worked from the very left edge of the screen inside tab stacks (previously it worked from anywhere via the native stack's `fullScreenGestureEnabled`).
- Keep the drawer's `PanGestureHandler` registered and shrink its swipe area to zero via `swipeEdgeWidth: 0` instead of fully disabling the handler. `swipeEdgeWidth` maps to the handler's `hitSlop` width, so width 0 prevents the drawer from opening while leaving the native stack's iOS full-screen back gesture free to respond across the whole screen.

## Why the previous fix regressed back-swipe
#14139 set both `swipeEnabled: false` and `gestureHandlerProps.enabled: false` on the drawer whenever the user was inside a tab stack. That stopped the drawer from inadvertently opening, but empirically it also narrowed the native stack's full-screen back gesture to the default ~50px left-edge responder — users could no longer start the swipe from the middle of the screen.

## What changed
- `AppDrawerScreen.tsx`: `swipeEdgeWidth` is now `isAtStackRoot ? SCREEN_WIDTH : 0`. `swipeEnabled` reverts to `!gesturesDisabled && !isNowPlayingDrawerOpen` (unconditional on stack depth). `gestureHandlerProps` is removed so the internal `enabled` isn't overridden.
- `AppTabScreen.tsx`: imperative `setOptions` now toggles `swipeEdgeWidth` instead of `swipeEnabled`, beating `NowPlayingDrawer`'s imperative writes the same way as before. Dropped the now-unused `useDrawer('NowPlaying')` subscription.

## Test plan
- [ ] iOS: from a nested screen (e.g. Feed → Track), swipe right starting from the middle of the screen → navigates back.
- [ ] iOS: from a nested screen, swipe right starting from the left edge → navigates back, left nav does NOT open.
- [ ] iOS: at a tab root (e.g. Feed top), swipe right from anywhere → left nav opens.
- [ ] iOS: with NowPlaying open, left nav remains non-swipeable; closing NowPlaying restores the expected root/non-root behavior.
- [ ] Android: swipe-back behavior unchanged (Android native-stack gesture is always left-edge).
- [ ] Tab switching: navigate deep into tab A, switch to tab B at root, back to tab A — swipe-back still works from anywhere.

https://claude.ai/code/session_013k2DmKvuGrQARuTPpnU367

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKLCKcqykjnsiKAnmvEzxp)_