### PR TITLE
Drop hard-coded CONTESTS flag on mobile

### DIFF
--- a/packages/common/src/hooks/useFeatureFlag.ts
+++ b/packages/common/src/hooks/useFeatureFlag.ts
@@ -141,9 +141,7 @@ export const createUseFeatureFlagHook =
  * Optimizely and env defaults. Add entries only for short-lived release
  * toggles; remove when remote config is updated.
  */
-const HARDCODED_ENABLED_FLAGS: Partial<Record<FeatureFlags, true>> = {
-  [FeatureFlags.CONTESTS]: true
-}
+const HARDCODED_ENABLED_FLAGS: Partial<Record<FeatureFlags, true>> = {}
 
 /** Fetches enabled status of a given feature flag with fallback. Result is memoized. */
 export const useFeatureFlag = (


### PR DESCRIPTION
## Summary
- Removes `FeatureFlags.CONTESTS` from `HARDCODED_ENABLED_FLAGS` in `packages/common/src/hooks/useFeatureFlag.ts`, so native mobile once again honors Optimizely / env defaults / local overrides for contests
- Leaves the `HARDCODED_ENABLED_FLAGS` mechanism (and the mobile-only `getPlatform()` gate) in place for future short-lived release toggles

This effectively reverts the mobile-only override from #14161 so contests UI is no longer forced on in the native app.

## Test plan
- [ ] With Optimizely/CONTESTS off, verify the Contests nav item is hidden in the native mobile drawer
- [ ] With Optimizely/CONTESTS off, verify contest detail / remix-contest / featured-remix-contests sections do not render on native mobile
- [ ] Verify web (desktop + mobile web) behavior is unchanged
- [ ] With a local override enabled for CONTESTS, verify the feature still shows on native mobile

https://claude.ai/code/session_01HAgF5nRqz7oFS1m2oeFKjm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNrWkJviaG8WJkT9C6raAi)_