### PR TITLE
Fetch current account from server on refresh

### DIFF
--- a/.changeset/fix-account-cross-device-sync.md
+++ b/.changeset/fix-account-cross-device-sync.md
@@ -1,0 +1,5 @@
+---
+"@audius/common": patch
+---
+
+Fix cross-device account sync so refreshing on Device B picks up edits made on Device A instead of showing stale localStorage data

--- a/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
@@ -61,45 +61,50 @@ export const getCurrentAccountQueryFn = async (
   currentUserWallet: string | null,
   queryClient: QueryClient
 ): Promise<AccountState | null | undefined> => {
-  const localAccount = getLocalAccount(localStorage, queryClient)
-  if (localAccount) {
-    return localAccount
-  }
-
   if (!currentUserWallet) {
-    return null
+    // No wallet yet (bootstrap); fall back to cached account if present
+    return getLocalAccount(localStorage, queryClient)
   }
 
-  const { data } = await sdk.users.getUserAccount({
-    wallet: currentUserWallet!
-  })
+  try {
+    const { data } = await sdk.users.getUserAccount({
+      wallet: currentUserWallet
+    })
 
-  if (!data) {
-    console.warn('Missing user from account response')
-    return null
+    if (!data) {
+      console.warn('Missing user from account response')
+      return getLocalAccount(localStorage, queryClient)
+    }
+
+    const account = accountFromSDK(data)
+    if (account) {
+      queryClient.setQueryData(getAccountStatusQueryKey(), Status.SUCCESS)
+      primeUserData({ users: [account.user], queryClient })
+    } else {
+      queryClient.setQueryData(getAccountStatusQueryKey(), Status.ERROR)
+    }
+
+    return {
+      collections: account?.playlists,
+      userId: account?.user?.user_id,
+      hasTracks: (account?.user?.track_count ?? 0) > 0,
+      status: account ? Status.SUCCESS : Status.ERROR,
+      reason: null,
+      connectivityFailure: false,
+      needsAccountRecovery: false,
+      walletAddresses: { currentUser: null, web3User: null },
+      playlistLibrary: account?.playlist_library ?? null,
+      trackSaveCount: account?.track_save_count ?? null,
+      guestEmail: null
+    } as AccountState
+  } catch (e) {
+    // On server error (e.g. offline), fall back to the cached account
+    console.warn(
+      'Failed to fetch current account, falling back to local cache',
+      e
+    )
+    return getLocalAccount(localStorage, queryClient)
   }
-
-  const account = accountFromSDK(data)
-  if (account) {
-    queryClient.setQueryData(getAccountStatusQueryKey(), Status.SUCCESS)
-    primeUserData({ users: [account.user], queryClient })
-  } else {
-    queryClient.setQueryData(getAccountStatusQueryKey(), Status.ERROR)
-  }
-
-  return {
-    collections: account?.playlists,
-    userId: account?.user?.user_id,
-    hasTracks: (account?.user?.track_count ?? 0) > 0,
-    status: account ? Status.SUCCESS : Status.ERROR,
-    reason: null,
-    connectivityFailure: false,
-    needsAccountRecovery: false,
-    walletAddresses: { currentUser: null, web3User: null },
-    playlistLibrary: account?.playlist_library ?? null,
-    trackSaveCount: account?.track_save_count ?? null,
-    guestEmail: null
-  } as AccountState
 }
 
 /**
@@ -123,6 +128,10 @@ export const useCurrentAccount = <TResult = AccountState | null | undefined>(
         currentUserWallet!,
         queryClient
       ),
+    // Render cached account immediately while fresh data loads, so the UI
+    // doesn't flash empty but server data still wins once it arrives.
+    placeholderData: () =>
+      getLocalAccount(localStorage, queryClient) ?? undefined,
     staleTime: Infinity,
     gcTime: Infinity,
     enabled: options?.enabled !== false && !!currentUserWallet,


### PR DESCRIPTION
## Summary

Fixes a cross-device sync bug where account edits made on one device are never picked up on another device after refresh — the user just keeps seeing their old locally-cached data.

### Root cause

`getCurrentAccountQueryFn` in `packages/common/src/api/tan-query/users/account/useCurrentAccount.ts` returned the cached localStorage account early (lines 64–67 before the fix) and never called `sdk.users.getUserAccount` when the cache was populated. Combined with `staleTime: Infinity` on the query, this meant React Query would treat that cached result as fresh forever, so no server fetch would ever replace it after an app reload.

### Fix

- Always call the server when a wallet is available — server data wins.
- Fall back to the local cache only when there is no wallet yet (bootstrap) or the request fails (offline).
- Surface the cached account immediately via `placeholderData` so the UI still renders instantly and doesn't flash empty while the server request is in flight.

## Test plan

- [ ] Log in on Device A, edit a profile field (e.g. display name / location / playlist library), and confirm it persists server-side.
- [ ] On Device B, refresh the web app and confirm the UI updates to the new value instead of showing the old localStorage-cached value.
- [ ] Sign out / sign in flow still works (no regression in the wallet-less bootstrap path).
- [ ] Offline / airplane-mode refresh still renders cached account data (falls back via the `catch` branch).
- [ ] Initial load feels no slower than before — cached account renders instantly via `placeholderData`.
- [ ] `npm run typecheck` in `packages/common` passes.

https://claude.ai/code/session_015dyBojkU9LhH5C7QhNTefa

---
_Generated by [Claude Code](https://claude.ai/code/session_015dyBojkU9LhH5C7QhNTefa)_