### PR TITLE
Fix profile/contest scroll banner dark mode

### DIFF
--- a/.changeset/fix-mobile-scroll-banner-dark-mode.md
+++ b/.changeset/fix-mobile-scroll-banner-dark-mode.md
@@ -1,0 +1,5 @@
+---
+'@audius/mobile': patch
+---
+
+Fix the blurred nav overlay that fades in when scrolling the profile and contest screens not adapting to dark mode. The banner now uses a dark blur in dark themes (matching the rest of the page), and the phone's status bar icons switch to light content so they stay readable against the dark blur.

--- a/packages/mobile/src/screens/contest-screen/ContestNavOverlay.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestNavOverlay.tsx
@@ -17,6 +17,7 @@ import {
 } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
+import { isDarkTheme, useThemeVariant } from 'app/utils/theme'
 
 import { useContestScrollY } from './ContestScrollContext'
 
@@ -95,6 +96,7 @@ export const ContestNavOverlay = ({
   const insets = useSafeAreaInsets()
   const navigation = useNavigation()
   const scrollY = useContestScrollY()
+  const isDarkMode = isDarkTheme(useThemeVariant())
 
   const overlayHeight = insets.top + CONTEST_NAV_CONTROLS_HEIGHT
 
@@ -144,7 +146,7 @@ export const ContestNavOverlay = ({
       style={[styles.root, { height: overlayHeight }]}
     >
       <AnimatedBlurView
-        blurType='light'
+        blurType={isDarkMode ? 'dark' : 'light'}
         blurAmount={20}
         style={[styles.blurBackground, blurBackgroundStyle]}
       />

--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -52,6 +52,7 @@ import { ContestCommentsTab } from './tabs/ContestCommentsTab'
 import { ContestDetailsTab } from './tabs/ContestDetailsTab'
 import { ContestSubmissionsTab } from './tabs/ContestSubmissionsTab'
 import { ContestUpdatesTab } from './tabs/ContestUpdatesTab'
+import { useContestScrollStatusBar } from './useContestScrollStatusBar'
 
 const messages = {
   title: 'Remix Contest',
@@ -171,6 +172,7 @@ export const ContestScreen = () => {
   // floating nav bar's blur background + icon colors fade in as the
   // hero scrolls out of view — same pattern `ProfileScreen` uses.
   const scrollY = useSharedValue(0)
+  useContestScrollStatusBar(scrollY)
 
   // Updates tab visibility — for non-hosts, hide the tab until
   // there's at least one host-authored top-level post (a "post

--- a/packages/mobile/src/screens/contest-screen/useContestScrollStatusBar.ts
+++ b/packages/mobile/src/screens/contest-screen/useContestScrollStatusBar.ts
@@ -8,15 +8,16 @@ import { runOnJS, useAnimatedReaction } from 'react-native-reanimated'
 
 import { isDarkTheme, useThemeVariant } from 'app/utils/theme'
 
-import { PROFILE_NAV_SCROLL_FADE_PX } from './ProfileNavOverlay'
+import { CONTEST_NAV_SCROLL_FADE_PX } from './ContestNavOverlay'
 
 /**
- * Status bar / nav bar style for profile: light icons over the cover at the
- * top, then switch to icons that contrast with the blurred nav bar surface
- * once the header has scrolled up — dark icons on the light-blur surface in
- * light mode, light icons on the dark-blur surface in dark mode.
+ * Status bar / nav bar style for the contest screen: light icons over the
+ * hero cover at the top, then switch to icons that contrast with the
+ * blurred `ContestNavOverlay` surface once the hero has scrolled up — dark
+ * icons on the light-blur surface in light mode, light icons on the
+ * dark-blur surface in dark mode. Mirrors `useProfileScrollStatusBar`.
  */
-export const useProfileScrollStatusBar = (scrollY: SharedValue<number>) => {
+export const useContestScrollStatusBar = (scrollY: SharedValue<number>) => {
   const statusBarEntryRef = useRef<StatusBarProps | null>(null)
   const navigationBarEntryRef = useRef<StatusBarProps | null>(null)
   const lastBarStyleRef = useRef<'light-content' | 'dark-content' | null>(null)
@@ -59,7 +60,7 @@ export const useProfileScrollStatusBar = (scrollY: SharedValue<number>) => {
       // Align with restored scroll position (reaction only fires on change).
       requestAnimationFrame(() => {
         const barStyle =
-          scrollY.value < PROFILE_NAV_SCROLL_FADE_PX
+          scrollY.value < CONTEST_NAV_SCROLL_FADE_PX
             ? 'light-content'
             : scrolledBarStyle
         applyBarStyle(barStyle)
@@ -82,10 +83,10 @@ export const useProfileScrollStatusBar = (scrollY: SharedValue<number>) => {
   useAnimatedReaction(
     () => scrollY.value,
     (y, prev) => {
-      const atTop = y < PROFILE_NAV_SCROLL_FADE_PX
+      const atTop = y < CONTEST_NAV_SCROLL_FADE_PX
       const barStyle = atTop ? 'light-content' : scrolledBarStyle
       const prevY = prev ?? 0
-      const prevAtTop = prevY < PROFILE_NAV_SCROLL_FADE_PX
+      const prevAtTop = prevY < CONTEST_NAV_SCROLL_FADE_PX
       if (atTop !== prevAtTop) {
         runOnJS(applyBarStyle)(barStyle)
       }
@@ -97,7 +98,7 @@ export const useProfileScrollStatusBar = (scrollY: SharedValue<number>) => {
   // otherwise the status bar stays on the previous mode's content style
   // until the user scrolls across the fade threshold again.
   useEffect(() => {
-    if (scrollY.value < PROFILE_NAV_SCROLL_FADE_PX) return
+    if (scrollY.value < CONTEST_NAV_SCROLL_FADE_PX) return
     applyBarStyle(scrolledBarStyle)
   }, [applyBarStyle, scrolledBarStyle, scrollY])
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileNavOverlay.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileNavOverlay.tsx
@@ -22,6 +22,7 @@ import {
 import { UserLink } from 'app/components/user-link'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
+import { isDarkTheme, useThemeVariant } from 'app/utils/theme'
 
 import { useProfileScrollY } from './ProfileScrollContext'
 
@@ -81,6 +82,7 @@ export const ProfileNavOverlay = () => {
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const scrollY = useProfileScrollY()
+  const isDarkMode = isDarkTheme(useThemeVariant())
 
   const { data: accountId } = useCurrentUserId()
   const { user_id } =
@@ -166,7 +168,7 @@ export const ProfileNavOverlay = () => {
       style={[styles.root, { height: overlayHeight }]}
     >
       <AnimatedBlurView
-        blurType='light'
+        blurType={isDarkMode ? 'dark' : 'light'}
         blurAmount={20}
         style={[styles.blurBackground, blurBackgroundStyle]}
       />


### PR DESCRIPTION
## Summary

- Drive the blurred nav overlay (`ProfileNavOverlay`, `ContestNavOverlay`) from the resolved theme — `blurType='dark'` in dark mode, `'light'` in light mode — instead of being hardcoded to light. In dark mode the banner was rendering a white frosted glass over the dark page.
- Mirror the change in `useProfileScrollScrollBar`: once scrolled past the fade threshold, status bar icons flip to `light-content` in dark mode and `dark-content` in light mode so the phone's time/battery/signal icons stay readable against the blurred banner.
- Add a matching `useContestScrollStatusBar` hook and wire it from `ContestScreen` (previously missing) so the contest screen's status bar adapts the same way as profile's.
- Text in the banner (title / `UserLink`) and `IconButton` (`color='default'`) already read from harmony theme tokens, so they pick up the correct dark-mode color automatically once the blur is theme-aware.

## Test plan

- [ ] Profile screen in **light** mode: scroll down — banner fades in with a light blur, back/share icons turn dark, status bar icons go dark (same as today).
- [ ] Profile screen in **dark** mode: scroll down — banner fades in with a **dark** blur (not white), title + icons read as light, status bar icons are **light** (not invisible dark-on-dark).
- [ ] Contest screen (`/contest/:handle/:slug`) in light mode: same as profile — light blur banner, dark status icons when scrolled.
- [ ] Contest screen in dark mode: dark blur banner, **light** status icons when scrolled.
- [ ] Toggle the theme from Settings while sitting mid-scroll on profile and contest — status bar restyles to the new mode without needing to scroll again.
- [ ] At the top of either screen (over the hero/cover) the status bar is still `light-content` in both themes, since the hero artwork has white-on-image treatment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rk4BZpFHQyp3d4EuDpKAaK)_