### PR TITLE
Contest flow follow-ups: stems UI, follow + comment cache, download caret

### DIFF
--- a/packages/common/src/api/tan-query/comments/usePostEventComment.ts
+++ b/packages/common/src/api/tan-query/comments/usePostEventComment.ts
@@ -5,7 +5,8 @@ import { useQueryContext } from '~/api/tan-query/utils'
 import { Comment, Feature, ID } from '~/models'
 import { toast } from '~/store/ui/toast/slice'
 
-import { getEventCommentsQueryKey } from './useEventComments'
+import { QUERY_KEYS } from '../queryKeys'
+
 import { getCommentQueryKey } from './utils'
 
 export type PostEventCommentArgs = {
@@ -76,29 +77,28 @@ export const usePostEventComment = () => {
 
       // Only optimistically push top-level comments to the feed; replies are
       // nested inside their parent comment and come back on invalidation.
+      // Patch every cached sort variant ('top' / 'newest' / 'timestamp') so
+      // the comment shows up regardless of which tab the user is viewing.
       if (!args.parentCommentId) {
-        const feedQueryKey = getEventCommentsQueryKey({
-          eventId,
-          sortMethod: 'newest'
-        })
-        queryClient.setQueryData(feedQueryKey, (prevData: any) => {
-          if (!prevData) return prevData
-          const next = structuredClone(prevData)
-          if (next.pages?.[0]) {
-            next.pages[0].unshift({ commentId: newId })
+        queryClient.setQueriesData<any>(
+          { queryKey: [QUERY_KEYS.eventComments, eventId] },
+          (prevData: any) => {
+            if (!prevData) return prevData
+            const next = structuredClone(prevData)
+            if (next.pages?.[0]) {
+              next.pages[0].unshift({ commentId: newId })
+            }
+            return next
           }
-          return next
-        })
+        )
       }
 
       return { newId }
     },
     onSuccess: (_data, args) => {
+      // Invalidate every sort variant — the user might be on Top or Newest.
       queryClient.invalidateQueries({
-        queryKey: getEventCommentsQueryKey({
-          eventId: args.eventId,
-          sortMethod: 'newest'
-        })
+        queryKey: [QUERY_KEYS.eventComments, args.eventId]
       })
     },
     onError: (error: Error, args) => {
@@ -112,10 +112,7 @@ export const usePostEventComment = () => {
         content: 'There was an error posting your comment. Please try again.'
       })
       queryClient.invalidateQueries({
-        queryKey: getEventCommentsQueryKey({
-          eventId: args.eventId,
-          sortMethod: 'newest'
-        })
+        queryKey: [QUERY_KEYS.eventComments, args.eventId]
       })
     }
   })

--- a/packages/common/src/api/tan-query/events/useCreateEvent.ts
+++ b/packages/common/src/api/tan-query/events/useCreateEvent.ts
@@ -6,6 +6,8 @@ import { useQueryContext } from '~/api/tan-query/utils'
 import { Event, Feature, ID } from '~/models'
 import { toast } from '~/store/ui/toast/slice'
 
+import { QUERY_KEYS } from '../queryKeys'
+
 import { getEventQueryKey, getEventIdsByEntityIdQueryKey } from './utils'
 
 export type CreateEventArgs = {
@@ -26,6 +28,11 @@ export const useCreateEvent = () => {
     mutationFn: async (args: CreateEventArgs) => {
       const sdk = await audiusSdk()
       return await sdk.events.createEvent(args)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.remixContestsList]
+      })
     },
     onMutate: async (args: CreateEventArgs) => {
       const { userId, eventType, entityType, entityId, endDate, eventData } =

--- a/packages/common/src/api/tan-query/events/useFollowEvent.ts
+++ b/packages/common/src/api/tan-query/events/useFollowEvent.ts
@@ -107,6 +107,11 @@ export const useFollowEvent = () => {
       queryClient.invalidateQueries({
         queryKey: getEventFollowStateQueryKey(eventId, userId)
       })
+      // Also refresh the followers avatar list so the user's avatar
+      // appears in the leaderboard card / modal without a refresh.
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.eventFollowers, eventId]
+      })
     }
   })
 }
@@ -147,6 +152,9 @@ export const useUnfollowEvent = () => {
     onSettled: (_data, _err, { userId, eventId }) => {
       queryClient.invalidateQueries({
         queryKey: getEventFollowStateQueryKey(eventId, userId)
+      })
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.eventFollowers, eventId]
       })
     }
   })

--- a/packages/common/src/api/tan-query/events/useUpdateEvent.ts
+++ b/packages/common/src/api/tan-query/events/useUpdateEvent.ts
@@ -5,6 +5,8 @@ import { useQueryContext } from '~/api/tan-query/utils'
 import { Event, Feature, ID } from '~/models'
 import { toast } from '~/store/ui/toast/slice'
 
