### PR TITLE
add frosted surface appearance controls

### DIFF
--- a/packages/common/src/messages/settings.ts
+++ b/packages/common/src/messages/settings.ts
@@ -16,9 +16,9 @@ export const settingsMessages = {
   matrixMode: 'Matrix',
   defaultPalette: 'Default',
   classicPalette: 'Classic',
-  themeLabel: 'Theme',
-  colorModeLabel: 'Color Mode',
-  surfaceStyleLabel: 'Surface Style',
+  themeLabel: 'Color Theme',
+  colorModeLabel: 'Light / Dark',
+  surfaceStyleLabel: 'Glass Effect',
   surfaceStyleSolid: 'Solid',
   surfaceStyleSubtle: 'Subtle',
   surfaceStyleDefault: 'Default',
@@ -38,7 +38,7 @@ export const settingsMessages = {
   desktopAppCardTitle: 'Download the Desktop App',
 
   appearanceDescription:
-    'Choose a theme palette, color mode, and surface style.',
+    'Customize colors, light/dark mode, and glass effects.',
   inboxSettingsCardDescription:
     'Configure who is able to send messages to your inbox.',
   commentSettingsCardDescription:

--- a/packages/common/src/messages/settings.ts
+++ b/packages/common/src/messages/settings.ts
@@ -16,6 +16,13 @@ export const settingsMessages = {
   matrixMode: 'Matrix',
   defaultPalette: 'Default',
   classicPalette: 'Classic',
+  themeLabel: 'Theme',
+  colorModeLabel: 'Color Mode',
+  surfaceStyleLabel: 'Surface Style',
+  surfaceStyleSolid: 'Solid',
+  surfaceStyleSubtle: 'Subtle',
+  surfaceStyleDefault: 'Default',
+  surfaceStyleStrong: 'Strong',
   signOut: 'Sign Out',
 
   appearanceTitle: 'Appearance',
@@ -31,7 +38,7 @@ export const settingsMessages = {
   desktopAppCardTitle: 'Download the Desktop App',
 
   appearanceDescription:
-    'Choose a theme palette and enable dark mode or use the default setting to match your system preferences.',
+    'Choose a theme palette, color mode, and surface style.',
   inboxSettingsCardDescription:
     'Configure who is able to send messages to your inbox.',
   commentSettingsCardDescription:

--- a/packages/common/src/models/Theme.ts
+++ b/packages/common/src/models/Theme.ts
@@ -12,6 +12,13 @@ export enum ThemePalette {
   MATRIX = 'matrix'
 }
 
+export enum FrostedSurfaceIntensity {
+  OFF = 'off',
+  SUBTLE = 'subtle',
+  DEFAULT = 'default',
+  STRONG = 'strong'
+}
+
 /**
  * @deprecated Use ThemePalette + ThemeMode. Legacy theme enum.
  * - LIGHT/DARK/AUTO = mode (map to ThemeMode)

--- a/packages/common/src/store/ui/index.ts
+++ b/packages/common/src/store/ui/index.ts
@@ -61,6 +61,7 @@ export type {
   SetThemeAction,
   SetThemePaletteAction,
   SetThemeModeAction,
+  SetFrostedSurfaceIntensityAction,
   SetSystemAppearanceAction
 } from './theme/slice'
 export * as themeSelectors from './theme/selectors'

--- a/packages/common/src/store/ui/theme/selectors.ts
+++ b/packages/common/src/store/ui/theme/selectors.ts
@@ -17,6 +17,10 @@ export const getThemeMode = (state: CommonState) => {
   return getBaseState(state).themeMode
 }
 
+export const getFrostedSurfaceIntensity = (state: CommonState) => {
+  return getBaseState(state).frostedSurfaceIntensity
+}
+
 export const getSystemAppearance = (state: CommonState) => {
   return getBaseState(state).systemAppearance
 }

--- a/packages/common/src/store/ui/theme/slice.ts
+++ b/packages/common/src/store/ui/theme/slice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import {
+  FrostedSurfaceIntensity,
   SystemAppearance,
   Theme,
   ThemeMode,
@@ -15,6 +16,7 @@ export type ThemeState = {
   themePalette: Nullable<ThemePalette>
   /** Mode selected in segmented control: auto, light, dark. Ignored when palette is matrix. */
   themeMode: Nullable<ThemeMode>
+  frostedSurfaceIntensity: Nullable<FrostedSurfaceIntensity>
   systemAppearance: Nullable<SystemAppearance>
 }
 
@@ -30,6 +32,10 @@ export type SetThemeModeAction = PayloadAction<{
   themeMode: ThemeMode
 }>
 
+export type SetFrostedSurfaceIntensityAction = PayloadAction<{
+  frostedSurfaceIntensity: FrostedSurfaceIntensity
+}>
+
 export type SetSystemAppearanceAction = PayloadAction<{
   systemAppearance: SystemAppearance
 }>
@@ -38,6 +44,7 @@ const initialState: ThemeState = {
   theme: null,
   themePalette: null,
   themeMode: null,
+  frostedSurfaceIntensity: null,
   systemAppearance: null
 }
 
@@ -78,13 +85,24 @@ const themeSlice = createSlice({
             ? Theme.DARK
             : Theme.AUTO
     },
+    setFrostedSurfaceIntensity: (
+      state,
+      action: SetFrostedSurfaceIntensityAction
+    ) => {
+      state.frostedSurfaceIntensity = action.payload.frostedSurfaceIntensity
+    },
     setSystemAppearance: (state, action: SetSystemAppearanceAction) => {
       state.systemAppearance = action.payload.systemAppearance
     }
   }
 })
 
-export const { setTheme, setThemePalette, setThemeMode, setSystemAppearance } =
-  themeSlice.actions
+export const {
+  setTheme,
+  setThemePalette,
+  setThemeMode,
+  setFrostedSurfaceIntensity,
+  setSystemAppearance
+} = themeSlice.actions
 export default themeSlice.reducer
 export const actions = themeSlice.actions

--- a/packages/web/src/app/AppProviders.tsx
+++ b/packages/web/src/app/AppProviders.tsx
@@ -40,8 +40,7 @@ export const AppProviders = ({ children }: AppProvidersProps) => {
     const themePalette = getThemePaletteFromStorage() ?? ThemePalette.DEFAULT
     const themeMode = getThemeModeFromStorage()
     const frostedSurfaceIntensity =
-      getFrostedSurfaceIntensityFromStorage() ??
-      FrostedSurfaceIntensity.DEFAULT
+      getFrostedSurfaceIntensityFromStorage() ?? FrostedSurfaceIntensity.DEFAULT
     const initialStoreState = {
       ui: {
         theme: {

--- a/packages/web/src/app/AppProviders.tsx
+++ b/packages/web/src/app/AppProviders.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState, useMemo } from 'react'
 
-import { ThemePalette } from '@audius/common/models'
+import { FrostedSurfaceIntensity, ThemePalette } from '@audius/common/models'
 import { MediaProvider } from '@audius/harmony/src/contexts'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
@@ -18,6 +18,7 @@ import { env } from 'services/env'
 import { queryClient } from 'services/query-client'
 import { configureStore } from 'store/configureStore'
 import {
+  getFrostedSurfaceIntensityFromStorage,
   getSystemAppearance,
   getTheme,
   getThemeModeFromStorage,
@@ -38,12 +39,16 @@ export const AppProviders = ({ children }: AppProvidersProps) => {
     const theme = getTheme()
     const themePalette = getThemePaletteFromStorage() ?? ThemePalette.DEFAULT
     const themeMode = getThemeModeFromStorage()
+    const frostedSurfaceIntensity =
+      getFrostedSurfaceIntensityFromStorage() ??
+      FrostedSurfaceIntensity.DEFAULT
     const initialStoreState = {
       ui: {
         theme: {
           theme,
           themePalette,
           themeMode,
+          frostedSurfaceIntensity,
           systemAppearance: getSystemAppearance()
         }
       }

--- a/packages/web/src/app/web-player/WebPlayer.module.css
+++ b/packages/web/src/app/web-player/WebPlayer.module.css
@@ -18,11 +18,35 @@
   --nav-shift: 0px;
   --mobile-min-width: 280px;
   --play-bar-height: 88px;
+  --frosted-surface-backdrop-filter: blur(10px);
+  --frosted-surface-background-color: var(--harmony-n-25);
+  --frosted-surface-opacity: 65%;
+  --frosted-surface-background: color-mix(
+    in srgb,
+    var(--frosted-surface-background-color) var(--frosted-surface-opacity),
+    transparent
+  );
   position: relative;
   width: 100%;
   height: 100%;
   display: flex;
   overflow: hidden;
+}
+
+.app:not(.mobileApp)[data-frosted-surface-intensity='off'] {
+  --frosted-surface-backdrop-filter: none;
+  --frosted-surface-background-color: var(--harmony-bg-surface-1);
+  --frosted-surface-opacity: 100%;
+}
+
+.app:not(.mobileApp)[data-frosted-surface-intensity='subtle'] {
+  --frosted-surface-backdrop-filter: blur(6px);
+  --frosted-surface-opacity: 85%;
+}
+
+.app:not(.mobileApp)[data-frosted-surface-intensity='strong'] {
+  --frosted-surface-backdrop-filter: blur(18px);
+  --frosted-surface-opacity: 50%;
 }
 
 .app.mobileApp {
@@ -42,8 +66,10 @@
 .mainContentWrapper {
   position: relative;
   margin-left: var(--nav-width);
-  margin-bottom: 88px;
+  margin-bottom: 0;
   width: 100%;
+  padding-bottom: var(--play-bar-height);
+  box-sizing: border-box;
   transform: translateX(var(--nav-shift));
   transition: transform 0.2s ease;
   /* Use theme background - ensures classic-dark/default-dark etc. apply correctly */

--- a/packages/web/src/app/web-player/WebPlayer.tsx
+++ b/packages/web/src/app/web-player/WebPlayer.tsx
@@ -14,8 +14,9 @@ import {
   useCurrentAccountUser,
   useHasAccount
 } from '@audius/common/api'
-import { Client, Status } from '@audius/common/models'
+import { Client, FrostedSurfaceIntensity, Status } from '@audius/common/models'
 import { StringKeys } from '@audius/common/services'
+import { themeSelectors } from '@audius/common/store'
 import {
   COIN_DETAIL_BUY_PAGE,
   CLUB_DETAIL_PAGE,
@@ -77,6 +78,7 @@ import 'utils/redirect'
 import { getPathname } from 'utils/route'
 
 import styles from './WebPlayer.module.css'
+const { getFrostedSurfaceIntensity } = themeSelectors
 const TrendingGenreSelectionPage = lazy(
   () => import('components/trending-genre-selection/TrendingGenreSelectionPage')
 )
@@ -495,6 +497,8 @@ const WebPlayer = (props: WebPlayerProps) => {
   const { userHandle, isGuestAccount = false } = accountUserData ?? {}
   const { data: accountStatus } = useAccountStatus()
   const showCookieBanner = useSelector(getShowCookieBanner)
+  const frostedSurfaceIntensity =
+    useSelector(getFrostedSurfaceIntensity) ?? FrostedSurfaceIntensity.DEFAULT
 
   // Convert mapDispatchToProps to useCallback with useDispatch
   const updateRouteOnSignUpCompletion = useCallback(
@@ -758,6 +762,9 @@ const WebPlayer = (props: WebPlayerProps) => {
       <div
         id='webPlayer'
         className={cn(styles.app, { [styles.mobileApp]: isMobile })}
+        data-frosted-surface-intensity={
+          isMobile ? undefined : frostedSurfaceIntensity
+        }
       >
         {showCookieBanner ? <CookieBanner /> : null}
         <Notice shouldPadTop={false} />

--- a/packages/web/src/app/web-player/WebPlayer.tsx
+++ b/packages/web/src/app/web-player/WebPlayer.tsx
@@ -16,7 +16,6 @@ import {
 } from '@audius/common/api'
 import { Client, FrostedSurfaceIntensity, Status } from '@audius/common/models'
 import { StringKeys } from '@audius/common/services'
-import { themeSelectors } from '@audius/common/store'
 import {
   COIN_DETAIL_BUY_PAGE,
   CLUB_DETAIL_PAGE,
@@ -29,6 +28,7 @@ import {
   CLUBS_CREATE_PAGE,
   guestRoutes
 } from '@audius/common/src/utils/route'
+import { themeSelectors } from '@audius/common/store'
 import { route } from '@audius/common/utils'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'

--- a/packages/web/src/components/cookie-banner/CookieBanner.module.css
+++ b/packages/web/src/components/cookie-banner/CookieBanner.module.css
@@ -5,8 +5,6 @@
   opacity: 1;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 10px;
-  background-color: #1a1a1a;
-  color: rgba(255, 255, 255, 0.88);
   box-shadow:
     0 4px 24px rgba(0, 0, 0, 0.45),
     0 0 0 1px rgba(0, 0, 0, 0.2);
@@ -32,14 +30,12 @@
 .link {
   cursor: pointer;
   margin-left: 3px;
-  color: #fff;
   text-decoration: underline;
   text-underline-offset: 2px;
   text-decoration-color: rgba(255, 255, 255, 0.45);
 }
 
 .link:hover {
-  color: #fff;
   text-decoration-color: rgba(255, 255, 255, 0.75);
 }
 
@@ -57,7 +53,11 @@
   transition: all ease-in-out 0.07s;
 }
 
-.iconRemove path {
+.container:not(.isMobile) .iconRemove path {
+  fill: var(--harmony-neutral);
+}
+
+.isMobile .iconRemove path {
   fill: rgba(255, 255, 255, 0.75);
 }
 
@@ -65,7 +65,11 @@
   transform: scale(1.1);
 }
 
-.iconRemove:hover path {
+.container:not(.isMobile) .iconRemove:hover path {
+  fill: var(--harmony-neutral);
+}
+
+.isMobile .iconRemove:hover path {
   fill: #fff;
 }
 
@@ -76,11 +80,21 @@
 /* Mobile Styles */
 .isMobile {
   transition: all 0.07s ease-in-out;
+  background-color: #1a1a1a;
+  color: rgba(255, 255, 255, 0.88);
   bottom: 18px;
   left: 0px;
   right: 0px;
   margin: 0px 12px;
   max-width: none;
+}
+
+.isMobile .link {
+  color: #fff;
+}
+
+.isMobile .link:hover {
+  color: #fff;
 }
 
 .isMobile.isPlaying {

--- a/packages/web/src/components/cookie-banner/CookieBanner.tsx
+++ b/packages/web/src/components/cookie-banner/CookieBanner.tsx
@@ -7,6 +7,7 @@ import cn from 'classnames'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 
+import { Frosted } from 'components/frosted/Frosted'
 import { useIsMobile } from 'hooks/useIsMobile'
 import { dismissCookieBanner } from 'store/application/ui/cookieBanner/actions'
 import { AppState } from 'store/types'
@@ -33,13 +34,8 @@ export const CookieBanner = ({ isPlaying, dismiss }: CookieBannerProps) => {
     if (win) win.focus()
   }
 
-  return (
-    <div
-      className={cn(styles.container, {
-        [styles.isMobile]: isMobile,
-        [styles.isPlaying]: isPlaying
-      })}
-    >
+  const content = (
+    <>
       <div className={styles.description}>
         {messages.description}
         <span className={styles.link} onClick={goToCookiePolicy}>
@@ -49,7 +45,26 @@ export const CookieBanner = ({ isPlaying, dismiss }: CookieBannerProps) => {
       <div className={styles.iconContainer} onClick={dismiss}>
         <IconRemove className={styles.iconRemove} />
       </div>
+    </>
+  )
+
+  return isMobile ? (
+    <div
+      className={cn(styles.container, {
+        [styles.isMobile]: isMobile,
+        [styles.isPlaying]: isPlaying
+      })}
+    >
+      {content}
     </div>
+  ) : (
+    <Frosted
+      contentPaddingInline='0px'
+      direction='row'
+      className={styles.container}
+    >
+      {content}
+    </Frosted>
   )
 }
 

--- a/packages/web/src/components/edit/AnchoredSubmitRow.module.css
+++ b/packages/web/src/components/edit/AnchoredSubmitRow.module.css
@@ -9,10 +9,13 @@
 
   width: calc(100% - var(--nav-width));
 
-  background: var(--harmony-bg-surface-1);
+  z-index: 2; /* zIndex.ts: SVG_BUTTON_ICONS+1 */
+}
+
+.frosted {
+  width: 100%;
+  box-sizing: border-box;
   padding-top: var(--harmony-unit-3);
   padding-bottom: var(--harmony-unit-3);
-  border-top: 1px solid var(--harmony-border-strong);
-
-  z-index: 2; /* zIndex.ts: SVG_BUTTON_ICONS+1 */
+  border-top: 1px solid var(--harmony-border-default);
 }

--- a/packages/web/src/components/edit/AnchoredSubmitRow.tsx
+++ b/packages/web/src/components/edit/AnchoredSubmitRow.tsx
@@ -39,7 +39,7 @@ export const AnchoredSubmitRow = () => {
     <>
       <Portal>
         <div className={styles.buttonRow}>
-          <Frosted alignItems='center' gap='m'>
+          <Frosted className={styles.frosted} alignItems='center' gap='m'>
             <Button
               variant='primary'
               size='default'

--- a/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
+++ b/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
@@ -9,10 +9,13 @@
 
   width: calc(100% - var(--nav-width));
 
-  background: var(--harmony-bg-surface-1);
+  z-index: 2; /* zIndex.ts: SVG_BUTTON_ICONS+1 */
+}
+
+.frosted {
+  width: 100%;
+  box-sizing: border-box;
   padding-top: var(--harmony-unit-3);
   padding-bottom: var(--harmony-unit-3);
-  border-top: 1px solid var(--harmony-border-strong);
-
-  z-index: 2; /* zIndex.ts: SVG_BUTTON_ICONS+1 */
+  border-top: 1px solid var(--harmony-border-default);
 }

--- a/packages/web/src/components/edit/AnchoredSubmitRowEdit.tsx
+++ b/packages/web/src/components/edit/AnchoredSubmitRowEdit.tsx
@@ -53,7 +53,7 @@ export const AnchoredSubmitRowEdit = ({
     <>
       <Portal>
         <div className={styles.buttonRow}>
-          <Frosted alignItems='center' gap='m'>
+          <Frosted className={styles.frosted} alignItems='center' gap='m'>
             <Flex gap='l'>
               <Button
                 variant='secondary'

--- a/packages/web/src/components/frosted/Frosted.tsx
+++ b/packages/web/src/components/frosted/Frosted.tsx
@@ -18,12 +18,14 @@ export const Frosted = ({
       column
       css={[
         {
-          backdropFilter: 'blur(10px)',
+          backdropFilter: 'var(--frosted-surface-backdrop-filter, blur(10px))',
+          WebkitBackdropFilter:
+            'var(--frosted-surface-backdrop-filter, blur(10px))',
           zIndex: 10,
           position: 'relative',
           paddingInline: contentPaddingInline,
           background:
-            'color-mix(in srgb, var(--harmony-n-25) 60%, transparent)'
+            'var(--frosted-surface-background, color-mix(in srgb, var(--frosted-surface-background-color, var(--harmony-n-25)) var(--frosted-surface-opacity, 65%), transparent))'
         },
         css
       ]}

--- a/packages/web/src/components/frosted/Frosted.tsx
+++ b/packages/web/src/components/frosted/Frosted.tsx
@@ -1,22 +1,32 @@
 import { ReactNode } from 'react'
 
+import type { Interpolation, Theme } from '@emotion/react'
 import { Flex, FlexProps } from '@audius/harmony'
 
 export const Frosted = ({
   children,
   contentPaddingInline = 'var(--harmony-unit-15)',
+  css,
   ...props
-}: { children: ReactNode; contentPaddingInline?: string } & FlexProps) => {
+}: {
+  children: ReactNode
+  contentPaddingInline?: string
+  css?: Interpolation<Theme>
+} & FlexProps) => {
   return (
     <Flex
       column
-      css={{
-        backdropFilter: 'blur(10px)',
-        zIndex: 10,
-        position: 'relative',
-        paddingInline: contentPaddingInline,
-        background: 'color-mix(in srgb, var(--harmony-n-25) 60%, transparent)'
-      }}
+      css={[
+        {
+          backdropFilter: 'blur(10px)',
+          zIndex: 10,
+          position: 'relative',
+          paddingInline: contentPaddingInline,
+          background:
+            'color-mix(in srgb, var(--harmony-n-25) 60%, transparent)'
+        },
+        css
+      ]}
       {...props}
     >
       {children}

--- a/packages/web/src/components/frosted/Frosted.tsx
+++ b/packages/web/src/components/frosted/Frosted.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
-import type { Interpolation, Theme } from '@emotion/react'
 import { Flex, FlexProps } from '@audius/harmony'
+import type { Interpolation, Theme } from '@emotion/react'
 
 export const Frosted = ({
   children,

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -70,7 +70,6 @@ export const LeftNav = (props: OwnProps) => {
 
   return (
     <Flex
-      backgroundColor='surface1'
       borderRight='default'
       as='nav'
       id='leftNav'
@@ -82,7 +81,12 @@ export const LeftNav = (props: OwnProps) => {
         userSelect: 'none',
         overflowX: 'clip',
         overflowY: 'visible',
-        flexShrink: 0
+        flexShrink: 0,
+        backdropFilter: 'var(--frosted-surface-backdrop-filter, blur(10px))',
+        WebkitBackdropFilter:
+          'var(--frosted-surface-backdrop-filter, blur(10px))',
+        background:
+          'var(--frosted-surface-background, color-mix(in srgb, var(--frosted-surface-background-color, var(--harmony-n-25)) var(--frosted-surface-opacity, 65%), transparent))'
       }}
     >
       {isElectron ? <RouteNav /> : null}

--- a/packages/web/src/components/nav/desktop/NavHeader.tsx
+++ b/packages/web/src/components/nav/desktop/NavHeader.tsx
@@ -81,7 +81,7 @@ export const NavHeader = () => {
     return (
       <Flex
         direction='column'
-        backgroundColor='surface1'
+        borderBottom='default'
         flex={0}
         css={{ minHeight: 58, width: COLLAPSED_HEADER_WIDTH, flexShrink: 0 }}
       >
@@ -115,7 +115,7 @@ export const NavHeader = () => {
   return (
     <Flex
       alignItems='center'
-      backgroundColor='surface1'
+      borderBottom='default'
       justifyContent='space-between'
       pv='l'
       ph='m'

--- a/packages/web/src/components/page/Page.tsx
+++ b/packages/web/src/components/page/Page.tsx
@@ -16,12 +16,19 @@ const HEADER_MARGIN_PX = 32
 // Responsible for positioning the header
 type HeaderContainerProps = Pick<
   PageProps,
-  'header' | 'showSearch' | 'headerContentPaddingInline' | 'disableHeaderFrosted'
+  | 'header'
+  | 'showSearch'
+  | 'headerContentPaddingInline'
+  | 'disableHeaderFrosted'
 >
 
 const HeaderContainer = (props: HeaderContainerProps) => {
-  const { header, showSearch, headerContentPaddingInline, disableHeaderFrosted } =
-    props
+  const {
+    header,
+    showSearch,
+    headerContentPaddingInline,
+    disableHeaderFrosted
+  } = props
 
   const headerContainerRef = useRef<HTMLDivElement>(null)
   const headerElement = cloneElement(header as any, {

--- a/packages/web/src/components/page/Page.tsx
+++ b/packages/web/src/components/page/Page.tsx
@@ -16,22 +16,28 @@ const HEADER_MARGIN_PX = 32
 // Responsible for positioning the header
 type HeaderContainerProps = Pick<
   PageProps,
-  'header' | 'showSearch' | 'headerContentPaddingInline'
+  'header' | 'showSearch' | 'headerContentPaddingInline' | 'disableHeaderFrosted'
 >
 
 const HeaderContainer = (props: HeaderContainerProps) => {
-  const { header, showSearch, headerContentPaddingInline } = props
+  const { header, showSearch, headerContentPaddingInline, disableHeaderFrosted } =
+    props
 
   const headerContainerRef = useRef<HTMLDivElement>(null)
+  const headerElement = cloneElement(header as any, {
+    headerContainerRef,
+    topLeftElement: showSearch ? <DesktopSearchBar /> : null
+  })
 
   return (
     <div ref={headerContainerRef} className={styles.headerContainer}>
-      <Frosted contentPaddingInline={headerContentPaddingInline}>
-        {cloneElement(header as any, {
-          headerContainerRef,
-          topLeftElement: showSearch ? <DesktopSearchBar /> : null
-        })}
-      </Frosted>
+      {disableHeaderFrosted ? (
+        headerElement
+      ) : (
+        <Frosted contentPaddingInline={headerContentPaddingInline}>
+          {headerElement}
+        </Frosted>
+      )}
       {/* We attach the box shadow as a separate element to
           avoid overlapping the scroll bar.
       */}
@@ -52,6 +58,7 @@ type PageProps = {
   fadeDuration?: number
   header?: ReactNode
   headerContentPaddingInline?: string
+  disableHeaderFrosted?: boolean
 
   // There are some pages which don't have a fixed header but still display
   // a search bar that scrolls with the page.
@@ -79,6 +86,7 @@ export const Page = (props: PageProps) => {
     fromOpacity = 0.2,
     header,
     headerContentPaddingInline = 'var(--harmony-unit-8)',
+    disableHeaderFrosted = false,
     image,
     noIndex = false,
     ogDescription,
@@ -126,6 +134,7 @@ export const Page = (props: PageProps) => {
             header={header}
             showSearch={showSearch}
             headerContentPaddingInline={headerContentPaddingInline}
+            disableHeaderFrosted={disableHeaderFrosted}
           />
         )}
         <div

--- a/packages/web/src/components/play-bar/PlayBarProvider.module.css
+++ b/packages/web/src/components/play-bar/PlayBarProvider.module.css
@@ -18,6 +18,7 @@
   top: 0;
   right: 0;
   height: 1px;
-  background-color: var(--harmony-n-700);
-  opacity: 0.1;
+  z-index: 1;
+  pointer-events: none;
+  background-color: var(--harmony-border-default);
 }

--- a/packages/web/src/components/play-bar/desktop/PlayBar.module.css
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.module.css
@@ -3,7 +3,17 @@
   min-width: 320px;
   text-align: center;
   height: var(--play-bar-height);
-  background: var(--harmony-n-25);
+  backdrop-filter: var(--frosted-surface-backdrop-filter, blur(10px));
+  -webkit-backdrop-filter: var(--frosted-surface-backdrop-filter, blur(10px));
+  background: var(
+    --frosted-surface-background,
+    color-mix(
+      in srgb,
+      var(--frosted-surface-background-color, var(--harmony-n-25))
+        var(--frosted-surface-opacity, 65%),
+      transparent
+    )
+  );
   user-select: none;
 }
 

--- a/packages/web/src/pages/chat-page/ChatPage.module.css
+++ b/packages/web/src/pages/chat-page/ChatPage.module.css
@@ -1,4 +1,5 @@
 .page {
+  --chat-header-height: 112px;
   width: 100%;
   height: 100%;
   min-height: 0;
@@ -72,10 +73,14 @@
    * ChatComposer (grows with the track/collection preview, base ~88px). */
   --chat-pane-header-height: 112px;
   --chat-composer-height: 88px;
+  --chat-message-overlap-top: var(--chat-header-height, 112px);
 }
 
 .chatAreaNarrow {
-  --chat-pane-header-height: 60px;
+  --chat-pane-header-height: 80px;
+  --chat-message-overlap-top: calc(
+    var(--chat-header-height, 112px) + var(--chat-pane-header-height, 80px)
+  );
 }
 
 .chatPaneHeader {
@@ -88,6 +93,22 @@
   flex: 1;
   min-width: 0;
   min-height: 0;
+}
+
+.emptyState {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--harmony-unit-8);
+  box-sizing: border-box;
+}
+
+.emptyState > * {
+  margin: 0;
+  width: 100%;
 }
 
 .composer {

--- a/packages/web/src/pages/chat-page/ChatPage.module.css
+++ b/packages/web/src/pages/chat-page/ChatPage.module.css
@@ -1,5 +1,6 @@
 .page {
   --chat-header-height: 112px;
+  --chat-row-height: 80px;
   width: 100%;
   height: 100%;
   min-height: 0;
@@ -77,9 +78,9 @@
 }
 
 .chatAreaNarrow {
-  --chat-pane-header-height: 80px;
+  --chat-pane-header-height: var(--chat-row-height, 80px);
   --chat-message-overlap-top: calc(
-    var(--chat-header-height, 112px) + var(--chat-pane-header-height, 80px)
+    var(--chat-header-height, 112px) + var(--chat-pane-header-height)
   );
 }
 

--- a/packages/web/src/pages/chat-page/ChatPage.tsx
+++ b/packages/web/src/pages/chat-page/ChatPage.tsx
@@ -126,6 +126,7 @@ export const ChatPage = () => {
       showSearch={false}
       headerPadding={0}
       headerContentPaddingInline='0px'
+      disableHeaderFrosted
       header={
         <ChatHeader
           currentChatId={currentChatId}
@@ -173,7 +174,9 @@ export const ChatPage = () => {
               ) : null}
             </>
           ) : (
-            <CreateChatPrompt hasChats={!hideChatList} />
+            <div className={styles.emptyState}>
+              <CreateChatPrompt hasChats={!hideChatList} />
+            </div>
           )}
         </div>
       </div>

--- a/packages/web/src/pages/chat-page/components/ChatHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatHeader.tsx
@@ -16,6 +16,7 @@ import {
 import { useSelector } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
+import { Frosted } from 'components/frosted/Frosted'
 
 import { ChatBlastHeader } from './ChatBlastHeader'
 import { UserChatHeader } from './UserChatHeader'
@@ -75,32 +76,38 @@ export const ChatHeader = forwardRef<HTMLDivElement, ChatHeaderProps>(
     )
 
     return (
-      <Flex
-        ref={ref}
+      <Frosted
         w='100%'
-        h={112}
-        ph={CHAT_HEADER_PADDING_PX}
-        css={{ minWidth: 0, borderRadius: 0 }}
+        h='var(--chat-header-height, 112px)'
+        contentPaddingInline='0px'
         borderBottom='default'
       >
         <Flex
-          w={isNarrowLayout ? '100%' : CHAT_LIST_WIDTH_PX}
-          css={{ flexShrink: 0 }}
+          ref={ref}
+          w='100%'
+          h='var(--chat-header-height, 112px)'
+          ph={CHAT_HEADER_PADDING_PX}
+          css={{ minWidth: 0, borderRadius: 0 }}
         >
-          {headerContent}
-        </Flex>
-        {isNarrowLayout ? null : (
-          <Flex p='l' flex={1} alignItems='center' css={{ minWidth: 0 }}>
-            {chat ? (
-              isBlast ? (
-                <ChatBlastHeader chat={chat} />
-              ) : (
-                <UserChatHeader chatId={chat.chat_id} />
-              )
-            ) : null}
+          <Flex
+            w={isNarrowLayout ? '100%' : CHAT_LIST_WIDTH_PX}
+            css={{ flexShrink: 0 }}
+          >
+            {headerContent}
           </Flex>
-        )}
-      </Flex>
+          {isNarrowLayout ? null : (
+            <Flex p='l' flex={1} alignItems='center' css={{ minWidth: 0 }}>
+              {chat ? (
+                isBlast ? (
+                  <ChatBlastHeader chat={chat} />
+                ) : (
+                  <UserChatHeader chatId={chat.chat_id} />
+                )
+              ) : null}
+            </Flex>
+          )}
+        </Flex>
+      </Frosted>
     )
   }
 )

--- a/packages/web/src/pages/chat-page/components/ChatList.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatList.module.css
@@ -13,8 +13,8 @@
   /* Extend scroll container behind the frosted ChatHeader so
    * backdrop-filter has real content to blur (same pattern as ChatMessageList). */
   margin-top: calc(-1 * var(--chat-header-height, 112px));
-  padding-top: calc(var(--chat-header-height, 112px) + 8px);
-  scroll-padding-top: calc(var(--chat-header-height, 112px) + 8px);
+  padding-top: var(--chat-header-height, 112px);
+  scroll-padding-top: var(--chat-header-height, 112px);
 }
 
 .compact {

--- a/packages/web/src/pages/chat-page/components/ChatList.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatList.module.css
@@ -1,9 +1,20 @@
 .root {
-  height: 100%;
+  /* calc(100% + header) compensates for the negative margin-top so the
+   * scroll container spans from behind the ChatHeader all the way to the
+   * bottom of the layout. box-sizing: border-box absorbs padding-top into
+   * the declared height rather than adding to it. */
+  height: calc(100% + var(--chat-header-height, 112px));
+  box-sizing: border-box;
   min-height: 0;
   overflow-y: auto;
   background-color: var(--harmony-n-50);
   border-right: 1px solid var(--harmony-n-150);
+
+  /* Extend scroll container behind the frosted ChatHeader so
+   * backdrop-filter has real content to blur (same pattern as ChatMessageList). */
+  margin-top: calc(-1 * var(--chat-header-height, 112px));
+  padding-top: calc(var(--chat-header-height, 112px) + 8px);
+  scroll-padding-top: calc(var(--chat-header-height, 112px) + 8px);
 }
 
 .compact {

--- a/packages/web/src/pages/chat-page/components/ChatListItem.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatListItem.module.css
@@ -69,6 +69,12 @@
   justify-content: center;
 }
 
+.root.compact {
+  height: var(--chat-row-height, 80px);
+  box-sizing: border-box;
+  justify-content: center;
+}
+
 .root.compact .messagePreview,
 .root.compact .userText,
 .root.compact .unreadIndicatorTag,

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.module.css
@@ -1,5 +1,6 @@
 .root {
-  flex: 1;
+  flex: 0 0 auto;
+  height: calc(100% + var(--chat-header-height, 112px));
   min-width: 0;
   overflow-y: scroll;
   box-sizing: border-box;
@@ -9,10 +10,19 @@
    * scroll-padding properties keep the inner content 32px clear of the
    * chrome once scrolled to either edge, while letting the backdrop-filter
    * still pick up messages flowing behind them mid-scroll. */
-  margin-top: calc(-1 * var(--chat-pane-header-height, 112px));
+  margin-top: calc(-1 * var(--chat-message-overlap-top, 112px));
   margin-bottom: calc(-1 * var(--chat-composer-height, 88px));
-  padding-top: calc(var(--chat-pane-header-height, 112px) + 32px);
+  padding-top: calc(var(--chat-message-overlap-top, 112px) + 32px);
   padding-bottom: calc(var(--chat-composer-height, 88px) + 32px);
+}
+
+.emptyStateRoot {
+  flex: 1;
+  height: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .listRoot {
@@ -23,6 +33,18 @@
   padding-left: 32px;
   padding-right: 32px;
   min-width: 0;
+}
+
+.emptyListRoot {
+  flex-direction: column;
+  min-height: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.emptyListRoot > * {
+  margin: 0;
+  width: 100%;
 }
 
 .separator {

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -238,29 +238,37 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     }, [dispatch, chatId, chat, chatMessages])
 
     const unreadMessageCount = chatFrozenRef.current?.unread_message_count ?? 0
+    const showSendMessagePrompt =
+      chat?.messagesStatus === Status.SUCCESS &&
+      chatMessages?.length === 0 &&
+      !chat?.is_blast
+
     return (
       <StickyScrollList
         ref={mergeRefs([forwardedRef, ref])}
         onScroll={throttledScrollHandler}
-        className={cn(styles.root, classNameProp)}
+        className={cn(styles.root, classNameProp, {
+          [styles.emptyStateRoot]: showSendMessagePrompt
+        })}
         resetKey={chatId}
         updateKey={chatMessages}
         stickToBottom
         scrollBottomThreshold={SCROLL_BOTTOM_THRESHOLD}
         {...other}
       >
-        <div className={styles.listRoot} ref={messageListRef}>
+        <div
+          className={cn(styles.listRoot, {
+            [styles.emptyListRoot]: showSendMessagePrompt
+          })}
+          ref={messageListRef}
+        >
           {!canSendMessage && firstOtherUser ? (
             <InboxUnavailableMessage
               user={firstOtherUser}
               action={callToAction}
             />
           ) : null}
-          {chat?.messagesStatus === Status.SUCCESS &&
-          chatMessages?.length === 0 &&
-          !chat?.is_blast ? (
-            <SendMessagePrompt />
-          ) : null}
+          {showSendMessagePrompt ? <SendMessagePrompt /> : null}
           {chatId &&
             chatMessages?.map((message, i) => (
               <Fragment key={message.message_id}>

--- a/packages/web/src/pages/chat-page/components/ChatPaneHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatPaneHeader.tsx
@@ -33,7 +33,7 @@ export const ChatPaneHeader = (props: ChatPaneHeaderProps) => {
       w='100%'
       h={
         isNarrowLayout
-          ? 'var(--chat-pane-header-height, 80px)'
+          ? 'var(--chat-pane-header-height, var(--chat-row-height, 80px))'
           : CHAT_PANE_HEADER_HEIGHT_PX
       }
       contentPaddingInline='0px'

--- a/packages/web/src/pages/chat-page/components/ChatPaneHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatPaneHeader.tsx
@@ -31,7 +31,11 @@ export const ChatPaneHeader = (props: ChatPaneHeaderProps) => {
   return (
     <Frosted
       w='100%'
-      h={isNarrowLayout ? undefined : CHAT_PANE_HEADER_HEIGHT_PX}
+      h={
+        isNarrowLayout
+          ? 'var(--chat-pane-header-height, 80px)'
+          : CHAT_PANE_HEADER_HEIGHT_PX
+      }
       contentPaddingInline='0px'
       css={{
         borderRadius: 0,

--- a/packages/web/src/pages/chat-page/components/CreateChatPrompt.module.css
+++ b/packages/web/src/pages/chat-page/components/CreateChatPrompt.module.css
@@ -5,7 +5,7 @@
   gap: var(--harmony-unit-6);
 
   min-width: 220px;
-  max-width: 700px;
+  max-width: 550px;
   margin-top: var(--harmony-unit-8);
   margin-left: var(--harmony-unit-8);
   margin-right: var(--harmony-unit-8);

--- a/packages/web/src/pages/chat-page/components/SendMessagePrompt.module.css
+++ b/packages/web/src/pages/chat-page/components/SendMessagePrompt.module.css
@@ -1,6 +1,6 @@
 .root {
   min-width: 220px;
-  max-width: 700px;
+  max-width: 550px;
   margin-top: var(--harmony-unit-8);
   margin-left: var(--harmony-unit-8);
   margin-right: var(--harmony-unit-8);

--- a/packages/web/src/pages/fan-clubs-explore-page/FanClubsExplorePage.tsx
+++ b/packages/web/src/pages/fan-clubs-explore-page/FanClubsExplorePage.tsx
@@ -8,7 +8,6 @@ import { useFeatureFlag } from '@audius/common/hooks'
 import { walletMessages } from '@audius/common/messages'
 import { FeatureFlags } from '@audius/common/services'
 import { COINS_CREATE_PAGE, clubPage } from '@audius/common/src/utils/route'
-import { convertHexToRGBA } from '@audius/common/utils'
 import {
   Box,
   Button,
@@ -17,7 +16,6 @@ import {
   IconButton,
   IconClose,
   IconVerified,
-  Paper,
   SelectablePill,
   Text,
   TextInput,
@@ -30,6 +28,7 @@ import { useNavigate } from 'react-router'
 
 import imageCoinsBackgroundImage from 'assets/img/imageCoinsBackgroundImage2x.webp'
 import { MIN_DESKTOP_CONTENT_WIDTH_PX } from 'common/utils/layout'
+import { Frosted } from 'components/frosted/Frosted'
 import Page from 'components/page/Page'
 import { useIsContainerNarrow } from 'hooks/useIsContainerNarrow'
 import { usePortal } from 'hooks/usePortal'
@@ -73,7 +72,7 @@ const messages = {
 // Desktop version
 const DesktopFanClubsExplorePage = () => {
   const navigate = useNavigate()
-  const { motion, spacing, color } = useTheme()
+  const { motion, spacing } = useTheme()
   const pageContentRef = useRef<HTMLDivElement>(null)
   const controlsRowRef = useRef<HTMLDivElement>(null)
   const isNarrowLayout = useIsContainerNarrow(pageContentRef, 760)
@@ -146,12 +145,6 @@ const DesktopFanClubsExplorePage = () => {
     shouldShowLaunchCta && !isLaunchBannerDismissed
       ? spacing.xl + spacing['5xl'] + spacing['3xl']
       : 0
-
-  const bannerSurface =
-    typeof color.background.surface1 === 'string' &&
-    color.background.surface1.startsWith('#')
-      ? convertHexToRGBA(color.background.surface1, 0.78)
-      : 'rgba(255, 255, 255, 0.78)'
 
   const viewModeOptions = [
     {
@@ -337,17 +330,15 @@ const DesktopFanClubsExplorePage = () => {
               zIndex: zIndex.NAVIGATOR_POPUP
             }}
           >
-            <Paper
-              border='strong'
+            <Frosted
+              contentPaddingInline='0px'
+              border='default'
               borderRadius='m'
-              shadow='mid'
               w='100%'
               css={{
                 position: 'relative',
                 overflow: 'hidden',
-                backdropFilter: 'blur(20px)',
-                WebkitBackdropFilter: 'blur(20px)',
-                backgroundColor: bannerSurface,
+                boxShadow: 'var(--harmony-shadow-mid)',
                 transition: `opacity ${motion.expressive}`
               }}
             >
@@ -383,16 +374,15 @@ const DesktopFanClubsExplorePage = () => {
                     {messages.launchYourOwn}
                   </Text>
                   <Tooltip text={messages.getStartedTooltip} placement='top'>
-                    <Flex
+                    <Frosted
+                      contentPaddingInline='0px'
+                      direction='row'
                       alignItems='center'
                       border='strong'
                       borderRadius='m'
                       css={{
                         alignSelf: 'flex-start',
-                        overflow: 'hidden',
-                        backgroundColor: bannerSurface,
-                        backdropFilter: 'blur(12px)',
-                        WebkitBackdropFilter: 'blur(12px)'
+                        overflow: 'hidden'
                       }}
                     >
                       <Flex ph='s' pv='xs'>
@@ -407,7 +397,7 @@ const DesktopFanClubsExplorePage = () => {
                       >
                         <IconVerified size='s' />
                       </Flex>
-                    </Flex>
+                    </Frosted>
                   </Tooltip>
                 </Flex>
                 <Box
@@ -428,7 +418,7 @@ const DesktopFanClubsExplorePage = () => {
                   </Button>
                 </Box>
               </Flex>
-            </Paper>
+            </Frosted>
           </Box>
         ) : null}
       </Portal>

--- a/packages/web/src/pages/fan-clubs-launchpad-page/components/FanClubsSubmitRow.tsx
+++ b/packages/web/src/pages/fan-clubs-launchpad-page/components/FanClubsSubmitRow.tsx
@@ -43,7 +43,7 @@ export const FanClubsSubmitRow = ({
   isValid: isValidProp,
   errorText
 }: FanClubsSubmitRowProps) => {
-  const { color, spacing } = useTheme()
+  const { spacing } = useTheme()
   const { isValid: isEntireFormValid } = useFormikContext()
   const isFormValid = isValidProp ?? isEntireFormValid
   const [showError, setShowError] = useState(false)
@@ -71,7 +71,7 @@ export const FanClubsSubmitRow = ({
           left: 'var(--nav-width)',
           width: 'calc(100% - var(--nav-width))',
           padding: spacing.unit3,
-          borderTop: `1px solid ${color.border.strong}`,
+          borderTop: '1px solid var(--harmony-border-default)',
           zIndex: zIndex.NAVIGATOR_POPUP
         }}
         direction='column'

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsCard.module.css
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsCard.module.css
@@ -58,4 +58,8 @@
   .settingsCardFull {
     text-align: center;
   }
+
+  .description {
+    text-align: left;
+  }
 }

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.module.css
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.module.css
@@ -47,6 +47,18 @@
   flex: 1 1 100%;
 }
 
+.matrixDisabledControl {
+  opacity: 0.2;
+}
+
+.matrixDisabledControl > div {
+  opacity: 1;
+}
+
+.matrixDisabledSegmentedControl {
+  opacity: 1 !important;
+}
+
 .showPrivateKey {
   line-height: var(--harmony-unit-5);
 }

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.module.css
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.module.css
@@ -47,6 +47,29 @@
   flex: 1 1 100%;
 }
 
+.appearanceControls {
+  text-align: left;
+}
+
+.appearanceControlRow {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  align-items: end;
+  gap: var(--harmony-unit-4);
+  width: 100%;
+}
+
+.appearanceControl {
+  align-items: stretch;
+  min-width: 0;
+  text-align: left;
+}
+
+.appearanceThemeControl {
+  width: max-content;
+  max-width: 100%;
+}
+
 .matrixDisabledControl {
   opacity: 0.2;
 }
@@ -61,4 +84,10 @@
 
 .showPrivateKey {
   line-height: var(--harmony-unit-5);
+}
+
+@media (max-width: 990px) {
+  .appearanceControlRow {
+    grid-template-columns: 1fr;
+  }
 }

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -3,7 +3,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useCurrentAccountUser, useQueryContext } from '@audius/common/api'
 import { useIsManagedAccount } from '@audius/common/hooks'
 import { settingsMessages } from '@audius/common/messages'
-import { Name, Theme, ThemeMode, ThemePalette } from '@audius/common/models'
+import {
+  FrostedSurfaceIntensity,
+  Name,
+  Theme,
+  ThemeMode,
+  ThemePalette
+} from '@audius/common/models'
 import { API_TERMS, FAN_CLUB_TERMS } from '@audius/common/src/utils/route'
 import {
   BrowserNotificationSetting,
@@ -67,7 +73,12 @@ import {
 import { isElectron } from 'utils/clientUtil'
 import { push } from 'utils/navigation'
 import { useSelector } from 'utils/reducer'
-import { THEME_KEY, THEME_MODE_KEY, THEME_PALETTE_KEY } from 'utils/theme/theme'
+import {
+  FROSTED_SURFACE_INTENSITY_KEY,
+  THEME_KEY,
+  THEME_MODE_KEY,
+  THEME_PALETTE_KEY
+} from 'utils/theme/theme'
 
 import packageInfo from '../../../../../package.json'
 
@@ -85,8 +96,18 @@ import { WormholeConversionSettingsCard } from './WormholeConversionSettingsCard
 
 const { show } = musicConfettiActions
 const { signOut: signOutAction } = signOutActions
-const { setTheme, setThemePalette, setThemeMode } = themeActions
-const { getTheme, getThemePalette, getThemeMode } = themeSelectors
+const {
+  setTheme,
+  setThemePalette,
+  setThemeMode,
+  setFrostedSurfaceIntensity
+} = themeActions
+const {
+  getTheme,
+  getThemePalette,
+  getThemeMode,
+  getFrostedSurfaceIntensity
+} = themeSelectors
 const { getBrowserNotificationSettings, getEmailFrequency } =
   settingsPageSelectors
 const {
@@ -141,6 +162,7 @@ export const SettingsPage = () => {
   const theme = useSelector(getTheme)
   const themePalette = useSelector(getThemePalette)
   const themeMode = useSelector(getThemeMode)
+  const frostedSurfaceIntensity = useSelector(getFrostedSurfaceIntensity)
   const emailFrequency = useSelector(getEmailFrequency)
   const notificationSettings = useSelector(getBrowserNotificationSettings)
   const { tier } = useTierAndVerifiedForUser(userId)
@@ -349,6 +371,8 @@ export const SettingsPage = () => {
       : theme === Theme.DARK
         ? ThemeMode.DARK
         : ThemeMode.AUTO)
+  const effectiveFrostedSurfaceIntensity =
+    frostedSurfaceIntensity ?? FrostedSurfaceIntensity.DEFAULT
 
   const onPaletteChange = (value: ThemePalette) => {
     dispatch(setThemePalette({ themePalette: value }))
@@ -390,6 +414,19 @@ export const SettingsPage = () => {
     )
   }
 
+  const onFrostedSurfaceIntensityChange = (
+    value: FrostedSurfaceIntensity
+  ) => {
+    dispatch(
+      setFrostedSurfaceIntensity({
+        frostedSurfaceIntensity: value
+      })
+    )
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(FROSTED_SURFACE_INTENSITY_KEY, value)
+    }
+  }
+
   const paletteOptions = useMemo(() => {
     const options: { value: ThemePalette; label: string }[] = [
       { value: ThemePalette.DEFAULT, label: settingsMessages.defaultPalette },
@@ -413,6 +450,28 @@ export const SettingsPage = () => {
     []
   )
 
+  const frostedSurfaceIntensityOptions = useMemo(
+    () => [
+      {
+        key: FrostedSurfaceIntensity.OFF,
+        text: settingsMessages.surfaceStyleSolid
+      },
+      {
+        key: FrostedSurfaceIntensity.SUBTLE,
+        text: settingsMessages.surfaceStyleSubtle
+      },
+      {
+        key: FrostedSurfaceIntensity.DEFAULT,
+        text: settingsMessages.surfaceStyleDefault
+      },
+      {
+        key: FrostedSurfaceIntensity.STRONG,
+        text: settingsMessages.surfaceStyleStrong
+      }
+    ],
+    []
+  )
+
   const isMobile = useIsMobile()
   const isDownloadDesktopEnabled = !isMobile && !isElectron()
 
@@ -432,27 +491,64 @@ export const SettingsPage = () => {
             title={settingsMessages.appearanceTitle}
             description={settingsMessages.appearanceDescription}
             isFull={true}
-            headerAction={
-              <FilterButton<ThemePalette>
-                label={settingsMessages.appearanceTitle}
-                value={effectivePalette}
-                options={paletteOptions}
-                onChange={(value) => onPaletteChange(value)}
-                variant='replaceLabel'
-                optionsLabel='Theme'
-              />
-            }
           >
-            {effectivePalette !== ThemePalette.MATRIX ? (
-              <SegmentedControl
-                fullWidth
-                label='Color mode'
-                options={modeOptions}
-                selected={effectiveMode}
-                onSelectOption={(option) => onModeChange(option)}
-                key={`tab-slider-${effectivePalette}`}
-              />
-            ) : null}
+            <Flex column gap='l'>
+              <Flex gap='l' alignItems='flex-end' css={{ flexWrap: 'wrap' }}>
+                <Flex column gap='s' css={{ flex: '0 0 180px' }}>
+                  <Text variant='label' size='s'>
+                    {settingsMessages.themeLabel}
+                  </Text>
+                  <FilterButton<ThemePalette>
+                    label={settingsMessages.themeLabel}
+                    value={effectivePalette}
+                    options={paletteOptions}
+                    onChange={(value) => onPaletteChange(value)}
+                    variant='replaceLabel'
+                    optionsLabel={settingsMessages.themeLabel}
+                  />
+                </Flex>
+                <Flex
+                  column
+                  gap='s'
+                  className={cn({
+                    [styles.matrixDisabledControl]:
+                      effectivePalette === ThemePalette.MATRIX
+                  })}
+                  css={{ flex: '1 1 320px' }}
+                >
+                  <Text variant='label' size='s'>
+                    {settingsMessages.colorModeLabel}
+                  </Text>
+                  <SegmentedControl
+                    fullWidth
+                    disabled={effectivePalette === ThemePalette.MATRIX}
+                    className={cn({
+                      [styles.matrixDisabledSegmentedControl]:
+                        effectivePalette === ThemePalette.MATRIX
+                    })}
+                    label={settingsMessages.colorModeLabel}
+                    options={modeOptions}
+                    selected={effectiveMode}
+                    onSelectOption={(option) => onModeChange(option)}
+                    key={`tab-slider-${effectivePalette}`}
+                  />
+                </Flex>
+              </Flex>
+              <Flex column gap='s'>
+                <Text variant='label' size='s'>
+                  {settingsMessages.surfaceStyleLabel}
+                </Text>
+                <SegmentedControl
+                  fullWidth
+                  label={settingsMessages.surfaceStyleLabel}
+                  options={frostedSurfaceIntensityOptions}
+                  selected={effectiveFrostedSurfaceIntensity}
+                  onSelectOption={(option) =>
+                    onFrostedSurfaceIntensityChange(option)
+                  }
+                />
+              </Flex>
+            </Flex>
           </SettingsCard>
         ) : null}
         {!isManagedAccount ? (

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -96,18 +96,10 @@ import { WormholeConversionSettingsCard } from './WormholeConversionSettingsCard
 
 const { show } = musicConfettiActions
 const { signOut: signOutAction } = signOutActions
-const {
-  setTheme,
-  setThemePalette,
-  setThemeMode,
-  setFrostedSurfaceIntensity
-} = themeActions
-const {
-  getTheme,
-  getThemePalette,
-  getThemeMode,
-  getFrostedSurfaceIntensity
-} = themeSelectors
+const { setTheme, setThemePalette, setThemeMode, setFrostedSurfaceIntensity } =
+  themeActions
+const { getTheme, getThemePalette, getThemeMode, getFrostedSurfaceIntensity } =
+  themeSelectors
 const { getBrowserNotificationSettings, getEmailFrequency } =
   settingsPageSelectors
 const {
@@ -414,9 +406,7 @@ export const SettingsPage = () => {
     )
   }
 
-  const onFrostedSurfaceIntensityChange = (
-    value: FrostedSurfaceIntensity
-  ) => {
+  const onFrostedSurfaceIntensityChange = (value: FrostedSurfaceIntensity) => {
     dispatch(
       setFrostedSurfaceIntensity({
         frostedSurfaceIntensity: value

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -492,10 +492,17 @@ export const SettingsPage = () => {
             description={settingsMessages.appearanceDescription}
             isFull={true}
           >
-            <Flex column gap='l'>
-              <Flex gap='l' alignItems='flex-end' css={{ flexWrap: 'wrap' }}>
-                <Flex column gap='s' css={{ flex: '0 0 180px' }}>
-                  <Text variant='label' size='s'>
+            <Flex column gap='l' className={styles.appearanceControls}>
+              <div className={styles.appearanceControlRow}>
+                <Flex
+                  column
+                  gap='s'
+                  className={cn(
+                    styles.appearanceControl,
+                    styles.appearanceThemeControl
+                  )}
+                >
+                  <Text variant='label' size='s' textAlign='left'>
                     {settingsMessages.themeLabel}
                   </Text>
                   <FilterButton<ThemePalette>
@@ -510,13 +517,12 @@ export const SettingsPage = () => {
                 <Flex
                   column
                   gap='s'
-                  className={cn({
+                  className={cn(styles.appearanceControl, {
                     [styles.matrixDisabledControl]:
                       effectivePalette === ThemePalette.MATRIX
                   })}
-                  css={{ flex: '1 1 320px' }}
                 >
-                  <Text variant='label' size='s'>
+                  <Text variant='label' size='s' textAlign='left'>
                     {settingsMessages.colorModeLabel}
                   </Text>
                   <SegmentedControl
@@ -533,9 +539,9 @@ export const SettingsPage = () => {
                     key={`tab-slider-${effectivePalette}`}
                   />
                 </Flex>
-              </Flex>
-              <Flex column gap='s'>
-                <Text variant='label' size='s'>
+              </div>
+              <Flex column gap='s' className={styles.appearanceControl}>
+                <Text variant='label' size='s' textAlign='left'>
                   {settingsMessages.surfaceStyleLabel}
                 </Text>
                 <SegmentedControl

--- a/packages/web/src/utils/theme/theme.ts
+++ b/packages/web/src/utils/theme/theme.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import {
+  FrostedSurfaceIntensity,
   SystemAppearance,
   Theme,
   ThemeMode,
@@ -18,6 +19,7 @@ export { getLottieThemeColors }
 export const THEME_KEY = 'theme'
 export const THEME_PALETTE_KEY = 'themePalette'
 export const THEME_MODE_KEY = 'themeMode'
+export const FROSTED_SURFACE_INTENSITY_KEY = 'frostedSurfaceIntensity'
 export const PREFERS_DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)'
 
 const doesPreferDarkMode = () => {
@@ -76,6 +78,21 @@ export const getThemeModeFromStorage = (): ThemeMode | null => {
   if (theme === Theme.DARK) return ThemeMode.DARK
   return ThemeMode.AUTO
 }
+
+export const getFrostedSurfaceIntensityFromStorage =
+  (): FrostedSurfaceIntensity | null => {
+    if (typeof window === 'undefined') return null
+    const stored = window.localStorage.getItem(FROSTED_SURFACE_INTENSITY_KEY)
+    if (
+      stored &&
+      Object.values(FrostedSurfaceIntensity).includes(
+        stored as FrostedSurfaceIntensity
+      )
+    ) {
+      return stored as FrostedSurfaceIntensity
+    }
+    return null
+  }
 
 export const getSystemAppearance = () =>
   doesPreferDarkMode() ? SystemAppearance.DARK : SystemAppearance.LIGHT


### PR DESCRIPTION
## Summary
- Adds a desktop appearance setting for frosted surface intensity.
- Applies the selected glass effect across desktop shell surfaces like nav, headers, playbar, cookie banner, and chat.
- Refines chat/settings layout to better support the frosted visual treatment.