### PR TITLE
Smooth out contest explore + detail page loading states

### DIFF
--- a/.changeset/smooth-contest-loading-states.md
+++ b/.changeset/smooth-contest-loading-states.md
@@ -1,0 +1,11 @@
+---
+"@audius/web": patch
+"@audius/mobile": patch
+---
+
+Smooth out the contest explore page and contest detail page loading states:
+
+- Contest explore now paginates via infinite scroll (initial page size 8 web / 6 mobile) so first paint doesn't fan out 25 concurrent cover image requests; tail skeletons render while the next page is fetching.
+- Mobile contest cards now render a skeleton (instead of collapsing to nothing) while each card's per-track queries are pending, removing the blank gap users saw between "skeletons" and "cards".
+- The web contest card skeleton reserves the same 2-line title block as the populated card to prevent a layout shift when cards swap in.
+- The contest detail page hero now sits on a skeleton and layers a small (150×150) blurred thumbnail under the full (1000×1000) cover so the banner is never totally blank while the large image is in flight.

--- a/packages/mobile/src/components/contest-card/ContestCard.tsx
+++ b/packages/mobile/src/components/contest-card/ContestCard.tsx
@@ -272,7 +272,10 @@ export const ContestCard = (props: ContestCardProps) => {
   }, [navigation, trackId, noNavigation])
 
   if (!track || !user || !remixContest) {
-    return null
+    // Return a skeleton rather than null so the outer list doesn't collapse
+    // to an empty row between when the contest IDs resolve and when each
+    // card's per-track queries finish — prevents the "blank gap" flash.
+    return <ContestCardSkeleton variant={variant} {...other} />
   }
 
   const status = formatStatus(remixContest.endDate)

--- a/packages/mobile/src/screens/contests-screen/ContestsScreen.tsx
+++ b/packages/mobile/src/screens/contests-screen/ContestsScreen.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { useAllRemixContests } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { FeatureFlags } from '@audius/common/services'
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native'
 
 import { Flex, IconTrophy, Text } from '@audius/harmony-native'
 import { ContestCard, ContestCardSkeleton } from 'app/components/contest-card'
