### PR TITLE
Fix contest header stuck on light backdrop after theme change

### DIFF
--- a/.changeset/fix-contest-header-theme.md
+++ b/.changeset/fix-contest-header-theme.md
@@ -1,0 +1,5 @@
+---
+"@audius/mobile": patch
+---
+
+Fix mobile contest detail header backdrop staying on the light theme after the system/app theme flips. The title, submissions-due block, countdown, and hosted-by row now re-theme alongside the rest of the screen.

--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -295,8 +295,15 @@ export const ContestScreen = () => {
   // UserLink, ContestHero's back button) still capture their own
   // taps because they're explicit touch targets — only empty space
   // becomes scroll-transparent.
+  // Theme-aware `backgroundColor='white'` on the outermost wrapper so
+  // the header reacts when the app theme flips (e.g. system light→dark).
+  // Without it, `Tabs.Container`'s internal `topContainer` style
+  // hardcodes `backgroundColor: 'white'` (literal) behind the header,
+  // leaving the title / submissions-due / hosted-by block stuck on a
+  // white backdrop after a theme change. Same pattern `ProfileHeader`
+  // uses to cover the library default.
   const renderHeader = () => (
-    <View pointerEvents='box-none'>
+    <Flex backgroundColor='white' pointerEvents='box-none'>
       {/* Scroll bridge — lives inside the collapsible header so
           `useCurrentTabScrollY` resolves to the current tab's scroll
           value. It writes the scroll value into the outer
@@ -409,7 +416,7 @@ export const ContestScreen = () => {
             of running directly into the host's name. */}
         <Divider />
       </Flex>
-    </View>
+    </Flex>
   )
 
   const contextValue = {


### PR DESCRIPTION
## Summary
- On the native contest detail screen, the title / `SUBMISSIONS DUE` / countdown / `HOSTED BY` block kept rendering on a white backdrop after the system theme flipped from light to dark, while the rest of the screen (tab bar, tab content, bottom nav) followed the theme.
- Root cause: `react-native-collapsible-tab-view`'s `topContainer` hardcodes `backgroundColor: 'white'` (literal) behind the rendered header. The contest `renderHeader` used a plain `<View>` with no background, so that literal white showed through. Text colors inside the header re-rendered correctly via Emotion's `useTheme()`, which is why only the backdrop looked stuck.
- Fix: wrap the contest `renderHeader` content in a Harmony `<Flex backgroundColor='white' …>` so the backdrop uses the semantic `white` token and reacts to theme changes — same pattern `ProfileHeader` already uses to cover the library default.

## Test plan
- [ ] Open a contest detail page on iOS and Android.
- [ ] With the app set to follow system theme, toggle system light ↔ dark and confirm the title, submissions-due block, countdown, and hosted-by row backdrop switch themes along with the rest of the screen.
- [ ] Toggle the in-app theme setting (Light / Dark / Matrix) while a contest screen is open and confirm the header follows.
- [ ] Scroll the contest screen and confirm the collapsing header still animates and the floating nav overlay still behaves correctly.

https://claude.ai/code/session_01YDvZK1zynmiAkA1srJmNwG

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDvZK1zynmiAkA1srJmNwG)_