### PR TITLE
Hide Enter Contest button once the contest has ended

### DIFF
--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -323,24 +323,27 @@ export const ContestScreen = () => {
         {/* Primary CTA — sits in the scrolling header. Overflow lives
             in the floating `ContestNavOverlay` kebab, matching the
             profile screen pattern (one kebab, always reachable at
-            the top of the screen). */}
-        <Flex
-          direction='row'
-          alignItems='center'
-          gap='s'
-          pointerEvents='box-none'
-        >
-          <Flex flex={1} pointerEvents='box-none'>
-            <Button
-              variant='primary'
-              size='small'
-              onPress={isOwner ? handlePickWinners : handleEnterContest}
-              fullWidth
-            >
-              {isOwner ? messages.pickWinners : messages.enterContest}
-            </Button>
+            the top of the screen). "Enter Contest" is hidden once
+            the contest ends — entering isn't meaningful anymore. */}
+        {isOwner || !isEnded ? (
+          <Flex
+            direction='row'
+            alignItems='center'
+            gap='s'
+            pointerEvents='box-none'
+          >
+            <Flex flex={1} pointerEvents='box-none'>
+              <Button
+                variant='primary'
+                size='small'
+                onPress={isOwner ? handlePickWinners : handleEnterContest}
+                fullWidth
+              >
+                {isOwner ? messages.pickWinners : messages.enterContest}
+              </Button>
+            </Flex>
           </Flex>
-        </Flex>
+        ) : null}
 
         {/* Submissions Due block — pure display; wrap the entire
             label + date + time group in `pointerEvents='none'`. */}

--- a/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
@@ -441,11 +441,11 @@ const ContestPage = ({
     <Button variant='primary' size='small' onClick={handlePickWinners}>
       {messages.pickWinners}
     </Button>
-  ) : (
+  ) : !isEnded ? (
     <Button variant='primary' size='small' onClick={handleEnterContest}>
       {messages.enterContest}
     </Button>
-  )
+  ) : null
 
   // Overflow menu items. Host gets Share only (follow doesn't apply to
   // your own contest); public gets Follow/Unfollow + Share. Wired


### PR DESCRIPTION
## Summary
- Mobile web contest page (`packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx`) no longer renders the "Enter Contest" primary CTA once `isEnded` is true; owners still see "Pick Winners".
- Native mobile contest screen (`packages/mobile/src/screens/contest-screen/ContestScreen.tsx`) wraps the primary CTA in `isOwner || !isEnded`, so the button disappears for non-owner viewers after the deadline while the kebab/share/follow overflow remains reachable.
- Matches the behaviour already implemented on the desktop web contest page, so all three surfaces are now consistent.

## Test plan
- [ ] Mobile web: open a contest page while it is still open and confirm "Enter Contest" shows for non-owners; after the deadline, confirm the button is hidden and the kebab still opens the follow/share menu.
- [ ] Native mobile: same check on the contest screen — "Enter Contest" present before end, hidden after; the floating nav overlay kebab still opens the actions drawer with Follow/Share.
- [ ] Owner view on both surfaces: "Pick Winners" continues to render before and after the contest ends.
- [ ] Desktop web: no change expected (already guarded on `!isEnded`).

## Follow-up
- Figma design updates for the full button set (owner and public, web and mobile) are still pending — the user is going to share the specific layouts from the four Figma frames and a subsequent commit will apply them.

https://claude.ai/code/session_01KKbmJLuTbCPf6zAEZUhV1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKbmJLuTbCPf6zAEZUhV1V)_