+import { QUERY_KEYS } from '../queryKeys'
+
 import { getEventQueryKey } from './utils'
 
 export type UpdateEventArgs = {
@@ -25,6 +27,11 @@ export const useUpdateEvent = () => {
     mutationFn: async (args: UpdateEventArgs) => {
       const sdk = await audiusSdk()
       return await sdk.events.updateEvent({ ...args })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.remixContestsList]
+      })
     },
     onMutate: async (args: UpdateEventArgs) => {
       const { eventId, ...updates } = args

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -192,6 +192,11 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
   const hasStems = stemTracks.length > 0 || isUploadingStems
   const downloadButtonText = hasStems ? messages.downloadAll : messages.download
 
+  // No caret / no expandable list when there's a single downloadable track
+  // (download original ON, no stems). Tapping the row's download button
+  // should be the entire interaction — there's nothing to expand.
+  const isSingleTrackDownload = !!is_downloadable && !hasStems
+
   const handleDownloadButtonClick = useRequiresAccountCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
@@ -244,13 +249,13 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
           justifyContent='space-between'
           alignItems='center'
           p='l'
-          onClick={onToggleExpand}
+          onClick={isSingleTrackDownload ? undefined : onToggleExpand}
           css={{
-            cursor: 'pointer'
+            cursor: isSingleTrackDownload ? 'default' : 'pointer'
           }}
-          role='button'
-          aria-expanded={expanded}
-          aria-controls='download-section'
+          role={isSingleTrackDownload ? undefined : 'button'}
+          aria-expanded={isSingleTrackDownload ? undefined : expanded}
+          aria-controls={isSingleTrackDownload ? undefined : 'download-section'}
         >
           <Flex
             justifyContent='space-between'
@@ -316,14 +321,16 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
             ) : null}
           </Flex>
 
