### PR TITLE
Fix SelectablePill theme adaptation by nudging shared value

### DIFF
--- a/.changeset/fix-selectable-pill-theme-adaptation.md
+++ b/.changeset/fix-selectable-pill-theme-adaptation.md
@@ -1,0 +1,5 @@
+---
+'@audius/mobile': patch
+---
+
+Fix SelectablePill components (e.g., the Trending category pills) not adapting to system theme changes until the next interaction.

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -117,6 +117,26 @@ export const SelectablePill = (props: SelectablePillProps) => {
     disableUnselectAnimation
   ])
 
+  // Force animated styles to repaint with the new theme colors when the
+  // theme changes. Updating the dependency arrays below refreshes the
+  // worklet closures, but Reanimated only re-renders the view when a
+  // shared value it reads actually changes. Nudging `selected` here
+  // triggers that re-render so the interpolated colors pick up the new
+  // theme values instead of staying cached on the previous palette.
+  useEffect(() => {
+    const target = isSelected ? 1 : 0
+    selected.value = 1 - target
+    selected.value = target
+  }, [
+    color.background.white,
+    color.secondary.s400,
+    color.border.strong,
+    color.text.default,
+    color.static.white,
+    selected,
+    isSelected
+  ])
+
   const animatedRootStyles = useAnimatedStyle(
     () => ({
       opacity: withTiming(disabled ? 0.45 : 1, motion.press),


### PR DESCRIPTION
## Summary

The Trending screen's category pills (Tracks / Underground / Winners) still weren't adapting when the system theme flipped, despite prior attempts. This fixes it.

## Why the previous fix didn't stick

PR #14145 swapped the `useAnimatedStyle` dependency arrays from `[themeType]` to individual color values and removed the `useEffect` that had been force-resetting the `selected` shared value on theme change.

That refactor refreshes the worklet closure with new colors when deps change, but **Reanimated only repaints the view when a shared value read by the worklet actually changes**. Theme changes don't touch `selected` or `pressed`, so the interpolated background/border/text colors stayed cached on the previous palette until the next interaction.

## Fix

Re-introduce a targeted effect that nudges the `selected` shared value whenever any of the theme color tokens used in the animated styles change. Writing the opposite value then the current value forces Reanimated to re-run the (already-updated) worklet and repaint with the new theme colors. No visible flash, since both writes happen synchronously before the next frame.

## Test plan

- [ ] Open Trending (Tracks / Underground / Winners pills visible)
- [ ] Toggle system theme from light to dark (or vice versa) with the app in foreground
- [ ] Confirm unselected pills switch to the dark-mode background/border (not stuck white) and text color adapts
- [ ] Confirm selected (purple) pill still looks correct in both themes
- [ ] Tap between pills and confirm the selection color transition still animates smoothly
- [ ] Repeat on both iOS and Android

https://claude.ai/code/session_01UP7cLv1aKVDSgZ8hXAkpKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UP7cLv1aKVDSgZ8hXAkpKd)_