### PR TITLE
Make profile, library, and fan-club tabs URL-driven

### DIFF
--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -20,6 +20,7 @@ import { isKeyboardActivationKey, Text, Tooltip } from '@audius/harmony'
 import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 import cn from 'classnames'
 import { throttle } from 'lodash'
+import { useLocation, useNavigate } from 'react-router'
 // eslint-disable-next-line no-restricted-imports
 import { animated, useTransition, useSpring } from 'react-spring'
 import { useDrag } from 'react-use-gesture'
@@ -1099,6 +1100,12 @@ type UseTabsArguments = {
   initialScrollOffset?: number
   // The base pathname url of the page to determine tab navigation
   pathname?: string
+
+  // When true, integrate with react-router. Requires `pathname`.
+  // The active tab is derived from the current location matched against
+  // `${pathname}/${tab.to}`, and clicking a tab pushes that URL via navigate().
+  // This makes browser back/forward and deep links work for tabs.
+  routed?: boolean
 }
 
 type UseTabsResult = {
@@ -1136,12 +1143,38 @@ const useTabs = ({
   disabledTabTooltipText,
   tabRecalculator,
   initialScrollOffset = 0,
-  pathname
+  pathname,
+  routed = false
 }: UseTabsArguments): UseTabsResult => {
   if (tabs.length !== elements.length)
     throw new Error('Non-matching number of tabs and elements')
 
-  const isControlled = !!selectedTabLabel
+  // Always call these hooks (rules of hooks); only use the values when `routed`.
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  // Derive the active tab from the URL when in routed mode.
+  // Falls back to `initialTab` when no subpath matches a tab.to (e.g. the
+  // canonical "default tab" URL like /handle for an artist's tracks).
+  const routedSelectedLabel = useMemo(() => {
+    if (!routed || !pathname) return undefined
+    const subpath = location.pathname.startsWith(pathname)
+      ? location.pathname
+          .slice(pathname.length)
+          .replace(/^\/+/, '')
+          .split('/')[0]
+      : ''
+    const matched = tabs.find((t) => t.to === subpath)
+    if (matched) return matched.label
+    if (initialTab && tabs.some((t) => t.label === initialTab))
+      return initialTab
+    return tabs[0]?.label
+  }, [routed, pathname, location.pathname, tabs, initialTab])
+
+  const effectiveSelectedTabLabel = routed
+    ? routedSelectedLabel
+    : selectedTabLabel
+  const isControlled = !!effectiveSelectedTabLabel
 
   // Set up full width transitions
   const fullWidthContainerRef = useRef<HTMLDivElement>(null)
@@ -1182,7 +1215,7 @@ const useTabs = ({
 
   // Find the starting index
   const controlledIndex = isControlled
-    ? tabs.findIndex((t) => t.label === selectedTabLabel)
+    ? tabs.findIndex((t) => t.label === effectiveSelectedTabLabel)
     : initialTab
       ? tabs.findIndex((t) => t.label === initialTab)
       : 0
@@ -1263,6 +1296,17 @@ const useTabs = ({
 
   const onTabClick = useCallback(
     (newIndex: number) => {
+      // In routed mode, push the URL and let useLocation drive the active
+      // index. didChangeTabsFrom will fire from the URL-change effect below.
+      if (routed && pathname) {
+        const tab = tabs[newIndex]
+        const target = tab.to !== undefined ? `${pathname}/${tab.to}` : pathname
+        // Preserve query string so filters/search persist across tab clicks.
+        navigate({ pathname: target, search: location.search })
+        onTabClickCb && onTabClickCb(tab.label)
+        return
+      }
+
       if (isControlled) {
         onChangeComplete(activeIndex, newIndex)
         onTabClickCb && onTabClickCb(tabs[newIndex].label)
@@ -1277,6 +1321,10 @@ const useTabs = ({
       onTabClickCb && onTabClickCb(tabs[newIndex].label)
     },
     [
+      routed,
+      pathname,
+      navigate,
+      location.search,
       isControlled,
       isMobile,
       isMobileV2,
@@ -1286,6 +1334,20 @@ const useTabs = ({
       tabs
     ]
   )
+
+  // In routed mode, fire didChangeTabsFrom when the URL change moves the
+  // active tab (controlled mode otherwise routes this through onChangeComplete
+  // synchronously on click).
+  const prevRoutedLabelRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    if (!routed) return
+    const newLabel = tabs[activeIndex]?.label
+    const prev = prevRoutedLabelRef.current
+    if (prev !== undefined && newLabel && prev !== newLabel) {
+      didChangeTabsFrom?.(prev, newLabel)
+    }
+    prevRoutedLabelRef.current = newLabel
+  }, [routed, activeIndex, tabs, didChangeTabsFrom])
 
   const tabBarKey = tabs.map((t) => t.label).join('-')
 

--- a/packages/web/src/pages/fan-club-detail-page/FanClubDetailTabs.tsx
+++ b/packages/web/src/pages/fan-club-detail-page/FanClubDetailTabs.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 
 import { coinDetailsMessages } from '@audius/common/messages'
 import { EDIT_COIN_DETAILS_PAGE } from '@audius/common/src/utils/route'
 import { Button } from '@audius/harmony'
-import { useNavigate } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
 
 import useTabs from 'hooks/useTabs/useTabs'
 import { AudioWalletTransactions } from 'pages/audio-page/AudioWalletTransactions'
+import { useUpdateSearchParams } from 'pages/search-page/hooks'
 import { env } from 'services/env'
 
 import { FanClubDetailContent } from './FanClubDetailContent'
@@ -15,6 +16,8 @@ export enum FanClubDetailTabType {
   HOME = 'home',
   TRANSACTIONS = 'transactions'
 }
+
+const TAB_PARAM = 'tab'
 
 const messages = {
   home: 'Home',
@@ -33,12 +36,13 @@ export const useFanClubDetailTabs = ({
   ticker,
   isOwner = false
 }: UseFanClubDetailTabsProps) => {
-  const [selectedTab, setSelectedTab] = useState(FanClubDetailTabType.HOME)
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const updateTabSearchParam = useUpdateSearchParams(TAB_PARAM)
 
-  const handleTabChange = useCallback((_from: string, to: string) => {
-    setSelectedTab(to as FanClubDetailTabType)
-  }, [])
+  const selectedTab =
+    (searchParams.get(TAB_PARAM) as FanClubDetailTabType) ??
+    FanClubDetailTabType.HOME
 
   const handleEditClick = useCallback(() => {
     if (ticker) {
@@ -70,7 +74,7 @@ export const useFanClubDetailTabs = ({
     tabs,
     selectedTabLabel: selectedTab,
     elements: tabElements,
-    didChangeTabsFrom: handleTabChange
+    onTabClick: updateTabSearchParam
   })
 
   const rightDecorator = isOwner ? (

--- a/packages/web/src/pages/library-page/components/desktop/LibraryPage.tsx
+++ b/packages/web/src/pages/library-page/components/desktop/LibraryPage.tsx
@@ -224,24 +224,29 @@ const LibraryPage = () => {
     },
     bodyClassName: styles.tabBody,
     elementClassName: styles.tabElement,
+    pathname: '/library',
+    routed: true,
     tabs: [
       {
         icon: <IconNote />,
         text: LibraryPageTabs.TRACKS,
         label: LibraryPageTabs.TRACKS,
-        hideText: shouldHideTabText
+        hideText: shouldHideTabText,
+        to: 'tracks'
       },
       {
         icon: <IconAlbum />,
         text: LibraryPageTabs.ALBUMS,
         label: LibraryPageTabs.ALBUMS,
-        hideText: shouldHideTabText
+        hideText: shouldHideTabText,
+        to: 'albums'
       },
       {
         icon: <IconPlaylists />,
         text: LibraryPageTabs.PLAYLISTS,
         label: LibraryPageTabs.PLAYLISTS,
-        hideText: shouldHideTabText
+        hideText: shouldHideTabText,
+        to: 'playlists'
       }
     ],
     elements: [

--- a/packages/web/src/pages/library-page/components/mobile/LibraryPage.tsx
+++ b/packages/web/src/pages/library-page/components/mobile/LibraryPage.tsx
@@ -590,17 +590,20 @@ const tabHeaders = [
   {
     icon: <IconNote />,
     text: LibraryPageTabs.TRACKS,
-    label: LibraryPageTabs.TRACKS
+    label: LibraryPageTabs.TRACKS,
+    to: 'tracks'
   },
   {
     icon: <IconAlbum />,
     text: LibraryPageTabs.ALBUMS,
-    label: LibraryPageTabs.ALBUMS
+    label: LibraryPageTabs.ALBUMS,
+    to: 'albums'
   },
   {
     icon: <IconPlaylists />,
     text: LibraryPageTabs.PLAYLISTS,
-    label: LibraryPageTabs.PLAYLISTS
+    label: LibraryPageTabs.PLAYLISTS,
+    to: 'playlists'
   }
 ]
 
@@ -662,7 +665,9 @@ const LibraryPage = () => {
     elements,
     selectedTabLabel: currentTab,
     initialScrollOffset: SCROLL_HEIGHT,
-    onTabClick: handleTabClick
+    onTabClick: handleTabClick,
+    pathname: '/library',
+    routed: true
   })
 
   const { setHeader } = useContext(HeaderContext)

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -389,7 +389,8 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
     tabRecalculator,
     initialTab: activeTab || undefined,
     elements,
-    pathname: profilePage(handle)
+    pathname: profilePage(handle),
+    routed: true
   })
 
   const {

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -390,7 +390,8 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
     tabs: profileTabs,
     elements: profileElements,
     initialTab: activeTab || undefined,
-    pathname: profilePage(handle)
+    pathname: profilePage(handle),
+    routed: true
   })
 
   if (!profile) {

--- a/packages/web/src/pages/profile-page/useProfilePage.ts
+++ b/packages/web/src/pages/profile-page/useProfilePage.ts
@@ -440,22 +440,9 @@ export const useProfilePage = () => {
         })
         dispatch(trackEvent)
       }
-      if (profile) {
-        let tab = `/${currLabel.toLowerCase()}`
-        if (isArtist) {
-          if (currLabel === ProfilePageTabs.TRACKS) {
-            tab = ''
-          }
-        } else {
-          if (currLabel === ProfilePageTabs.REPOSTS) {
-            tab = ''
-          }
-        }
-        window.history.replaceState({}, '', `/${profile.handle}${tab}`)
-      }
       setActiveTab(currLabel as ProfilePageTabs)
     },
-    [profile, isArtist, dispatch]
+    [dispatch]
   )
 
   const onEdit = useCallback(() => {


### PR DESCRIPTION
## Summary
- Adds a `routed` flag to `useTabs` that derives the active tab from `useLocation()` and pushes the URL via `useNavigate()` on click. Query string is preserved across tab clicks (so Library's `?filter=…&search=…` survives).
- Migrates ProfilePage (desktop + mobile) and LibraryPage (desktop + mobile) to `routed: true`. Tab clicks now go through react-router → browser back/forward and deep links work.
- Drops the manual `window.history.replaceState()` bandaid in `useProfilePage` that was bypassing react-router and breaking back/forward navigation.
- Migrates FanClubDetailTabs to `?tab=` query param (RemixContestSection's pattern). Pathname routing wasn't viable without registering new `/coins/:ticker/transactions` routes.
- SearchExplorePage and RemixContestSection were already URL-driven via their own mechanisms (`useSearchCategory`/`useMatch` and `?contest-tab=`) — left alone.

## Test plan
- [x] `npm run lint` (web) — clean
- [x] `npm run typecheck` (web) — clean
- [x] `vitest src/pages/profile-page/ProfilePage.test.tsx` — 3 passed (incl. an existing "should navigate to the correct tab when using sub-routes" test)
- [x] `vitest src/pages/fan-club-detail-page/FanClubDetailPage.test.tsx` — 7 passed
- [x] Profile tabs verified manually: click → URL updates, browser back → tab updates, deep-link `/dnb/playlists` lands on playlists, visual matches `audius.co/dnb`
- [ ] **Library**: please click through tab strip while signed in — confirm `?filter=` query string survives tab clicks
- [ ] **FanClub (wAUDIO)**: confirm `?tab=transactions` deep-link lands on transactions tab and back/forward works