### PR TITLE
Create Contest flow from contests discovery page

### DIFF
--- a/packages/common/src/utils/route.ts
+++ b/packages/common/src/utils/route.ts
@@ -151,6 +151,7 @@ export const TRACK_COMMENTS_PAGE = '/:handle/:slug/comments'
 export const PICK_WINNERS_PAGE = '/:handle/:slug/pick-winners'
 export const CONTEST_PAGE = '/:handle/:slug/contest'
 export const HOST_REMIX_CONTEST_PAGE = '/:handle/:slug/host-contest'
+export const HOST_REMIX_CONTEST_ROOT_PAGE = '/host-contest'
 export const PROFILE_PAGE = '/:handle'
 export const PROFILE_PAGE_TRACKS = '/:handle/tracks'
 export const PROFILE_PAGE_ALBUMS = '/:handle/albums'
@@ -352,6 +353,7 @@ export const staticRoutes = new Set([
   TRENDING_PAGE,
   EXPLORE_PAGE,
   CONTESTS_PAGE,
+  HOST_REMIX_CONTEST_ROOT_PAGE,
   TRENDING_PLAYLISTS_PAGE,
   TRENDING_PLAYLISTS_PAGE_LEGACY,
   TRENDING_UNDERGROUND_PAGE,

--- a/packages/web/src/app/web-player/WebPlayer.tsx
+++ b/packages/web/src/app/web-player/WebPlayer.tsx
@@ -254,6 +254,7 @@ const {
   PICK_WINNERS_PAGE,
   CONTEST_PAGE,
   HOST_REMIX_CONTEST_PAGE,
+  HOST_REMIX_CONTEST_ROOT_PAGE,
   PROFILE_PAGE,
   authenticatedRoutes,
   EMPTY_PAGE,
@@ -1189,6 +1190,10 @@ const WebPlayer = (props: WebPlayerProps) => {
                   element={<ContestPage containerRef={mainContentRef} />}
                 />
                 <Route
+                  path={HOST_REMIX_CONTEST_ROOT_PAGE}
+                  element={<HostRemixContestPage />}
+                />
+                <Route
                   path={HOST_REMIX_CONTEST_PAGE}
                   element={<HostRemixContestPage />}
                 />
@@ -1565,6 +1570,10 @@ const WebPlayer = (props: WebPlayerProps) => {
                 <Route
                   path={CONTEST_PAGE}
                   element={<ContestPage containerRef={mainContentRef} />}
+                />
+                <Route
+                  path={HOST_REMIX_CONTEST_ROOT_PAGE}
+                  element={<HostRemixContestPage />}
                 />
                 <Route
                   path={HOST_REMIX_CONTEST_PAGE}

--- a/packages/web/src/pages/contests-page/ContestsPage.tsx
+++ b/packages/web/src/pages/contests-page/ContestsPage.tsx
@@ -1,8 +1,9 @@
 import { useAllRemixContests } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { FeatureFlags } from '@audius/common/services'
+import { route } from '@audius/common/utils'
 import { Box, Button, Flex, IconTrophy, Text } from '@audius/harmony'
-import { Navigate } from 'react-router'
+import { Link, Navigate } from 'react-router'
 
 import { ContestCard, ContestCardSkeleton } from 'components/contest-card'
 import { Header } from 'components/header/desktop/Header'
@@ -12,8 +13,7 @@ import { useIsMobile } from 'hooks/useIsMobile'
 import styles from './ContestsPage.module.css'
 import { RunYourOwnContestBanner } from './RunYourOwnContestBanner'
 
-const CONTEST_HOSTING_HELP_URL =
-  'https://help.audius.co/artists/hosting-a-remix-contest'
+const { HOST_REMIX_CONTEST_ROOT_PAGE } = route
 
 const messages = {
   title: 'Contests',
@@ -50,20 +50,10 @@ export const ContestsPage = () => {
       icon={IconTrophy}
       primary={messages.title}
       rightDecorator={
-        <Button
-          variant='primary'
-          size='small'
-          asChild
-          // TODO: Link to the in-app contest creation flow once it exists
-          // outside of the per-track HostRemixContestModal.
-        >
-          <a
-            href={CONTEST_HOSTING_HELP_URL}
-            target='_blank'
-            rel='noopener noreferrer'
-          >
+        <Button variant='primary' size='small' asChild>
+          <Link to={HOST_REMIX_CONTEST_ROOT_PAGE}>
             {messages.createContest}
-          </a>
+          </Link>
         </Button>
       }
     />

--- a/packages/web/src/pages/contests-page/RunYourOwnContestBanner.tsx
+++ b/packages/web/src/pages/contests-page/RunYourOwnContestBanner.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 
+import { route } from '@audius/common/utils'
 import {
   Button,
   Flex,
@@ -8,11 +9,14 @@ import {
   Paper,
   Text
 } from '@audius/harmony'
+import { Link } from 'react-router'
 
 import { useIsMobile } from 'hooks/useIsMobile'
+import { usePortal } from 'hooks/usePortal'
+import { useMainContentRef } from 'pages/MainContentContext'
+import zIndex from 'utils/zIndex'
 
-const CONTEST_HOSTING_HELP_URL =
-  'https://help.audius.co/artists/hosting-a-remix-contest'
+const { HOST_REMIX_CONTEST_ROOT_PAGE } = route
 
 const messages = {
   title: 'Run Your Own Contest!',
@@ -23,68 +27,80 @@ const messages = {
 }
 
 /**
- * Desktop-only CTA encouraging viewers to host their own remix
- * contest. Hidden on mobile-width viewports. Renders in the normal
- * page flow underneath the contest grid — matches the placement on
- * other launchpad/explore pages (fan clubs, etc.) so the banner
- * tracks the content column's width + padding instead of
- * float-overlapping rows with a fixed viewport offset.
- * Dismissable for the rest of the session (state is not persisted
- * across reloads — flip to localStorage if we want it to stick).
+ * Desktop-only floating CTA encouraging viewers to host their own remix
+ * contest. Hidden on mobile-width viewports. Hovers at the bottom of the
+ * viewport (above the play bar) rather than sitting at the end of the
+ * document scroll, so it remains reachable while the user scrolls the
+ * contest grid.
+ *
+ * Positioning mirrors FanClubsExplorePage's launch banner: fixed inside
+ * a portal on the main content container, offset by the nav width on the
+ * left and the play bar height on the bottom. Dismissable for the rest
+ * of the session (state is not persisted across reloads).
  */
 export const RunYourOwnContestBanner = () => {
   const isMobile = useIsMobile()
   const [isDismissed, setIsDismissed] = useState(false)
+  const mainContentRef = useMainContentRef()
+  const Portal = usePortal({
+    container: mainContentRef.current?.parentElement ?? undefined
+  })
 
   if (isMobile || isDismissed) return null
 
   return (
-    <Paper
-      direction='row'
-      alignItems='center'
-      justifyContent='space-between'
-      gap='l'
-      p='xl'
-      border='default'
-      shadow='mid'
-      backgroundColor='white'
-      w='100%'
-      css={{
-        position: 'relative',
-        borderRadius: 16
-      }}
-    >
-      <Flex
-        direction='column'
-        gap='xs'
-        css={{ flex: '1 1 auto', minWidth: 0, paddingRight: 24 }}
+    <Portal>
+      <Paper
+        direction='row'
+        alignItems='center'
+        justifyContent='space-between'
+        gap='l'
+        p='xl'
+        border='default'
+        shadow='mid'
+        backgroundColor='white'
+        css={{
+          position: 'fixed',
+          bottom: 'calc(var(--play-bar-height) + 24px)',
+          left: 'calc(var(--nav-width) + 48px)',
+          right: 48,
+          borderRadius: 16,
+          zIndex: zIndex.NAVIGATOR_POPUP
+        }}
       >
-        <Text variant='heading' size='s'>
-          {messages.title}
-        </Text>
-        <Text variant='body' size='m' color='subdued'>
-          {messages.description}
-        </Text>
-      </Flex>
-
-      <Button variant='primary' size='default' asChild css={{ flexShrink: 0 }}>
-        <a
-          href={CONTEST_HOSTING_HELP_URL}
-          target='_blank'
-          rel='noopener noreferrer'
+        <Flex
+          direction='column'
+          gap='xs'
+          css={{ flex: '1 1 auto', minWidth: 0, paddingRight: 24 }}
         >
-          {messages.createContest}
-        </a>
-      </Button>
+          <Text variant='heading' size='s'>
+            {messages.title}
+          </Text>
+          <Text variant='body' size='m' color='subdued'>
+            {messages.description}
+          </Text>
+        </Flex>
 
-      <IconButton
-        icon={IconClose}
-        aria-label={messages.dismiss}
-        color='subdued'
-        size='s'
-        onClick={() => setIsDismissed(true)}
-        css={{ position: 'absolute', top: 8, right: 8 }}
-      />
-    </Paper>
+        <Button
+          variant='primary'
+          size='default'
+          asChild
+          css={{ flexShrink: 0 }}
+        >
+          <Link to={HOST_REMIX_CONTEST_ROOT_PAGE}>
+            {messages.createContest}
+          </Link>
+        </Button>
+
+        <IconButton
+          icon={IconClose}
+          aria-label={messages.dismiss}
+          color='subdued'
+          size='s'
+          onClick={() => setIsDismissed(true)}
+          css={{ position: 'absolute', top: 8, right: 8 }}
+        />
+      </Paper>
+    </Portal>
   )
 }

--- a/packages/web/src/pages/host-remix-contest-page/AddSourceTrackModal.tsx
+++ b/packages/web/src/pages/host-remix-contest-page/AddSourceTrackModal.tsx
@@ -9,17 +9,17 @@ import { SquareSizes } from '@audius/common/models'
 import {
   Box,
   Button,
-  Checkbox,
   Flex,
   Modal,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalTitle,
+  Radio,
+  RadioGroup,
   TextInput,
   Text,
-  IconSearch,
-  TextLink
+  IconSearch
 } from '@audius/harmony'
 
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
@@ -29,7 +29,6 @@ const messages = {
   search: 'Search for Tracks',
   done: 'Done',
   cancel: 'Cancel',
-  viewSelection: 'View Selection',
   selectedCount: (n: number) => `${n} Track${n === 1 ? '' : 's'} Selected`,
   empty: 'No tracks found.',
   loading: 'Loading tracks…'
@@ -38,16 +37,19 @@ const messages = {
 type AddSourceTrackModalProps = {
   isOpen: boolean
   onClose: () => void
-  /** Tracks already selected on the parent form, pre-checked in the picker. */
+  /** Tracks already selected on the parent form. First entry pre-selects the radio. */
   initialSelectedIds: number[]
   /** Called with the final set of selected track IDs when "Done" is clicked. */
   onDone: (selectedIds: number[]) => void
 }
 
 /**
- * Multi-select track picker modal used by the Host Remix Contest page's
+ * Single-select track picker modal used by the Host Remix Contest page's
  * Source Tracks section. Searches over the signed-in user's own tracks
- * (client-side filter for now; falls back to fetch-all).
+ * (client-side filter for now; falls back to fetch-all). Contests only
+ * support one Source Track today — the API returns the selection as an
+ * array so the wiring can expand to multi-select later without a
+ * caller-facing shape change.
  */
 export const AddSourceTrackModal = ({
   isOpen,
@@ -59,39 +61,36 @@ export const AddSourceTrackModal = ({
   const { data: currentUser } = useUser(currentUserId)
   const handle = currentUser?.handle
 
-  // Fetch the host's public + unlisted tracks. Page size is generous — we
-  // filter client-side and assume the host's own catalog fits. If we see
-  // real perf issues we'll swap this for a server-side search hook.
+  // Fetch the host's public + unlisted tracks. 100 is the discovery-node
+  // max per page; we filter client-side and assume the host's recent
+  // catalog fits. If someone has >100 tracks and can't find an older one,
+  // we'll swap this for a server-side search / paged fetch.
   const { data: tracks, isPending } = useUserTracksByHandle(
-    { handle, filterTracks: 'all', limit: 200 },
+    { handle, filterTracks: 'all', limit: 100 },
     { enabled: !!handle }
   )
 
   const [search, setSearch] = useState('')
-  const [selectedIds, setSelectedIds] = useState<number[]>(initialSelectedIds)
-  const [viewOnlySelected, setViewOnlySelected] = useState(false)
-
-  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds])
+  const [selectedId, setSelectedId] = useState<number | null>(
+    initialSelectedIds[0] ?? null
+  )
 
   const filtered = useMemo(() => {
     const term = search.trim().toLowerCase()
     return (tracks ?? []).filter((t) => {
-      if (viewOnlySelected && !selectedSet.has(t.track_id)) return false
       if (!term) return true
       return t.title.toLowerCase().includes(term)
     })
-  }, [tracks, search, viewOnlySelected, selectedSet])
+  }, [tracks, search])
 
-  const toggle = useCallback((id: number) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-    )
+  const handleSelect = useCallback((id: number) => {
+    setSelectedId(id)
   }, [])
 
   const handleDone = useCallback(() => {
-    onDone(selectedIds)
+    onDone(selectedId != null ? [selectedId] : [])
     onClose()
-  }, [selectedIds, onDone, onClose])
+  }, [selectedId, onDone, onClose])
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size='medium'>
@@ -128,16 +127,22 @@ export const AddSourceTrackModal = ({
                 </Text>
               </Flex>
             ) : (
-              filtered.map((t) => (
-                <TrackRow
-                  key={t.track_id}
-                  trackId={t.track_id}
-                  title={t.title}
-                  ownerName={currentUser?.name ?? ''}
-                  checked={selectedSet.has(t.track_id)}
-                  onToggle={() => toggle(t.track_id)}
-                />
-              ))
+              <RadioGroup
+                name='source-track-picker'
+                value={selectedId != null ? String(selectedId) : null}
+                css={{ gap: 0 }}
+              >
+                {filtered.map((t) => (
+                  <TrackRow
+                    key={t.track_id}
+                    trackId={t.track_id}
+                    title={t.title}
+                    ownerName={currentUser?.name ?? ''}
+                    checked={selectedId === t.track_id}
+                    onSelect={() => handleSelect(t.track_id)}
+                  />
+                ))}
+              </RadioGroup>
             )}
           </Box>
         </Flex>
@@ -149,19 +154,9 @@ export const AddSourceTrackModal = ({
           gap='m'
           w='100%'
         >
-          <Flex gap='m' alignItems='center'>
-            <Text variant='body' size='s' color='subdued'>
-              {messages.selectedCount(selectedIds.length)}
-            </Text>
-            {selectedIds.length > 0 ? (
-              <TextLink
-                variant='visible'
-                onClick={() => setViewOnlySelected((v) => !v)}
-              >
-                {messages.viewSelection}
-              </TextLink>
-            ) : null}
-          </Flex>
+          <Text variant='body' size='s' color='subdued'>
+            {messages.selectedCount(selectedId != null ? 1 : 0)}
+          </Text>
           <Flex gap='s'>
             <Button variant='secondary' onClick={onClose}>
               {messages.cancel}
@@ -169,7 +164,7 @@ export const AddSourceTrackModal = ({
             <Button
               variant='primary'
               onClick={handleDone}
-              disabled={selectedIds.length === 0}
+              disabled={selectedId == null}
             >
               {messages.done}
             </Button>
@@ -187,7 +182,7 @@ type TrackRowProps = {
   title: string
   ownerName: string
   checked: boolean
-  onToggle: () => void
+  onSelect: () => void
 }
 
 const TrackRow = ({
@@ -195,7 +190,7 @@ const TrackRow = ({
   title,
   ownerName,
   checked,
-  onToggle
+  onSelect
 }: TrackRowProps) => {
   const { imageUrl } = useTrackCoverArt({
     trackId,
@@ -210,7 +205,7 @@ const TrackRow = ({
         borderBottom: '1px solid var(--harmony-border-default)',
         cursor: 'pointer'
       }}
-      onClick={onToggle}
+      onClick={onSelect}
     >
       <Box
         css={{
@@ -231,7 +226,12 @@ const TrackRow = ({
           {ownerName}
         </Text>
       </Flex>
-      <Checkbox checked={checked} onChange={onToggle} aria-label={title} />
+      <Radio
+        value={String(trackId)}
+        checked={checked}
+        onChange={onSelect}
+        aria-label={title}
+      />
     </Flex>
   )
 }

--- a/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
+++ b/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@audius/common/api'
 import { remixMessages } from '@audius/common/messages'
 import { Name, SquareSizes } from '@audius/common/models'
-import { dayjs } from '@audius/common/utils'
+import { dayjs, route } from '@audius/common/utils'
 import {
   Box,
   Button,
@@ -49,6 +49,8 @@ import {
 import { AddSourceTrackModal } from './AddSourceTrackModal'
 import { ManageStemsModal } from './ManageStemsModal'
 import { useUploadContestCover } from './useUploadContestCover'
+
+const { CONTESTS_PAGE } = route
 
 const messages = {
   pageTitle: 'Create Contest',
@@ -111,30 +113,38 @@ type ContestEventData = {
 
 /**
  * Full-page Create / Edit Remix Contest flow. Replaces the legacy
- * HostRemixContestModal. Route: /:handle/:slug/host-contest.
+ * HostRemixContestModal.
+ *
+ * Routes:
+ *   /:handle/:slug/host-contest — track-scoped entry (from a track page).
+ *   /host-contest               — track-less entry (from the contests
+ *                                 discovery page). User picks exactly one
+ *                                 Source Track, which becomes the event's
+ *                                 `entity_id`.
  *
  * When the target track already has a remix_contest event, the form
  * loads into "edit" mode pre-filled from event_data.
  *
  * New fields (Title, Video Link, Cover Photo, Source Tracks) live as
  * extra keys inside event_data — the backend entity_manager accepts
- * arbitrary JSON, so no schema change is required. The single
- * `entity_id` still points at the primary track; additional source
- * tracks live in `event_data.sourceTrackIds`.
+ * arbitrary JSON, so no schema change is required. `entity_id` points
+ * at the primary / first source track.
  */
 export const HostRemixContestPage = () => {
   const navigate = useNavigate()
   useRequiresAccount()
-  const { handle, slug } = useParams<{ handle: string; slug: string }>()
+  const { handle, slug } = useParams<{ handle?: string; slug?: string }>()
 
   const { data: currentUserId } = useCurrentUserId()
   const { data: primaryTrack } = useTrackByPermalink(
     handle && slug ? `/${handle}/${slug}` : null
   )
-  const trackId = primaryTrack?.track_id
-  const { data: remixContest } = useRemixContest(trackId)
+  const primaryTrackId = primaryTrack?.track_id
+  // Only track-scoped entry (primaryTrack present) can show an existing
+  // contest in edit mode. Track-less entry is always create-mode.
+  const { data: remixContest } = useRemixContest(primaryTrackId)
   const { data: remixes, isLoading: remixesLoading } = useRemixesLineup({
-    trackId,
+    trackId: primaryTrackId,
     isContestEntry: true
   })
 
@@ -181,8 +191,19 @@ export const HostRemixContestPage = () => {
   )
 
   const [sourceTrackIds, setSourceTrackIds] = useState<number[]>(
-    existingEventData.sourceTrackIds ?? (trackId ? [trackId] : [])
+    existingEventData.sourceTrackIds ?? (primaryTrackId ? [primaryTrackId] : [])
   )
+
+  // The event's backing track: prefer the URL-scoped primary track, and
+  // fall back to the (required) first Source Track when entering from the
+  // track-less /host-contest route. This is the `entity_id` on create /
+  // update and drives the navigation target after save.
+  const entityTrackId = primaryTrackId ?? sourceTrackIds[0]
+  const { data: entityTrackPermalink } = useTrack(
+    !primaryTrack ? (sourceTrackIds[0] ?? null) : null,
+    { select: (t) => t?.permalink }
+  )
+  const effectivePermalink = primaryPermalink || entityTrackPermalink || ''
 
   // Modal state
   const [isAddTracksOpen, setIsAddTracksOpen] = useState(false)
@@ -194,7 +215,7 @@ export const HostRemixContestPage = () => {
   // Cover-photo upload + fallback to track artwork
   // ---------------------------------------------------------------------------
   const { imageUrl: trackArtworkUrl } = useTrackCoverArt({
-    trackId,
+    trackId: entityTrackId,
     size: SquareSizes.SIZE_1000_BY_1000
   })
   const resolvedCoverUrl = coverPhotoUrl || trackArtworkUrl
@@ -249,15 +270,17 @@ export const HostRemixContestPage = () => {
   }, [])
 
   const handleSourceTracksSelected = useCallback((ids: number[]) => {
+    // Only one Source Track supported today — take the first new pick.
     setSourceTrackIds((prev) => {
-      const merged = Array.from(new Set([...prev, ...ids]))
-      return merged
+      if (prev.length > 0) return prev
+      return ids.slice(0, 1)
     })
   }, [])
 
   const handleCancel = useCallback(() => {
+    // Track-less flow: fall back to the contests discovery page.
     if (!primaryPermalink) {
-      navigate(-1)
+      navigate(CONTESTS_PAGE)
       return
     }
     navigate(
@@ -287,7 +310,9 @@ export const HostRemixContestPage = () => {
     setEndDateTouched(true)
     setEndDateError(hasDateError)
     setDescriptionError(hasDescriptionError)
-    if (hasError || !trackId || !currentUserId) return
+    // entityTrackId is required on both track-scoped and track-less entry —
+    // on track-less entry it comes from the (required) first Source Track.
+    if (hasError || !entityTrackId || !currentUserId) return
 
     const endDate = parsedDate.toISOString()
     const eventData: ContestEventData = {
@@ -312,14 +337,14 @@ export const HostRemixContestPage = () => {
         make({
           eventName: Name.REMIX_CONTEST_UPDATE,
           remixContestId: remixContest.eventId,
-          trackId
+          trackId: entityTrackId
         })
       )
     } else {
       createEvent({
         eventType: EventEventTypeEnum.RemixContest,
         entityType: EventEntityTypeEnum.Track,
-        entityId: trackId,
+        entityId: entityTrackId,
         eventData,
         endDate,
         userId: currentUserId
@@ -328,13 +353,15 @@ export const HostRemixContestPage = () => {
       track(
         make({
           eventName: Name.REMIX_CONTEST_CREATE,
-          trackId
+          trackId: entityTrackId
         })
       )
     }
 
-    if (primaryPermalink) {
-      navigate(fullContestPage(primaryPermalink))
+    if (effectivePermalink) {
+      navigate(fullContestPage(effectivePermalink))
+    } else {
+      navigate(CONTESTS_PAGE)
     }
   }, [
     timeValue,
@@ -348,13 +375,13 @@ export const HostRemixContestPage = () => {
     sourceTrackIds,
     existingEventData.winners,
     contestMinDate,
-    trackId,
+    entityTrackId,
     currentUserId,
     isEdit,
     remixContest,
     updateEvent,
     createEvent,
-    primaryPermalink,
+    effectivePermalink,
     navigate
   ])
 
@@ -362,12 +389,12 @@ export const HostRemixContestPage = () => {
     if (!remixContest || !currentUserId) return
     deleteEvent({ eventId: remixContest.eventId, userId: currentUserId })
 
-    if (trackId) {
+    if (primaryTrackId) {
       track(
         make({
           eventName: Name.REMIX_CONTEST_DELETE,
           remixContestId: remixContest.eventId,
-          trackId
+          trackId: primaryTrackId
         })
       )
     }
@@ -378,15 +405,15 @@ export const HostRemixContestPage = () => {
     remixContest,
     currentUserId,
     deleteEvent,
-    trackId,
+    primaryTrackId,
     primaryPermalink,
     navigate
   ])
 
-  // ---------------------------------------------------------------------------
-  // Render
-  // ---------------------------------------------------------------------------
-  if (!primaryTrack) {
+  // Track-scoped URL (/:handle/:slug/host-contest) but the track hasn't
+  // resolved yet — avoid flashing an empty form against the wrong track.
+  // Track-less entry (/host-contest) skips this and renders immediately.
+  if (handle && slug && !primaryTrack) {
     return null
   }
 
@@ -665,18 +692,23 @@ export const HostRemixContestPage = () => {
                 {messages.sourceTracksHelper}
               </Text>
             </Flex>
-            <Flex gap='s'>
-              <Button
-                variant='primary'
-                fullWidth
-                onClick={handleAddSourceTrack}
-              >
-                {messages.addTrack}
-              </Button>
-              <Button variant='secondary' iconLeft={IconCloudUpload}>
-                {messages.uploadNow}
-              </Button>
-            </Flex>
+            {/* For now only one Source Track is supported. Once one has
+                been picked, both Add Track and Upload Now are locked out
+                — users can Remove the existing row to swap. */}
+            {sourceTrackIds.length === 0 ? (
+              <Flex gap='s'>
+                <Button
+                  variant='primary'
+                  fullWidth
+                  onClick={handleAddSourceTrack}
+                >
+                  {messages.addTrack}
+                </Button>
+                <Button variant='secondary' iconLeft={IconCloudUpload}>
+                  {messages.uploadNow}
+                </Button>
+              </Flex>
+            ) : null}
             {sourceTrackIds.length > 0 ? (
               <Flex direction='column' gap='xs'>
                 <Text variant='label' size='s' color='subdued'>
@@ -715,7 +747,12 @@ export const HostRemixContestPage = () => {
               <Button
                 variant='primary'
                 onClick={handleSubmit}
-                disabled={!contestEndDate || endDateError || timeError}
+                disabled={
+                  !contestEndDate ||
+                  endDateError ||
+                  timeError ||
+                  sourceTrackIds.length === 0
+                }
               >
                 {isEdit ? messages.save : messages.launch}
               </Button>


### PR DESCRIPTION
## Summary

- Wire both "Create Contest" CTAs on the contests discovery page (top-right header button + `RunYourOwnContestBanner` popover) to the in-app create flow at a new `/host-contest` route instead of the external help blog.
- Teach `HostRemixContestPage` to handle no-track entry: primary track is optional; when absent, the (required) first Source Track becomes the event's `entity_id` and drives post-save navigation. Track-scoped URL `/:handle/:slug/host-contest` still works unchanged.
- Contest creation now requires exactly one Source Track. The Add Track / Upload Now row hides once one is picked, and Launch is disabled until one is present.
- `AddSourceTrackModal` is now single-select (Radio / RadioGroup) and requests `limit=100` (the discovery-node max) instead of `200` which returned `400 "limit is invalid"`.
- `RunYourOwnContestBanner` now hovers at the bottom of the viewport (fixed inside a portal, mirroring the Fan Clubs launch banner) instead of sitting at the end of the document scroll.

## Test plan

- [ ] From `/contests`, click the top-right **Create Contest** button — lands on `/host-contest` with an empty form.
- [ ] From `/contests`, click **Create Contest** in the floating bottom banner — same behavior.
- [ ] Scroll the contests page — floating banner stays pinned to the bottom above the play bar.
- [ ] Dismiss the banner (×) — stays hidden for the session.
- [ ] On `/host-contest`, Launch is disabled until a Source Track is picked.
- [ ] Click **+ Add Track** — modal shows the host's own tracks; selection is single (radio).
- [ ] Pick a track → Done → row appears in Source Tracks, Add Track / Upload Now row hides.
- [ ] Launch → creates the contest with the picked track as `entity_id`; redirects to that track's contest page.
- [ ] From a track page, `/:handle/:slug/host-contest` still works (edit mode, pre-filled) and is also capped at 1 Source Track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)