-          <IconCaretDown
-            css={{
-              transition: 'transform var(--harmony-expressive)',
-              transform: expanded ? 'rotate(-180deg)' : undefined
-            }}
-            size='m'
-            color='default'
-          />
+          {isSingleTrackDownload ? null : (
+            <IconCaretDown
+              css={{
+                transition: 'transform var(--harmony-expressive)',
+                transform: expanded ? 'rotate(-180deg)' : undefined
+              }}
+              size='m'
+              color='default'
+            />
+          )}
         </Flex>
         {shouldDisplayOwnerPremiumDownloads && formattedPrice ? (
           <Flex pl='l' pr='l' pb='l'>

--- a/packages/web/src/pages/contest-page/components/EventFollowersCard.tsx
+++ b/packages/web/src/pages/contest-page/components/EventFollowersCard.tsx
@@ -76,28 +76,30 @@ export const EventFollowersCard = ({
         </Text>
       </Flex>
 
-      {hasAny ? (
+      {followerCount > 0 ? (
         <Flex alignItems='center' justifyContent='space-between' gap='s'>
           <Flex>
-            {visibleIds.map((userId, idx) => (
-              <Box
-                key={userId}
-                css={{
-                  // Overlap each subsequent avatar over the previous
-                  // to produce the stacked "face pile" look.
-                  marginLeft: idx === 0 ? 0 : -OVERLAP_PX,
-                  // Later avatars sit on top so the overlap reads
-                  // left → right.
-                  zIndex: idx
-                }}
-              >
-                <Avatar
-                  userId={userId}
-                  imageSize={SquareSizes.SIZE_150_BY_150}
-                  size='medium'
-                />
-              </Box>
-            ))}
+            {hasAny
+              ? visibleIds.map((userId, idx) => (
+                  <Box
+                    key={userId}
+                    css={{
+                      // Overlap each subsequent avatar over the previous
+                      // to produce the stacked "face pile" look.
+                      marginLeft: idx === 0 ? 0 : -OVERLAP_PX,
+                      // Later avatars sit on top so the overlap reads
+                      // left → right.
+                      zIndex: idx
+                    }}
+                  >
+                    <Avatar
+                      userId={userId}
+                      imageSize={SquareSizes.SIZE_150_BY_150}
+                      size='medium'
+                    />
+                  </Box>
+                ))
+              : null}
           </Flex>
           <IconButton
             icon={IconCaretRight}

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -28,12 +28,15 @@ import {
   Button,
   Divider,
   FilterButton,
-  FollowButton,
   Flex,
   IconButton,
   IconShare,
+  IconUserFollow,
+  IconUserFollowing,
+  IconUserUnfollow,
   Paper,
   SelectablePill,
+  Skeleton,
   Text
 } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
@@ -63,6 +66,9 @@ import { EventFollowersCard } from '../EventFollowersCard'
 const messages = {
   title: 'Remix Contest',
   enterContest: 'Enter Contest',
+  follow: 'Follow',
+  following: 'Following',
+  unfollow: 'Unfollow',
   share: 'Share contest',
   submissionsDue: 'Submissions Due:',
   contestEnded: 'Contest Ended',
@@ -216,6 +222,10 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
   const { data: followState } = useEventFollowState(eventId)
   const { mutate: followEvent, isPending: isFollowing } = useFollowEvent()
   const { mutate: unfollowEvent, isPending: isUnfollowing } = useUnfollowEvent()
+  // Drives the Following → Unfollow label swap on hover for the contest
+  // follow button. Local state keeps the parity with FollowButton's old
+  // behavior without bringing back the size mismatch.
+  const [isFollowHovering, setIsFollowHovering] = useState(false)
 
   const isOwner = !!currentUserId && currentUserId === track?.owner_id
 
@@ -370,10 +380,21 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
         </Flex>
       )
     }
-    // Public view: Share icon + profile-style Follow button
-    // (Follow → Following → hover Unfollow) + Enter Contest primary
-    // CTA, per the Figma. Enter Contest is hidden once the contest
-    // has ended — "entering" isn't meaningful anymore.
+    // Public view: Share icon + Follow / Following + Enter Contest, all
+    // size='small' (h=32) to match Figma 2857:94748. Renders the
+    // Follow / Following / Unfollow swap on the regular Button so its
+    // height aligns with the Enter Contest CTA next to it (FollowButton
+    // is 28px tall at small, which produced a visual mismatch).
+    const isFollowed = !!followState?.isFollowed
+    let followIcon = IconUserFollow
+    let followLabel = messages.follow
+    if (isFollowed && !isFollowHovering) {
+      followIcon = IconUserFollowing
+      followLabel = messages.following
+    } else if (isFollowed && isFollowHovering) {
+      followIcon = IconUserUnfollow
+      followLabel = messages.unfollow
+    }
     return (
       <Flex gap='s' alignItems='center' wrap='wrap'>
         <IconButton
@@ -382,14 +403,17 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
           aria-label={messages.share}
           onClick={handleShareContest}
         />
-        <FollowButton
+        <Button
           size='small'
-          fullWidth={false}
-          isFollowing={!!followState?.isFollowed}
+          variant={isFollowed ? 'primary' : 'secondary'}
+          iconLeft={followIcon}
           disabled={isFollowing || isUnfollowing}
-          onFollow={handleToggleFollow}
-          onUnfollow={handleToggleFollow}
-        />
+          onClick={handleToggleFollow}
+          onMouseEnter={() => setIsFollowHovering(true)}
+          onMouseLeave={() => setIsFollowHovering(false)}
+        >
+          {followLabel}
+        </Button>
         {!isEnded ? (
           <Button size='small' onClick={handleEnterContest}>
             {messages.enterContest}
@@ -402,6 +426,7 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     isOwner,
     isEnded,
     followState?.isFollowed,
+    isFollowHovering,
     isFollowing,
     isUnfollowing,
     handleToggleFollow,
@@ -420,18 +445,71 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     return null
   }
 
-  // No contest row on this track — keep the minimal placeholder behaviour.
+  // Contest hasn't resolved yet (or no contest exists for this track).
+  // Render a skeleton matching the page layout instead of the old
+  // "No contest is currently running" copy — covers the initial-load
+  // flash and avoids a confusing empty state.
   if (!contest || !eventId) {
     return (
       <Page
         title={messages.title}
         canonicalUrl={fullContestPage(track.permalink)}
+        variant='flush'
       >
-        <Flex column gap='l' p='xl'>
-          <Text variant='body'>
-            No contest is currently running for this track.
-          </Text>
-        </Flex>
+        <Box
+          css={{
+            maxWidth: MAX_CONTENT_WIDTH,
+            margin: '0 auto',
+            width: '100%'
+          }}
+        >
+          <Box
+            css={{
+              paddingInline: 'var(--harmony-unit-8)',
+              paddingBlock: 'var(--harmony-unit-6)'
+            }}
+          >
+            <Paper
+              direction='column'
+              borderRadius='l'
+              border='default'
+              shadow='flat'
+              backgroundColor='white'
+              css={{ overflow: 'hidden' }}
+            >
+              <Skeleton h={HERO_MIN_HEIGHT} w='100%' />
+              <Flex direction='column' gap='l' p='2xl'>
+                <Flex
+                  justifyContent='space-between'
+                  alignItems='center'
+                  gap='m'
+                >
+                  <Skeleton h={20} w={140} />
+                  <Flex gap='s'>
+                    <Skeleton h={32} w={32} css={{ borderRadius: '50%' }} />
+                    <Skeleton h={32} w={120} />
+                    <Skeleton h={32} w={120} />
+                  </Flex>
+                </Flex>
+                <Skeleton h={36} w='60%' />
+                <Divider orientation='horizontal' />
+                <Flex gap='m' alignItems='center'>
+                  <Skeleton h={40} w={40} css={{ borderRadius: '50%' }} />
+                  <Flex direction='column' gap='2xs' flex='1 1 auto'>
+                    <Skeleton h={12} w={100} />
+                    <Skeleton h={18} w={180} />
+                  </Flex>
+                </Flex>
+                <Flex gap='m'>
+                  <Skeleton h={56} w={72} />
+                  <Skeleton h={56} w={72} />
+                  <Skeleton h={56} w={72} />
+                  <Skeleton h={56} w={72} />
+                </Flex>
+              </Flex>
+            </Paper>
+          </Box>
+        </Box>
       </Page>
     )
   }

--- a/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
@@ -38,6 +38,7 @@ import {
   IconUserFollowing,
   Paper,
   PopupMenu,
+  Skeleton,
   Text,
   useTheme
 } from '@audius/harmony'
@@ -424,13 +425,41 @@ const ContestPage = ({
     return null
   }
 
+  // Contest hasn't resolved yet (or no contest exists for this track).
+  // Render a skeleton matching the mobile page layout instead of the old
+  // "No contest is currently running" copy.
   if (!contest || !eventId) {
     return (
       <Page title={messages.title} variant='flush'>
-        <Box p='xl'>
-          <Text variant='body'>
-            No contest is currently running for this track.
-          </Text>
+        <Box p='l'>
+          <Paper
+            direction='column'
+            borderRadius='l'
+            border='default'
+            shadow='flat'
+            backgroundColor='white'
+            css={{ overflow: 'hidden' }}
+          >
+            <Skeleton h={180} w='100%' />
+            <Flex direction='column' gap='m' p='l'>
+              <Skeleton h={20} w={140} />
+              <Skeleton h={28} w='80%' />
+              <Divider orientation='horizontal' />
+              <Flex gap='m' alignItems='center'>
+                <Skeleton h={32} w={32} css={{ borderRadius: '50%' }} />
+                <Flex direction='column' gap='2xs' flex='1 1 auto'>
+                  <Skeleton h={10} w={80} />
+                  <Skeleton h={16} w={140} />
+                </Flex>
+              </Flex>
+              <Flex gap='s'>
+                <Skeleton h={48} w={56} />
+                <Skeleton h={48} w={56} />
+                <Skeleton h={48} w={56} />
+                <Skeleton h={48} w={56} />
+              </Flex>
+            </Flex>
+          </Paper>
         </Box>
       </Page>
     )

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@audius/common/store'
 import { removeNullable } from '@audius/common/utils'
 import type { Genre, Mood } from '@audius/sdk'
-import { useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams, useSearchParams } from 'react-router'
 
 import { EditTrackForm } from 'components/edit-track/EditTrackForm'
 import { TrackEditFormValues } from 'components/edit-track/types'
@@ -36,6 +36,11 @@ export const EditTrackPage = (props: EditPageProps) => {
   const params = useParams<{ handle?: string; slug?: string }>()
   const { handle } = params
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  // When the user lands here from the host-contest page, we honour the
+  // `returnTo` param so Save / Back lead them back to the in-flight contest
+  // form (which restores from sessionStorage).
+  const returnTo = searchParams.get('returnTo')
   useRequiresAccount()
   useIsUnauthorizedForHandleRedirect(handle ?? '')
   const { onOpen: openReplaceTrackConfirmation } =
@@ -78,7 +83,7 @@ export const EditTrackPage = (props: EditPageProps) => {
             audioFile,
             imageFile
           })
-          navigate(metadata.permalink)
+          navigate(returnTo ?? metadata.permalink)
           closeReplaceTrackProgress()
         }
       })
@@ -89,7 +94,7 @@ export const EditTrackPage = (props: EditPageProps) => {
         audioFile,
         imageFile
       })
-      navigate(metadata.permalink)
+      navigate(returnTo ?? metadata.permalink)
     }
   }
 
@@ -132,7 +137,13 @@ export const EditTrackPage = (props: EditPageProps) => {
   return (
     <Page
       title={messages.title}
-      header={<Header primary={messages.title} showBackButton />}
+      header={
+        <Header
+          primary={messages.title}
+          showBackButton
+          onClickBack={returnTo ? () => navigate(returnTo) : undefined}
+        />
+      }
     >
       {trackStatus !== 'success' || !coverArtUrl ? (
         <LoadingSpinnerFullPage />

--- a/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
+++ b/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   useCreateEvent,
@@ -71,11 +71,11 @@ const messages = {
   deadlineHelper:
     'Remixes submitted after this date will not be accepted. Local timezone applies.',
   coverPhotoLabel: 'Cover Photo',
-  coverPhotoHelper: 'This image will represent your remix contest.',
+  coverPhotoHelper:
+    "Optional — defaults to the track's artwork if you don't upload one.",
   coverPhotoPlaceholder: 'Drag-and-drop an image here, or browse to upload',
-  coverPhotoComingSoon:
-    'Upload coming soon — temporarily paste an image URL below to override the track artwork default.',
-  coverPhotoUrlLabel: 'Cover image URL (optional)',
+  coverPhotoUploadFailed:
+    'Upload failed. Try again or leave blank to use the track artwork.',
   prizesLabel: 'Prizes',
   prizesHelper: 'Describe all prizes, rewards, or other incentives.',
   prizesPlaceholder: '1st place gets $500. 2nd place gets $250…',
@@ -84,9 +84,7 @@ const messages = {
     'Choose one or more tracks to be linked to this contest. Any stems included in that track will also be part of this contest.',
   sourceTracksSectionLabel: 'SOURCE TRACKS',
   addTrack: '+ Add Track',
-  uploadNow: 'Upload Now',
   cancel: 'Cancel',
-  saveDraft: 'Save Draft',
   launch: 'Launch',
   save: 'Save',
   turnOff: 'Turn off contest',
@@ -164,34 +162,73 @@ export const HostRemixContestPage = () => {
   const primaryPermalink = primaryTrack?.permalink ?? ''
 
   // ---------------------------------------------------------------------------
+  // Draft persistence — keyed by handle/slug (or 'new' for the trackless
+  // route) so a user can navigate to edit a source track and return without
+  // losing in-flight form state. Cleared on launch / cancel / delete.
+  // ---------------------------------------------------------------------------
+  const draftStorageKey = useMemo(
+    () =>
+      handle && slug
+        ? `host-remix-contest-draft:${handle}/${slug}`
+        : 'host-remix-contest-draft:new',
+    [handle, slug]
+  )
+  const draft = useMemo(() => {
+    if (typeof window === 'undefined') return null
+    try {
+      const raw = window.sessionStorage.getItem(draftStorageKey)
+      return raw ? JSON.parse(raw) : null
+    } catch {
+      return null
+    }
+    // Read once on mount; ignore deps churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftStorageKey])
+
+  // ---------------------------------------------------------------------------
   // Form state
   // ---------------------------------------------------------------------------
-  const [title, setTitle] = useState(existingEventData.title ?? '')
+  const [title, setTitle] = useState(
+    draft?.title ?? existingEventData.title ?? ''
+  )
   const [description, setDescription] = useState(
-    existingEventData.description ?? ''
+    draft?.description ?? existingEventData.description ?? ''
   )
   const [descriptionError, setDescriptionError] = useState(false)
-  const [videoUrl, setVideoUrl] = useState(existingEventData.videoUrl ?? '')
-  const [coverPhotoUrl, setCoverPhotoUrl] = useState(
-    existingEventData.coverPhotoUrl ?? ''
+  const [videoUrl, setVideoUrl] = useState(
+    draft?.videoUrl ?? existingEventData.videoUrl ?? ''
   )
-  const [prizeInfo, setPrizeInfo] = useState(existingEventData.prizeInfo ?? '')
+  const [coverPhotoUrl, setCoverPhotoUrl] = useState(
+    draft?.coverPhotoUrl ?? existingEventData.coverPhotoUrl ?? ''
+  )
+  const [prizeInfo, setPrizeInfo] = useState(
+    draft?.prizeInfo ?? existingEventData.prizeInfo ?? ''
+  )
 
+  const initialEndDate = draft?.contestEndDate
+    ? dayjs(draft.contestEndDate)
+    : remixContest
+      ? dayjs(remixContest.endDate)
+      : null
   const [contestEndDate, setContestEndDate] = useState<dayjs.Dayjs | null>(
-    remixContest ? dayjs(remixContest.endDate) : null
+    initialEndDate
   )
   const [endDateTouched, setEndDateTouched] = useState(false)
   const [endDateError, setEndDateError] = useState(false)
   const [timeValue, setTimeValue] = useState(
-    contestEndDate ? dayjs(contestEndDate).format('hh:mm') : ''
+    draft?.timeValue ??
+      (initialEndDate ? dayjs(initialEndDate).format('hh:mm') : '')
   )
   const [timeError, setTimeError] = useState(false)
   const [meridianValue, setMeridianValue] = useState(
-    contestEndDate ? dayjs(contestEndDate).format('A') : ''
+    draft?.meridianValue ??
+      (initialEndDate ? dayjs(initialEndDate).format('A') : '')
   )
 
   const [sourceTrackIds, setSourceTrackIds] = useState<number[]>(
-    existingEventData.sourceTrackIds ?? (primaryTrackId ? [primaryTrackId] : [])
+    draft?.sourceTrackIds ??
+      existingEventData.sourceTrackIds ??
+      (primaryTrackId ? [primaryTrackId] : [])
   )
 
   // The event's backing track: prefer the URL-scoped primary track, and
@@ -211,6 +248,50 @@ export const HostRemixContestPage = () => {
     null
   )
 
+  // Persist form state on every change so the user can leave (e.g. to
+  // edit a source track) and return without losing what they typed.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      window.sessionStorage.setItem(
+        draftStorageKey,
+        JSON.stringify({
+          title,
+          description,
+          videoUrl,
+          coverPhotoUrl,
+          prizeInfo,
+          contestEndDate: contestEndDate?.toISOString() ?? null,
+          timeValue,
+          meridianValue,
+          sourceTrackIds
+        })
+      )
+    } catch {
+      /* ignore quota errors */
+    }
+  }, [
+    draftStorageKey,
+    title,
+    description,
+    videoUrl,
+    coverPhotoUrl,
+    prizeInfo,
+    contestEndDate,
+    timeValue,
+    meridianValue,
+    sourceTrackIds
+  ])
+
+  const clearDraft = useCallback(() => {
+    if (typeof window === 'undefined') return
+    try {
+      window.sessionStorage.removeItem(draftStorageKey)
+    } catch {
+      /* ignore */
+    }
+  }, [draftStorageKey])
+
   // ---------------------------------------------------------------------------
   // Cover-photo upload + fallback to track artwork
   // ---------------------------------------------------------------------------
@@ -222,12 +303,18 @@ export const HostRemixContestPage = () => {
   const { upload: uploadCover, isUploading: isCoverUploading } =
     useUploadContestCover()
   const coverFileInputRef = useRef<HTMLInputElement>(null)
+  const [coverUploadError, setCoverUploadError] = useState(false)
 
   const handleCoverFileSelected = useCallback(
     async (file: File | null) => {
       if (!file) return
+      setCoverUploadError(false)
       const url = await uploadCover(file)
-      if (url) setCoverPhotoUrl(url)
+      if (url) {
+        setCoverPhotoUrl(url)
+      } else {
+        setCoverUploadError(true)
+      }
     },
     [uploadCover]
   )
@@ -278,6 +365,7 @@ export const HostRemixContestPage = () => {
   }, [])
 
   const handleCancel = useCallback(() => {
+    clearDraft()
     // Track-less flow: fall back to the contests discovery page.
     if (!primaryPermalink) {
       navigate(CONTESTS_PAGE)
@@ -288,7 +376,7 @@ export const HostRemixContestPage = () => {
         ? fullContestPage(primaryPermalink)
         : fullTrackPage(primaryPermalink)
     )
-  }, [isEdit, navigate, primaryPermalink])
+  }, [clearDraft, isEdit, navigate, primaryPermalink])
 
   const handleSubmit = useCallback(() => {
     const parsedTime = parseTime(timeValue)
@@ -358,12 +446,14 @@ export const HostRemixContestPage = () => {
       )
     }
 
+    clearDraft()
     if (effectivePermalink) {
       navigate(fullContestPage(effectivePermalink))
     } else {
       navigate(CONTESTS_PAGE)
     }
   }, [
+    clearDraft,
     timeValue,
     contestEndDate,
     meridianValue,
@@ -398,10 +488,12 @@ export const HostRemixContestPage = () => {
         })
       )
     }
+    clearDraft()
     if (primaryPermalink) {
       navigate(fullTrackPage(primaryPermalink))
     }
   }, [
+    clearDraft,
     remixContest,
     currentUserId,
     deleteEvent,
@@ -584,9 +676,6 @@ export const HostRemixContestPage = () => {
             <Flex direction='column' gap='xs'>
               <Text variant='title' size='l' tag='label'>
                 {messages.coverPhotoLabel}
-                <Text color='accent' tag='span'>
-                  {messages.required}
-                </Text>
               </Text>
               <Text variant='body' size='s' color='subdued'>
                 {messages.coverPhotoHelper}
@@ -647,6 +736,11 @@ export const HostRemixContestPage = () => {
                 e.target.value = ''
               }}
             />
+            {coverUploadError ? (
+              <Text variant='body' size='s' color='danger'>
+                {messages.coverPhotoUploadFailed}
+              </Text>
+            ) : null}
           </Paper>
 
           {/* Section: Prizes */}
@@ -693,21 +787,17 @@ export const HostRemixContestPage = () => {
               </Text>
             </Flex>
             {/* For now only one Source Track is supported. Once one has
-                been picked, both Add Track and Upload Now are locked out
-                — users can Remove the existing row to swap. */}
+                been picked, Add Track is locked out — users can Remove the
+                existing row to swap. (Upload-track-from-here is dropped for
+                v1; will follow up alongside Save Draft in v2.) */}
             {sourceTrackIds.length === 0 ? (
-              <Flex gap='s'>
-                <Button
-                  variant='primary'
-                  fullWidth
-                  onClick={handleAddSourceTrack}
-                >
-                  {messages.addTrack}
-                </Button>
-                <Button variant='secondary' iconLeft={IconCloudUpload}>
-                  {messages.uploadNow}
-                </Button>
-              </Flex>
+              <Button
+                variant='primary'
+                fullWidth
+                onClick={handleAddSourceTrack}
+              >
+                {messages.addTrack}
+              </Button>
             ) : null}
             {sourceTrackIds.length > 0 ? (
               <Flex direction='column' gap='xs'>
@@ -721,6 +811,11 @@ export const HostRemixContestPage = () => {
                       sourceTrackId={id}
                       onRemove={() => handleRemoveSourceTrack(id)}
                       onManageStems={() => setManageStemsTargetId(id)}
+                      editReturnTo={
+                        handle && slug
+                          ? `/${handle}/${slug}/host-contest`
+                          : '/host-contest'
+                      }
                     />
                   ))}
                 </Flex>
@@ -739,11 +834,6 @@ export const HostRemixContestPage = () => {
                   {messages.turnOff}
                 </Button>
               ) : null}
-              {/* Save Draft is scoped out for now (Chunk 2) — no draft
-                  model exists on the backend yet. */}
-              <Button variant='secondary' disabled>
-                {messages.saveDraft}
-              </Button>
               <Button
                 variant='primary'
                 onClick={handleSubmit}
@@ -782,12 +872,19 @@ type SourceTrackRowProps = {
   sourceTrackId: number
   onRemove: () => void
   onManageStems: () => void
+  /**
+   * Path the track-edit page should return to when the user clicks
+   * Save / Back. Encoded into a `returnTo` query param so the in-flight
+   * contest-creation form is restored from sessionStorage on landing.
+   */
+  editReturnTo: string
 }
 
 const SourceTrackRow = ({
   sourceTrackId,
   onRemove,
-  onManageStems
+  onManageStems,
+  editReturnTo
 }: SourceTrackRowProps) => {
   const navigate = useNavigate()
   const { data: trackData } = useTrack(sourceTrackId, {
@@ -870,7 +967,8 @@ const SourceTrackRow = ({
               text: messages.editTrack,
               onClick: () => {
                 if (trackData?.permalink) {
-                  navigate(`${trackData.permalink}/edit`)
+                  const target = `${trackData.permalink}/edit?returnTo=${encodeURIComponent(editReturnTo)}`
+                  navigate(target)
                 }
               }
             },

--- a/packages/web/src/pages/host-remix-contest-page/ManageStemsModal.tsx
+++ b/packages/web/src/pages/host-remix-contest-page/ManageStemsModal.tsx
@@ -1,17 +1,33 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { useTrack, useUpdateTrack } from '@audius/common/api'
-import type { AccessConditions, ID } from '@audius/common/models'
+import {
+  useDeleteTrack,
+  useStems,
+  useTrack,
+  useUpdateTrack
+} from '@audius/common/api'
+import { useUploadingStems } from '@audius/common/hooks'
+import type {
+  AccessConditions,
+  ID,
+  StemUploadWithFile
+} from '@audius/common/models'
+import { StemCategory, stemCategoryFriendlyNames } from '@audius/common/models'
+import { stemsUploadActions } from '@audius/common/store'
+import { uuid } from '@audius/common/utils'
 import {
   Box,
   Button,
   Divider,
   Flex,
+  IconButton,
   IconCart,
   IconCloudUpload,
   IconReceive,
+  IconTrash,
   IconUserFollowing,
   IconVisibilityPublic,
+  LoadingSpinner,
   Modal,
   ModalContent,
   ModalHeader,
@@ -20,6 +36,9 @@ import {
   Switch,
   Text
 } from '@audius/harmony'
+import { useDispatch } from 'react-redux'
+
+import { processFiles } from 'pages/upload-page/store/utils/processFiles'
 
 const messages = {
   title: 'Stems & Downloads',
@@ -35,8 +54,10 @@ const messages = {
   uploadHelper: 'Provide FLAC, WAV, ALAC, or AIFF for highest audio quality.',
   uploadPlaceholder: 'Drag-and-drop audio files here, or ',
   browseToUpload: 'browse to upload',
-  uploadComingSoon:
-    'Additional stem file uploads coming soon — managed from the track edit page today.',
+  uploading: (n: number) => `Uploading ${n} stem${n === 1 ? '' : 's'}…`,
+  uploadingStatus: 'Uploading…',
+  noStems: 'No stems on this track yet.',
+  removeStem: 'Remove stem',
   save: 'Save',
   cancel: 'Cancel'
 }
@@ -74,14 +95,36 @@ export const ManageStemsModal = ({
   })
 
   const { mutate: updateTrack, isPending: isSaving } = useUpdateTrack()
+  const { mutate: deleteTrack } = useDeleteTrack()
+  const dispatch = useDispatch()
+
+  // Existing stems on the track (already uploaded). Refetched in real-time
+  // by the publishStems success path, so newly-uploaded stems migrate from
+  // the "uploading" list into here once they finish.
+  const { data: existingStems = [] } = useStems(trackId ?? undefined)
+  // In-flight stem uploads triggered by the dropzone below. Comes from
+  // redux (stems-upload slice) — the upload-tracks saga consumes this and
+  // calls publishStems when ready.
+  const { uploadingTracks } = useUploadingStems(trackId ?? 0)
+  // The redux slice doesn't clear once publishStems completes, so dedupe
+  // anything already represented in `existingStems` to avoid double rows.
+  const stillUploading = uploadingTracks.filter(
+    (u) => !existingStems.some((s) => s.orig_filename === u.name)
+  )
 
   const [isDownloadable, setIsDownloadable] = useState(false)
   const [availability, setAvailability] = useState<Availability>('public')
+  const [pendingStemCount, setPendingStemCount] = useState(0)
+  const fileInputId = useMemo(
+    () => `manage-stems-file-input-${trackId ?? 'none'}`,
+    [trackId]
+  )
 
   // Seed form state from the track whenever the modal opens / the target
   // track changes.
   useEffect(() => {
-    if (!isOpen || !trackMeta) return
+    if (!isOpen) return
+    if (!trackMeta) return
     setIsDownloadable(!!trackMeta.is_downloadable)
     const cond = trackMeta.download_conditions as AccessConditions | null
     if (!cond) {
@@ -97,6 +140,47 @@ export const ManageStemsModal = ({
       setAvailability('public')
     }
   }, [isOpen, trackMeta])
+
+  const handleAddStemFiles = useCallback(
+    async (files: File[]) => {
+      if (!trackId || files.length === 0) return
+      setPendingStemCount(files.length)
+      try {
+        const processed = await Promise.all(
+          processFiles(files, (name, reason) => {
+            // eslint-disable-next-line no-console
+            console.warn('Skipping invalid stem file', name, reason)
+          })
+        )
+        const valid = processed.filter(
+          (p): p is NonNullable<typeof p> => p !== null
+        )
+        if (valid.length === 0) {
+          setPendingStemCount(0)
+          return
+        }
+
+        const uploads: StemUploadWithFile[] = valid.map((processedFile) => ({
+          file: processedFile.file,
+          metadata: processedFile.metadata,
+          category: StemCategory.OTHER,
+          allowDelete: true,
+          allowCategorySwitch: true
+        }))
+
+        dispatch(
+          stemsUploadActions.startStemUploads({
+            parentId: trackId,
+            uploads,
+            batchUID: uuid()
+          })
+        )
+      } finally {
+        setPendingStemCount(0)
+      }
+    },
+    [trackId, dispatch]
+  )
 
   const handleSave = useCallback(() => {
     if (!trackId) return
@@ -188,7 +272,7 @@ export const ManageStemsModal = ({
 
           <Divider />
 
-          {/* Upload Additional Files (stub) */}
+          {/* Upload Additional Files */}
           <Flex direction='column' gap='m'>
             <Text variant='label' size='s' color='subdued'>
               {messages.uploadHeading}
@@ -196,21 +280,75 @@ export const ManageStemsModal = ({
             <Text variant='body' size='s' color='subdued'>
               {messages.uploadHelper}
             </Text>
+
+            {/* Existing + uploading stems list */}
+            {existingStems.length > 0 || stillUploading.length > 0 ? (
+              <Flex
+                direction='column'
+                border='default'
+                borderRadius='m'
+                css={{ overflow: 'hidden' }}
+              >
+                {existingStems.map((stem) => (
+                  <StemRow
+                    key={`existing-${stem.track_id}`}
+                    title={stem.orig_filename ?? stem.title}
+                    category={stem.stem_of?.category ?? StemCategory.OTHER}
+                    onRemove={() => deleteTrack({ trackId: stem.track_id })}
+                  />
+                ))}
+                {stillUploading.map((u, i) => (
+                  <StemRow
+                    key={`uploading-${u.name}-${i}`}
+                    title={u.name}
+                    category={u.category ?? StemCategory.OTHER}
+                    isUploading
+                  />
+                ))}
+              </Flex>
+            ) : null}
+
             <Box
               p='xl'
               css={{
                 border: '1px dashed var(--harmony-border-default)',
                 borderRadius: 8,
-                textAlign: 'center'
+                textAlign: 'center',
+                cursor: trackId && pendingStemCount === 0 ? 'pointer' : 'wait'
+              }}
+              onClick={() => {
+                if (!trackId || pendingStemCount > 0) return
+                document.getElementById(fileInputId)?.click()
+              }}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => {
+                e.preventDefault()
+                if (!trackId || pendingStemCount > 0) return
+                const files = Array.from(e.dataTransfer?.files ?? [])
+                if (files.length > 0) handleAddStemFiles(files)
               }}
             >
               <Flex direction='column' alignItems='center' gap='s'>
                 <IconCloudUpload size='xl' color='subdued' />
                 <Text variant='body' size='s' color='subdued'>
-                  {messages.uploadComingSoon}
+                  {pendingStemCount > 0
+                    ? messages.uploading(pendingStemCount)
+                    : `${messages.uploadPlaceholder}${messages.browseToUpload}`}
                 </Text>
               </Flex>
             </Box>
+            <input
+              id={fileInputId}
+              type='file'
+              accept='audio/*,.flac,.wav,.alac,.aiff,.aif,.mp3,.ogg,.m4a'
+              multiple
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                const files = Array.from(e.target.files ?? [])
+                if (files.length > 0) handleAddStemFiles(files)
+                e.target.value = ''
+              }}
+            />
           </Flex>
 
           <Flex justifyContent='center' pt='s'>
@@ -225,5 +363,52 @@ export const ManageStemsModal = ({
         </Flex>
       </ModalContent>
     </Modal>
+  )
+}
+
+// ----- Stem row --------------------------------------------------------------
+
+type StemRowProps = {
+  title: string
+  category: StemCategory
+  isUploading?: boolean
+  onRemove?: () => void
+}
+
+const StemRow = ({ title, category, isUploading, onRemove }: StemRowProps) => {
+  return (
+    <Flex
+      alignItems='center'
+      justifyContent='space-between'
+      gap='m'
+      pv='s'
+      ph='m'
+      css={{
+        borderBottom: '1px solid var(--harmony-border-default)',
+        '&:last-of-type': { borderBottom: 'none' }
+      }}
+    >
+      <Flex direction='column' css={{ minWidth: 0, flex: 1 }}>
+        <Text variant='body' size='m' ellipses>
+          {title}
+        </Text>
+        <Text variant='body' size='s' color='subdued'>
+          {isUploading
+            ? messages.uploadingStatus
+            : (stemCategoryFriendlyNames[category] ?? '')}
+        </Text>
+      </Flex>
+      {isUploading ? (
+        <LoadingSpinner css={{ width: 16, height: 16 }} />
+      ) : onRemove ? (
+        <IconButton
+          aria-label={messages.removeStem}
+          icon={IconTrash}
+          color='default'
+          size='s'
+          onClick={onRemove}
+        />
+      ) : null}
+    </Flex>
   )
 }


### PR DESCRIPTION
## Summary
Polish pass on the contest creation + viewing flow — addresses several UX gaps surfaced while testing the new Create Contest page.

### Host Remix Contest page
- Drop **Save Draft** and **Upload Track** buttons (deferred to v2 — no draft model on the backend yet, and upload-from-here isn't wired)
- **Cover photo** is now optional and falls back to the track's artwork; a visible error message surfaces if upload fails
- Persist the in-flight form state in `sessionStorage` keyed by handle/slug so editing a source track and returning preserves the contest draft
- Pass `?returnTo=` to the track edit page so **Save** / **Back** land back on the contest form rather than the track page

### Manage Stems modal
- Wire up real stem upload via `stemsUploadActions.startStemUploads` (was a "coming soon" stub)
- Render existing + uploading stems above the dropzone, with category label and remove control

### Contest page actions row
- Replace `FollowButton` with a regular `Button` so it lines up with **Enter Contest** at `size='small'` (h=32, matches Figma 2857:94748)
- Preserves the Following → Unfollow hover swap

### Cache fixes
- **Followers card**: invalidate the `eventFollowers` query on follow/unfollow so the user's avatar appears without a refresh; show the chevron whenever `followerCount > 0` so the modal is always reachable
- **Comments**: optimistically push and invalidate every cached sort variant (top / newest / timestamp) — previously only `'newest'` was patched, so comments didn't appear on the Top tab until refresh
- **Discovery**: invalidate `remixContestsList` on event create/update so a new contest appears in the listing immediately

### Track page download tile
- When there's a single downloadable track with no stems, drop the caret/expand and use the inline Download button as the entire interaction

### Contest page empty state
- Replace the "No contest is currently running for this track" copy with a skeleton matching the page layout (desktop + mobile)

> Note: a paired backend change to `EventData` (Go API) was merged separately — without it the `title` / `videoUrl` / `coverPhotoUrl` / `sourceTrackIds` fields were silently dropped on read.

## Test plan
- [ ] Create a contest from a track page; confirm title / video link / cover photo URL all round-trip after refresh
- [ ] Confirm the new contest appears in `/contests` immediately (no refresh)
- [ ] In the source-tracks list, click **Edit Track**, save / back, confirm you return to the contest form with the same source tracks selected
- [ ] Open the **Manage Stems** modal, drop a couple of audio files, confirm rows appear with "Uploading…" then transition to the existing-stems list
- [ ] On a public contest page, follow the contest, confirm:
  - Button styling matches Enter Contest in size + variant
  - Followers card avatar shows up without refresh
  - Followers modal opens via the chevron
- [ ] Post a comment, confirm it appears immediately on both **Top** and **Newest** tabs
- [ ] Open a track with download original on / no stems, confirm the download tile shows a flat Download button (no caret, no expand)
- [ ] Visit a contest page during initial load (or for a track without a contest), confirm the skeleton renders instead of the old empty-state copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)