### PR TITLE
Enforce indexer length limits on profile inputs and toast on save failure

### DIFF
--- a/.changeset/fix-profile-edit-length-limits-and-toast.md
+++ b/.changeset/fix-profile-edit-length-limits-and-toast.md
@@ -1,0 +1,7 @@
+---
+"@audius/common": patch
+"@audius/web": patch
+"@audius/mobile": patch
+---
+
+Profile edit follow-ups: enforce indexer-mandated length limits on the desktop bio (256), desktop name (32), and native display-name (32) inputs so the discovery indexer can't silently reject long values; surface a toast when profile save fails instead of leaving the user with no feedback. Adds a shared `MAX_BIO_LENGTH` constant in `@audius/common`.

--- a/packages/common/src/services/oauth/formatSocialProfile.ts
+++ b/packages/common/src/services/oauth/formatSocialProfile.ts
@@ -2,6 +2,10 @@ import { TikTokProfile, TwitterProfile } from '~/store/account/types'
 
 export const MAX_HANDLE_LENGTH = 30
 export const MAX_DISPLAY_NAME_LENGTH = 32
+// Must match CHARACTER_LIMIT_USER_BIO in
+// packages/discovery-provider/src/tasks/entity_manager/utils.py — the
+// indexer rejects bios longer than this with IndexingValidationError.
+export const MAX_BIO_LENGTH = 256
 
 export const formatTwitterProfile = async (
   twitterProfile: TwitterProfile,

--- a/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
+++ b/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { useCurrentAccountUser } from '@audius/common/api'
 import type { UserMetadata } from '@audius/common/models'
 import { SquareSizes, WidthSizes } from '@audius/common/models'
+import { MAX_BIO_LENGTH } from '@audius/common/services'
 import { profilePageActions } from '@audius/common/store'
 import type { FormikProps } from 'formik'
 import { Formik } from 'formik'
@@ -82,7 +83,7 @@ const EditProfileForm = (props: EditProfileFormProps) => {
                 label='Bio'
                 placeholder='Tell us about yourself'
                 multiline
-                maxLength={256}
+                maxLength={MAX_BIO_LENGTH}
                 noGutter
               />
               <TextField

--- a/packages/mobile/src/screens/edit-profile-screen/ProfileHeader.tsx
+++ b/packages/mobile/src/screens/edit-profile-screen/ProfileHeader.tsx
@@ -1,3 +1,4 @@
+import { MAX_DISPLAY_NAME_LENGTH } from '@audius/common/services'
 import { View } from 'react-native'
 
 import { useTheme } from '@audius/harmony-native'
@@ -106,6 +107,7 @@ export const ProfileHeader = () => {
             name='name'
             label='Display Name'
             placeholder='Name'
+            maxLength={MAX_DISPLAY_NAME_LENGTH}
             noGutter
           />
         </View>

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -11,7 +11,8 @@ import {
   chatActions,
   reachabilitySelectors,
   confirmerActions,
-  getSDK
+  getSDK,
+  toastActions
 } from '@audius/common/store'
 import {
   squashNewLines,
@@ -161,6 +162,11 @@ function* confirmUpdateProfile(userId, metadata) {
       },
       function* () {
         yield put(profileActions.updateProfileFailed())
+        yield put(
+          toastActions.toast({
+            content: "Couldn't save your profile. Please try again."
+          })
+        )
       },
       undefined,
       undefined,

--- a/packages/web/src/pages/profile-page/components/EditableName.tsx
+++ b/packages/web/src/pages/profile-page/components/EditableName.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 
+import { MAX_DISPLAY_NAME_LENGTH } from '@audius/common/services'
 import { IconButton, IconPencil, useTheme } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -43,7 +44,7 @@ export const EditableName = (props: EditableNameProps) => {
               ref={inputRef}
               defaultValue={name || ''}
               onBlur={onInputBlur}
-              maxLength={32}
+              maxLength={MAX_DISPLAY_NAME_LENGTH}
             />
           </>
         ) : (

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -1,5 +1,6 @@
 import { useArtistCreatedFanClub } from '@audius/common/api'
 import { ID } from '@audius/common/models'
+import { MAX_BIO_LENGTH } from '@audius/common/services'
 import { Nullable } from '@audius/common/utils'
 import {
   Box,
@@ -141,6 +142,8 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
               grows
               placeholder={messages.description}
               defaultValue={bio || ''}
+              maxLength={MAX_BIO_LENGTH}
+              showMaxLength
               onChange={(e) => onUpdateBio(e.target.value)}
             />
 

--- a/packages/web/src/pages/profile-page/components/mobile/EditProfile.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/EditProfile.tsx
@@ -1,3 +1,7 @@
+import {
+  MAX_BIO_LENGTH,
+  MAX_DISPLAY_NAME_LENGTH
+} from '@audius/common/services'
 import { IconLink, IconTikTok, IconX, IconInstagram } from '@audius/harmony'
 
 import EditableRow, { Format } from 'components/groupable-list/EditableRow'
@@ -55,14 +59,14 @@ const EditProfile = ({
             format={Format.INPUT}
             initialValue={name}
             onChange={onUpdateName}
-            maxLength={32}
+            maxLength={MAX_DISPLAY_NAME_LENGTH}
           />
           <EditableRow
             label='Bio'
             format={Format.TEXT_AREA}
             initialValue={bio}
             onChange={onUpdateBio}
-            maxLength={256}
+            maxLength={MAX_BIO_LENGTH}
           />
           <EditableRow
             label='Location'


### PR DESCRIPTION
## Summary

Two follow-ups to the null-handle profile-save fix in #14191, motivated by `level_updjs` still being unable to update their bio after that fix shipped.

### 1. Enforce indexer-mandated length limits on profile inputs

The discovery indexer enforces `CHARACTER_LIMIT_USER_BIO = 256` (`packages/discovery-provider/src/tasks/entity_manager/utils.py`) and rejects long bios with `IndexingValidationError`. Same story for display name (32 chars). But:

- **Desktop** `ProfileLeftNav` bio `TextArea` had **no** `maxLength` — users could type a 500-character bio, the SDK schema accepts it (no length check there), the indexer rejects it, and the user gets no feedback.
- **Mobile-native** `ProfileHeader` display-name `TextField` had **no** `maxLength` — same problem for names.
- **Mobile-web** edit form already enforced both, but with hard-coded 256/32.

Most likely root cause for `level_updjs`'s symptom of "can't update bio" — they almost certainly typed a >256-char bio on desktop. SQL spot-check:

```sql
SELECT user_id, handle, length(bio) FROM users
WHERE is_current = true AND handle_lc = 'level_updjs';
```

Changes:
- Add `MAX_BIO_LENGTH = 256` to `@audius/common` next to the existing `MAX_HANDLE_LENGTH` and `MAX_DISPLAY_NAME_LENGTH`, with a code comment pointing at the matching Python constant so the two can't drift unnoticed.
- Wire `maxLength={MAX_BIO_LENGTH}` + `showMaxLength` on desktop bio TextArea — also gives users a visible counter.
- Add `maxLength={MAX_DISPLAY_NAME_LENGTH}` to mobile-native ProfileHeader display-name input.
- Replace hard-coded `256` / `32` with the shared constants in mobile-web `EditProfile` and desktop `EditableName`.

### 2. User-visible toast on profile save failure

The saga path's confirmer `onFailure` only dispatched `updateProfileFailed` into a redux slice that no UI surfaces, and `useUpdateProfile.onError` only reports to Sentry. Combined with the optimistic local state in `useProfilePage`, every save failure to date has presented as "edit appears to stick → user refreshes → values are gone." That's how the null-handle bug stayed under the radar, and how the bio-length bug stayed under the radar after that fix.

Add a single `toastActions.toast({ content: "Couldn't save your profile. Please try again." })` dispatch from the confirmer's `onFailure` in `packages/web/src/common/store/profile/sagas.js`. The toast slice is shared, so the mobile-native edit-profile screen (which dispatches `updateProfile` through the same saga) gets the toast for free via `useToast`.

## Test plan

- [ ] **Desktop**: open edit profile, paste a long bio, confirm typing stops at 256 and the counter shows `256/256`.
- [ ] **Mobile-web**: same behavior on `/profile/edit` (was already enforced; verify constant swap didn't regress).
- [ ] **Mobile-native**: open edit profile screen, try to type >32 characters in display name — input clips at 32.
- [ ] **Toast on failure**: temporarily make the saga's `audiusBackendInstance.updateCreator` throw (or simulate a 500), confirm the user sees "Couldn't save your profile. Please try again." on both desktop and mobile-native.
- [ ] **Toast on success path**: normal edit-and-save still has no toast (we only fire on failure).
- [ ] `npm run typecheck` clean across `@audius/common`, `@audius/web`, `@audius/mobile`.

## Out of scope

- The `useUpdateProfile` TanQuery hook (used by `LabelAccountModal` for the label toggle) still only reports to Sentry. Worth surfacing failures there too, but the LabelAccountModal flow is a switch — error UX wants a different copy / undo behavior, so leaving for a separate PR.
- Backend backfill / `NOT NULL` constraint for `users.handle` discussed in #14191 — separate ticket against discovery-provider.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReJbYRaink5hoyos4AJd2G)_