### PR TITLE
Fix contest page fallback test for skeleton rendering

### DIFF
--- a/packages/web/src/pages/contest-page/ContestPage.test.tsx
+++ b/packages/web/src/pages/contest-page/ContestPage.test.tsx
@@ -180,12 +180,15 @@ describe('ContestPage', () => {
     expect(container.querySelector('[data-testid="prizes-tab"]')).toBeNull()
   })
 
-  it('renders the "no contest" fallback when the track has no remix contest', () => {
+  it('renders the skeleton fallback when the track has no remix contest', () => {
     mocks.useRemixContest.mockReturnValue({ data: null })
-    renderContestPage()
+    const { container } = renderContestPage()
+    // The fallback replaces the old "No contest is currently running"
+    // copy with a layout-matching skeleton (Harmony `Skeleton` boxes
+    // expose `aria-busy`), so assert at least one skeleton is rendered.
     expect(
-      screen.getByText(/no contest is currently running for this track/i)
-    ).toBeInTheDocument()
+      container.querySelectorAll('[aria-busy="true"]').length
+    ).toBeGreaterThan(0)
     // The main layout sections should NOT render in the fallback branch.
     expect(screen.queryByTestId('details-tab')).not.toBeInTheDocument()
     expect(screen.queryByTestId('prizes-tab')).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary

The `ContestPage > renders the "no contest" fallback…` test was failing because the desktop and mobile `ContestPage` variants no longer render the "No contest is currently running for this track" copy in the fallback branch — both pages were updated to render a layout-matching skeleton instead (see `packages/web/src/pages/contest-page/components/{desktop,mobile}/ContestPage.tsx` around the `if (!contest || !eventId)` guard).

This PR retargets the test at the new behavior:

- Renamed the test to "renders the skeleton fallback when the track has no remix contest".
- Replaced the `getByText(/no contest is currently running.../i)` assertion with a query for `[aria-busy="true"]`, which Harmony's `Skeleton` always sets (`packages/harmony/src/components/skeleton/Skeleton.tsx:37`). At least one such element must render in the fallback.
- Kept the existing assertions that the main layout sections (`details-tab`, `prizes-tab`, `contest-comments-section`) do not render in the fallback branch.

## Test plan

- [ ] `npm run web:test -- ContestPage` passes (could not run locally — `node_modules` are not installed in this sandbox; verified the change matches the production fallback path).

https://claude.ai/code/session_01JzefMF12nVyeqeg3A6e4VJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzefMF12nVyeqeg3A6e4VJ)_