### PR TITLE
Fix desktop track tile click targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ packages/identity-service/emailCache
 
 # Playwright
 test-results
+
+# Local agent state
+.claude/

--- a/packages/web/src/components/track/desktop/CollectionTile.tsx
+++ b/packages/web/src/components/track/desktop/CollectionTile.tsx
@@ -513,6 +513,7 @@ export const CollectionTile = ({
   }
 
   const hasOrdering = order !== undefined
+  const canClickTile = !isLoading && !disableActions
 
   return (
     <Paper
@@ -522,7 +523,10 @@ export const CollectionTile = ({
       css={[
         isLoading && { opacity: 0.6 },
         disableActions && { opacity: 0.5, pointerEvents: 'none' },
-        { minHeight: size === TrackTileSize.LARGE ? 180 : 120 },
+        {
+          minHeight: size === TrackTileSize.LARGE ? 180 : 120,
+          cursor: canClickTile ? 'pointer' : 'default'
+        },
         {
           '&:hover .artworkIcon': { opacity: 0.75 },
           '&:hover': { transform: 'scale(1.004)' },

--- a/packages/web/src/components/track/desktop/TrackTile.test.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.test.tsx
@@ -173,31 +173,36 @@ describe('TrackTile', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('plays from the artwork without stealing track tile action clicks', async () => {
+  it('plays from the tile background and artwork without stealing action clicks', async () => {
     const { togglePlay } = renderTrackTile()
 
     const playButton = await screen.findByRole('button', {
       name: 'Play Test Track'
     })
-    fireEvent.click(playButton)
+    const tileClickTarget = await screen.findByTestId('track-tile-click-target')
+
+    fireEvent.click(tileClickTarget)
     expect(togglePlay).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(playButton)
+    expect(togglePlay).toHaveBeenCalledTimes(2)
 
     const favoriteButton = await screen.findByRole('button', {
       name: /^Favorite$/i
     })
     fireEvent.click(favoriteButton)
-    expect(togglePlay).toHaveBeenCalledTimes(1)
+    expect(togglePlay).toHaveBeenCalledTimes(2)
 
     const repostButton = await screen.findByRole('button', {
       name: /^Repost$/i
     })
     fireEvent.click(repostButton)
-    expect(togglePlay).toHaveBeenCalledTimes(1)
+    expect(togglePlay).toHaveBeenCalledTimes(2)
 
     const shareButton = await screen.findByRole('button', {
       name: /^Share$/i
     })
     fireEvent.click(shareButton)
-    expect(togglePlay).toHaveBeenCalledTimes(1)
+    expect(togglePlay).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -242,6 +242,14 @@ export const TrackTile = ({
     openLockedContentModal
   ])
 
+  const onClickArtwork = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation()
+      onTogglePlay()
+    },
+    [onTogglePlay]
+  )
+
   const renderOverflowMenu = () => {
     const menu: Omit<import('components/menu/TrackMenu').OwnProps, 'children'> =
       {
@@ -293,17 +301,19 @@ export const TrackTile = ({
     order ?? (ordered && index !== undefined ? index + 1 : undefined)
   const disableActions = false
   const showSkeleton = loading
+  const canClickTile = !loading && !disableActions
   const artworkActionLabel =
     trackId && !hasStreamAccess && !isPreviewable
       ? `Unlock ${title || 'track'}`
       : `${isTrackPlaying ? 'Pause' : 'Play'} ${title || 'track'}`
 
-  const tileContent = (
+  const tileBody = (
     <Paper
       css={[
         isLoading && { opacity: 0.6 },
         disableActions && { opacity: 0.5, pointerEvents: 'none' },
         {
+          cursor: canClickTile ? 'pointer' : 'default',
           height: size === TrackTileSize.LARGE ? 144 : 128,
           containerType: 'inline-size',
           '&:hover .artworkIcon': { opacity: 0.75 },
@@ -338,7 +348,7 @@ export const TrackTile = ({
             type='button'
             aria-label={artworkActionLabel}
             disabled={isLoading || disableActions}
-            onClick={onTogglePlay}
+            onClick={onClickArtwork}
             css={{
               display: 'block',
               width: '100%',
@@ -470,6 +480,15 @@ export const TrackTile = ({
         )}
       </Flex>
     </Paper>
+  )
+
+  const tileContent = (
+    <div
+      data-testid='track-tile-click-target'
+      onClick={canClickTile ? onTogglePlay : undefined}
+    >
+      {tileBody}
+    </div>
   )
 
   if (isStreamGated) {


### PR DESCRIPTION
## Summary
- Restore background click-to-play behavior on desktop track tiles and keep the pointer cursor visible
- Stop artwork clicks from bubbling so the play action only fires once
- Add a desktop track tile test that covers background clicks and verifies action buttons do not trigger playback

## Testing
- `vitest --run src/components/track/desktop/TrackTile.test.tsx`
- `eslint` on the touched desktop track tile files
- `tsc` typecheck for `@audius/web`