@@ -15,13 +16,26 @@ const messages = {
 
 const HERO_SKELETON_COUNT = 1
 const GRID_SKELETON_COUNT = 4
+// Bounded first page so we don't fan out 25 concurrent image requests on
+// mount; the rest load as the user scrolls.
+const CONTEST_PAGE_SIZE = 6
+// Pixels from the bottom at which we trigger the next page fetch.
+const END_REACHED_THRESHOLD = 400
 
 export const ContestsScreen = () => {
   const { isEnabled: isContestsPageEnabled } = useFeatureFlag(
     FeatureFlags.CONTESTS
   )
-  const { data, isPending, isError, isSuccess } = useAllRemixContests(
-    undefined,
+  const {
+    data,
+    isPending,
+    isError,
+    isSuccess,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage
+  } = useAllRemixContests(
+    { pageSize: CONTEST_PAGE_SIZE },
     { enabled: isContestsPageEnabled }
   )
 
@@ -31,6 +45,19 @@ export const ContestsScreen = () => {
     isContestsPageEnabled && (isPending || (!isSuccess && !isError))
   const showEmpty = isSuccess && contests.length === 0
 
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (!hasNextPage || isFetchingNextPage) return
+      const { layoutMeasurement, contentOffset, contentSize } = e.nativeEvent
+      const distanceFromBottom =
+        contentSize.height - (contentOffset.y + layoutMeasurement.height)
+      if (distanceFromBottom <= END_REACHED_THRESHOLD) {
+        fetchNextPage()
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage]
+  )
+
   return (
     <Screen
       url='/contests'
@@ -39,7 +66,7 @@ export const ContestsScreen = () => {
       title={messages.title}
     >
       <ScreenContent>
-        <ScrollView>
+        <ScrollView onScroll={handleScroll} scrollEventThrottle={200}>
           <Flex direction='column' gap='l' mv='l' mh='m'>
             {showSkeletons ? (
               <Flex direction='column' gap='l'>
@@ -68,6 +95,14 @@ export const ContestsScreen = () => {
                 {gridTrackIds.map((id) => (
                   <ContestCard key={id} trackId={id} variant='grid' />
                 ))}
+                {isFetchingNextPage
+                  ? Array.from({ length: CONTEST_PAGE_SIZE }).map((_, i) => (
+                      <ContestCardSkeleton
+                        key={`load-more-skeleton-${i}`}
+                        variant='grid'
+                      />
+                    ))
+                  : null}
               </Flex>
             )}
           </Flex>

--- a/packages/web/src/components/contest-card/ContestCard.tsx
+++ b/packages/web/src/components/contest-card/ContestCard.tsx
@@ -184,6 +184,11 @@ const StatusPill = ({ children }: { children: ReactNode }) => {
 export const ContestCardSkeleton = (
   props: { variant?: ContestCardVariant } & Omit<PaperProps, 'variant'>
 ) => {
+  const { variant = 'grid', ...rest } = props
+  // Match the real card's reserved 2-line title block so swapping the
+  // skeleton for the populated card never shifts the layout.
+  const titleLineHeight = variant === 'hero' ? 40 : 32
+  const titleBlockHeight = titleLineHeight * 2
   return (
     <Paper
       direction='column'
@@ -191,7 +196,7 @@ export const ContestCardSkeleton = (
       shadow='mid'
       w='100%'
       css={{ overflow: 'hidden', borderRadius: 14 }}
-      {...props}
+      {...rest}
     >
       <Skeleton h={COVER_HEIGHT} w='100%' />
       <Flex direction='column' gap='l' p='xl'>
@@ -204,9 +209,13 @@ export const ContestCardSkeleton = (
         </Flex>
         <Divider orientation='horizontal' />
         <Flex direction='column' gap='s'>
-          <Skeleton h={28} w='80%' />
+          <Flex
+            alignItems='center'
+            css={{ height: titleBlockHeight, flexShrink: 0 }}
+          >
+            <Skeleton h={titleLineHeight - 8} w='80%' />
+          </Flex>
           <Flex gap='s'>
-            <Skeleton h={22} w={72} />
             <Skeleton h={22} w={120} />
           </Flex>
         </Flex>

--- a/packages/web/src/pages/contest-page/components/ContestHeroImage.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestHeroImage.tsx
@@ -17,7 +17,10 @@ type ContestHeroImageProps = {
  * sits on a skeleton until at least the small image is ready — avoids
  * the long "totally blank" window users saw before.
  */
-export const ContestHeroImage = ({ trackId, height }: ContestHeroImageProps) => {
+export const ContestHeroImage = ({
+  trackId,
+  height
+}: ContestHeroImageProps) => {
   const { motion } = useTheme()
 
   const { imageUrl: smallUrl, hasNoArtwork } = useTrackCoverArt({
@@ -55,9 +58,7 @@ export const ContestHeroImage = ({ trackId, height }: ContestHeroImageProps) => 
       })}
     >
       {showSkeleton ? (
-        <Skeleton
-          css={{ position: 'absolute', inset: 0, zIndex: 0 }}
-        />
+        <Skeleton css={{ position: 'absolute', inset: 0, zIndex: 0 }} />
       ) : null}
       {smallUrl ? (
         <img

--- a/packages/web/src/pages/contest-page/components/ContestHeroImage.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestHeroImage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react'
+
+import { ID, SquareSizes } from '@audius/common/models'
+import { Box, Skeleton, useTheme } from '@audius/harmony'
+
+import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
+
+type ContestHeroImageProps = {
+  trackId?: ID
+  height: string | number
+}
+
+/**
+ * Contest detail page hero banner. Fetches the small (150×150) cover art
+ * immediately to paint *something* while the full 1000×1000 is still in
+ * flight, layers them so the large image fades over the small one, and
+ * sits on a skeleton until at least the small image is ready — avoids
+ * the long "totally blank" window users saw before.
+ */
+export const ContestHeroImage = ({ trackId, height }: ContestHeroImageProps) => {
+  const { motion } = useTheme()
+
+  const { imageUrl: smallUrl, hasNoArtwork } = useTrackCoverArt({
+    trackId,
+    size: SquareSizes.SIZE_150_BY_150
+  })
+  const { imageUrl: largeUrl } = useTrackCoverArt({
+    trackId,
+    size: SquareSizes.SIZE_1000_BY_1000
+  })
+
+  const [isSmallLoaded, setIsSmallLoaded] = useState(false)
+  const [isLargeLoaded, setIsLargeLoaded] = useState(false)
+
+  useEffect(() => {
+    setIsSmallLoaded(false)
+  }, [smallUrl])
+  useEffect(() => {
+    setIsLargeLoaded(false)
+  }, [largeUrl])
+
+  // Hide the skeleton once either size has painted OR we know the track has
+  // no artwork at all (otherwise the skeleton would shimmer forever on
+  // artwork-less tracks).
+  const showSkeleton = !isSmallLoaded && !isLargeLoaded && !hasNoArtwork
+
+  return (
+    <Box
+      w='100%'
+      css={(theme) => ({
+        height,
+        position: 'relative',
+        overflow: 'hidden',
+        backgroundColor: theme.color.background.surface2
+      })}
+    >
+      {showSkeleton ? (
+        <Skeleton
+          css={{ position: 'absolute', inset: 0, zIndex: 0 }}
+        />
+      ) : null}
+      {smallUrl ? (
+        <img
+          src={smallUrl}
+          alt=''
+          draggable={false}
+          onLoad={() => setIsSmallLoaded(true)}
+          onError={() => setIsSmallLoaded(true)}
+          css={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            objectPosition: 'center',
+            // Slight blur while the small thumbnail is the only thing we have
+            // — reads as a deliberate low-fi placeholder rather than a
+            // pixelated thumbnail.
+            filter: isLargeLoaded ? 'none' : 'blur(16px)',
+            transform: 'scale(1.05)',
+            opacity: isSmallLoaded ? 1 : 0,
+            transition: `opacity ${motion.calm}`,
+            zIndex: 1
+          }}
+        />
+      ) : null}
+      {largeUrl ? (
+        <img
+          src={largeUrl}
+          alt=''
+          draggable={false}
+          onLoad={() => setIsLargeLoaded(true)}
+          onError={() => setIsLargeLoaded(true)}
+          css={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            objectPosition: 'center',
+            opacity: isLargeLoaded ? 1 : 0,
+            transition: `opacity ${motion.calm}`,
+            zIndex: 2
+          }}
+        />
+      ) : null}
+    </Box>
+  )
+}

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -13,7 +13,7 @@ import {
   useUser
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
-import { SquareSizes, ShareSource } from '@audius/common/models'
+import { ShareSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
   remixesPageActions,
@@ -46,7 +46,6 @@ import Page from 'components/page/Page'
 import UserBadges from 'components/user-badges/UserBadges'
 import { UserGeneratedText } from 'components/user-generated-text'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
-import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 import { useRemixPageParams } from 'pages/remixes-page/hooks'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
 import {
@@ -57,6 +56,7 @@ import {
 
 import { ContestCommentsTile } from '../ContestCommentsTile'
 import { ContestFollowersModal } from '../ContestFollowersModal'
+import { ContestHeroImage } from '../ContestHeroImage'
 import { ContestStemsCard } from '../ContestStemsCard'
 import { EventFollowersCard } from '../EventFollowersCard'
 
@@ -233,11 +233,6 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     followEvent,
     unfollowEvent
   ])
-
-  const { imageUrl: coverArtUrl } = useTrackCoverArt({
-    trackId,
-    size: SquareSizes.SIZE_1000_BY_1000
-  })
 
   // Only render the Stems & Downloads panel when the track actually has
   // downloadable content. The DownloadSection component assumes a
@@ -484,17 +479,12 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
               radius. The height fluidly tracks the content width
               (via `cqi` relative to the `contest` container) so
               narrow desktop shells get a shorter hero without a
-              hard mobile/desktop breakpoint. */}
-            <Box
-              w='100%'
-              css={{
-                height: `clamp(${HERO_MIN_HEIGHT}px, 30cqi, ${HERO_MAX_HEIGHT}px)`,
-                backgroundImage: coverArtUrl
-                  ? `url(${coverArtUrl})`
-                  : undefined,
-                backgroundSize: 'cover',
-                backgroundPosition: 'center'
-              }}
+              hard mobile/desktop breakpoint. ContestHeroImage
+              handles the skeleton + progressive (small→large)
+              fade-in so the banner is never blank. */}
+            <ContestHeroImage
+              trackId={trackId}
+              height={`clamp(${HERO_MIN_HEIGHT}px, 30cqi, ${HERO_MAX_HEIGHT}px)`}
             />
 
             {/* Header body content — padded section below the hero. */}

--- a/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
@@ -15,7 +15,7 @@ import {
   useUser
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
-import { ShareSource, SquareSizes } from '@audius/common/models'
+import { ShareSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
   remixesPageActions,
@@ -50,12 +50,12 @@ import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
 import Page from 'components/page/Page'
 import { UserGeneratedText } from 'components/user-generated-text'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
-import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 import { useRemixPageParams } from 'pages/remixes-page/hooks'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
 import { fullContestPage, pickWinnersPage } from 'utils/route'
 
 import { ContestCommentsTile } from '../ContestCommentsTile'
+import { ContestHeroImage } from '../ContestHeroImage'
 import { ContestStemsCard } from '../ContestStemsCard'
 import { EventFollowersCard } from '../EventFollowersCard'
 
@@ -305,11 +305,6 @@ const ContestPage = ({
     )
   }, [dispatch, trackId])
 
-  const { imageUrl: coverArtUrl } = useTrackCoverArt({
-    trackId,
-    size: SquareSizes.SIZE_1000_BY_1000
-  })
-
   // Updates tab visibility — for non-hosts, hide the tab until there's
   // at least one host-authored top-level post (a "post update"). The
   // host always sees the tab so they have somewhere to compose from.
@@ -477,17 +472,11 @@ const ContestPage = ({
         w='100%'
         css={(theme) => ({ backgroundColor: theme.color.background.white })}
       >
-        {/* Hero banner */}
-        <Box
-          w='100%'
-          h={HERO_HEIGHT}
-          css={{
-            backgroundImage: coverArtUrl ? `url(${coverArtUrl})` : undefined,
-            backgroundSize: 'cover',
-            backgroundPosition: 'center',
-            position: 'relative'
-          }}
-        >
+        {/* Hero banner — ContestHeroImage shows a skeleton + progressive
+            (small→large) fade-in so the banner is never blank. The back
+            button is layered on top via absolute positioning. */}
+        <Box w='100%' css={{ position: 'relative' }}>
+          <ContestHeroImage trackId={trackId} height={HERO_HEIGHT} />
           {/* Back button — white disc with an elevation shadow for
               emphasis instead of the previous translucent dark circle.
               Reads cleanly against both light and dark cover art. */}
@@ -498,7 +487,8 @@ const ContestPage = ({
               left: 12,
               borderRadius: '50%',
               backgroundColor: theme.color.background.white,
-              boxShadow: theme.shadows.mid
+              boxShadow: theme.shadows.mid,
+              zIndex: 3
             })}
           >
             <IconButton

--- a/packages/web/src/pages/contests-page/ContestsPage.tsx
+++ b/packages/web/src/pages/contests-page/ContestsPage.tsx
@@ -1,13 +1,17 @@
+import { useCallback } from 'react'
+
 import { useAllRemixContests } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { FeatureFlags } from '@audius/common/services'
 import { Box, Button, Flex, IconTrophy, Text } from '@audius/harmony'
+import InfiniteScroll from 'react-infinite-scroller'
 import { Navigate } from 'react-router'
 
 import { ContestCard, ContestCardSkeleton } from 'components/contest-card'
 import { Header } from 'components/header/desktop/Header'
 import Page from 'components/page/Page'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { useMainContentRef } from 'pages/MainContentContext'
 
 import styles from './ContestsPage.module.css'
 import { RunYourOwnContestBanner } from './RunYourOwnContestBanner'
@@ -24,16 +28,39 @@ const messages = {
 }
 
 const HERO_SKELETON_COUNT = 1
-const GRID_SKELETON_COUNT = 11
+const GRID_SKELETON_COUNT = 8
+// Initial page deliberately small so the first paint fires a bounded number
+// of per-card image requests. Subsequent pages load as the user scrolls.
+const CONTEST_PAGE_SIZE = 8
 
 export const ContestsPage = () => {
   const isMobile = useIsMobile()
+  const containerRef = useMainContentRef()
   const { isEnabled: isContestsPageEnabled, isLoaded: isFlagLoaded } =
     useFeatureFlag(FeatureFlags.CONTESTS)
-  const { data, isPending, isError, isSuccess } = useAllRemixContests(
-    undefined,
+  const {
+    data,
+    isPending,
+    isError,
+    isSuccess,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage
+  } = useAllRemixContests(
+    { pageSize: CONTEST_PAGE_SIZE },
     { enabled: isContestsPageEnabled }
   )
+
+  const getScrollParent = useCallback(
+    () => containerRef.current ?? null,
+    [containerRef]
+  )
+
+  const handleLoadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   if (isFlagLoaded && !isContestsPageEnabled) {
     return <Navigate to='/' replace />
@@ -109,11 +136,27 @@ export const ContestsPage = () => {
               <ContestCard trackId={heroTrackId} variant='hero' />
             ) : null}
             {gridTrackIds.length > 0 ? (
-              <div className={styles.cardsContainer}>
-                {gridTrackIds.map((id) => (
-                  <ContestCard key={id} trackId={id} variant='grid' />
-                ))}
-              </div>
+              <InfiniteScroll
+                hasMore={hasNextPage}
+                loadMore={handleLoadMore}
+                getScrollParent={getScrollParent}
+                useWindow={false}
+                threshold={400}
+              >
+                <div className={styles.cardsContainer}>
+                  {gridTrackIds.map((id) => (
+                    <ContestCard key={id} trackId={id} variant='grid' />
+                  ))}
+                  {isFetchingNextPage
+                    ? Array.from({ length: CONTEST_PAGE_SIZE }).map((_, i) => (
+                        <ContestCardSkeleton
+                          key={`load-more-skeleton-${i}`}
+                          variant='grid'
+                        />
+                      ))
+                    : null}
+                </div>
+              </InfiniteScroll>
             ) : null}
           </Flex>
         )}


### PR DESCRIPTION
## Summary

Fixes the "skeletons → blank gap → cards" flicker on the contest explore page, the long tail of concurrent image requests, and the totally-blank hero on the contest detail page while the 1000×1000 cover is in flight.

### Contest explore page
- **Infinite scroll**: drop the initial page size to 8 (web) / 6 (mobile) and paginate via `fetchNextPage`, so first paint fires a bounded number of image requests instead of 25. Tail skeletons render while the next page is loading.
- **Mobile ContestCard** (`packages/mobile/src/components/contest-card/ContestCard.tsx`): return `<ContestCardSkeleton />` instead of `null` when per-card queries (track/user/contest) are still pending. That `null` return is the actual source of the blank gap on mobile — the list collapses to an empty row between when contest IDs resolve and when each card's sub-queries finish.
- **Web ContestCardSkeleton** (`packages/web/src/components/contest-card/ContestCard.tsx`): reserve the same 2-line title block height as the populated card so swapping the skeleton for the card never shifts layout.

### Contest detail page
- New **`ContestHeroImage`** component (`packages/web/src/pages/contest-page/components/ContestHeroImage.tsx`): layers a 150×150 (blurred) under a 1000×1000, sitting on a `Skeleton` until at least one size has painted. The small thumbnail fetches first and gives the hero something to display while the 1000×1000 finishes loading; the blur + scale makes it read as a deliberate low-fi placeholder.
- Wired into both desktop and mobile-web `ContestPage`, replacing the previous CSS `background-image` approach that left the banner totally blank during load.
- Guards against artwork-less tracks via `hasNoArtwork` so the skeleton doesn't shimmer forever.

## Test plan

- [ ] Contest explore page renders with no blank gap between skeleton → cards (web + mobile-web + mobile native)
- [ ] Scrolling near the bottom triggers a fetch and renders tail skeletons until the next batch arrives
- [ ] First paint fires ≤ 8 cover image requests (verify in DevTools Network tab)
- [ ] Contest detail page hero shows a blurred placeholder / skeleton immediately on cold load, then fades to the full-size cover (both desktop + mobile-web)
- [ ] Artwork-less contests don't render a permanent shimmer on the hero
- [ ] No layout shift when a grid card swaps from skeleton to populated

https://claude.ai/code/session_01X7Dr9vcu1p9VwRugo792HT

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7Dr9vcu1p9VwRugo792HT)_