### PR TITLE
Reduce re-renders in mobile contest submissions tab

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useLineupQuery.ts
+++ b/packages/common/src/api/tan-query/lineups/useLineupQuery.ts
@@ -143,7 +143,12 @@ export const useLineupQuery = <T>({
   const prevQueryKey = usePrevious(queryKey)
   const hasQueryKeyChanged = !isEqual(prevQueryKey, queryKey)
 
-  // Function to handle loading cached data into the lineup
+  // Only depend on the stable `prefix` string rather than the full
+  // lineup state object — otherwise every Redux lineup update (including
+  // the ones this callback itself dispatches) gives us a new `lineup`
+  // reference, re-creates the callback, and retriggers consumers'
+  // effects that list it as a dep, causing redundant dispatches.
+  const lineupPrefix = lineup.prefix
   const loadCachedDataIntoLineup = useCallback(() => {
     // Any time this function is run we reset the lineup.
     // If there's already data in our query cache it will get put back into the lineup below.
@@ -159,7 +164,7 @@ export const useLineupQuery = <T>({
         lineupData,
         queryClient,
         reportToSentry,
-        lineup.prefix
+        lineupPrefix
       )
       // Put the full entities in the lineup
       dispatch(
@@ -168,7 +173,14 @@ export const useLineupQuery = <T>({
         })
       )
     }
-  }, [dispatch, lineupActions, lineupData, queryClient, reportToSentry, lineup])
+  }, [
+    dispatch,
+    lineupActions,
+    lineupData,
+    queryClient,
+    reportToSentry,
+    lineupPrefix
+  ])
 
   // Normally we prime the redux lineup store with the lineupData from the queryFn.
   // However this doesnt work for cache hits, so here we check for cache hits.

--- a/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
@@ -139,15 +139,21 @@ export const ContestSubmissionsTab = () => {
   //   after the last winner (index `winnerCount`).
   // - Without winners: SUBMISSIONS after original (index 0).
   // Same pattern the legacy `TrackRemixesScreen` uses.
-  const delineatorMap =
-    winnerCount > 0
-      ? {
-          0: winnersDelineator,
-          [winnerCount]: submissionsDelineator
-        }
-      : {
-          0: submissionsDelineator
-        }
+  // Memoized so the reference stays stable across renders — the map
+  // feeds `TanQueryLineup`'s `renderItem` deps, and a fresh object
+  // each render would force the whole list to re-render.
+  const delineatorMap = useMemo(
+    () =>
+      winnerCount > 0
+        ? {
+            0: winnersDelineator,
+            [winnerCount]: submissionsDelineator
+          }
+        : {
+            0: submissionsDelineator
+          },
+    [winnerCount, winnersDelineator, submissionsDelineator]
+  )
 
   return (
     <TanQueryLineup


### PR DESCRIPTION
## Summary

The submissions section in the mobile contest screen was doing a full page re-render multiple times on load and on filter/sort interactions. Two small changes cut the cascade:

- **Memoize `delineatorMap` in `ContestSubmissionsTab`** (`packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx`). The map feeds `TanQueryLineup`'s `renderItem` dependency array, so a fresh object reference every render was invalidating `renderItem` and re-rendering the whole `SectionList`.

- **Narrow `loadCachedDataIntoLineup`'s deps in `useLineupQuery`** (`packages/common/src/api/tan-query/lineups/useLineupQuery.ts`) from the full `lineup` selector result to the stable `lineup.prefix` string. Previously, every Redux lineup update — including the ones this callback itself dispatched — produced a new `lineup` reference, re-created the callback, and retriggered the `useEffect` in `ContestSubmissionsTab` that calls it, leading to redundant `reset()` + `fetchLineupMetadatas` dispatches on each lineup state update.

## The re-render cascade (before)

1. User changes sort/filter → `ContestSubmissionsTab` re-renders
2. `delineatorMap` rebuilt as a fresh object → `renderItem` dep changes → `SectionList` re-renders all items
3. `useRemixesLineup` effect dispatches `fetchLineupMetadatas` when `processedLineupData` resolves
4. Redux lineup state changes → `lineup` selector returns new reference → `loadCachedDataIntoLineup` recreated
5. `ContestSubmissionsTab`'s `useEffect([hasData, loadCachedDataIntoLineup])` fires again → dispatches `reset()` + `fetchLineupMetadatas` again → back to step 4

## Test plan

- [ ] Open the contest submissions tab on iOS and confirm the list renders without the visible flash/flicker of a full re-render
- [ ] Same check on Android
- [ ] Change the sort option (Most Recent / Most Plays / Most Favorites) — list should update once, not flicker
- [ ] Toggle the Co-Signed filter — list should update once, not flicker
- [ ] Scroll to load the next page — pagination still works; no duplicate dispatch churn in the Redux devtools
- [ ] Navigate away and back to the tab — cache hydrates correctly; no regression in the contest or track remixes flows (both consume `useLineupQuery`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fh9ecDHR4gpK8Q6ZdBcsZb)_