### PR TITLE
Library false empty state fix

### DIFF
--- a/packages/web/src/components/table/Table.module.css
+++ b/packages/web/src/components/table/Table.module.css
@@ -287,14 +287,18 @@
 
 .tableRow:hover:not(.skeletonRow),
 .tableRow:focus-within:not(.skeletonRow),
-.tableRow:hover > .tableCell,
-.tableRow:focus-within > .tableCell {
+.tableRow:hover:not(.skeletonRow) > .tableCell,
+.tableRow:focus-within:not(.skeletonRow) > .tableCell {
   z-index: 3;
   box-shadow:
     0 1px 0 0 var(--harmony-n-100),
     0 -1px 0 0 var(--harmony-n-100);
   transition: all 0.07s ease-in-out;
   background-color: var(--harmony-n-50);
+}
+
+.tableRow.skeletonRow {
+  cursor: default;
 }
 
 .tableRow.disabled {

--- a/packages/web/src/pages/library-page/components/desktop/LibraryPage.tsx
+++ b/packages/web/src/pages/library-page/components/desktop/LibraryPage.tsx
@@ -159,8 +159,6 @@ const LibraryPage = () => {
   const tracksLoading = status === Status.LOADING && isEmpty
   const showTrackTableSkeletons =
     (tracksLoading || initFetch) && !hasResolvedTrackRows
-  const tracksTableShowsSpinner =
-    (tracksLoading || initFetch) && !showTrackTableSkeletons
   const trackSkeletonRowCount =
     expectedTrackCount > 0
       ? Math.min(expectedTrackCount, INITIAL_TRACK_SKELETON_ROWS)
@@ -233,7 +231,6 @@ const LibraryPage = () => {
         fetchMore={fetchMoreTracks}
         isVirtualized
         key='favorites'
-        loading={tracksTableShowsSpinner}
         onClickFavorite={toggleSaveTrack}
         onClickRepost={onClickRepost}
         onClickRow={onClickRow}

--- a/packages/web/src/pages/library-page/components/desktop/LibraryPage.tsx
+++ b/packages/web/src/pages/library-page/components/desktop/LibraryPage.tsx
@@ -156,9 +156,20 @@ const LibraryPage = () => {
   const hasResolvedTrackRows = entries.some((entry: LibraryPageTrack) =>
     Boolean(entry.track_id)
   )
-  const tracksLoading = status === Status.LOADING && isEmpty
+  // Skeletons cover two cases:
+  //  1. `initFetch` (a fetchSaves refetch from cold load OR a
+  //     category/filter/sort change) — we always want skeletons here, even
+  //     over stale rows from the previous query, so users don't click rows
+  //     that no longer match the new filter.
+  //  2. `status === LOADING && !hasResolvedTrackRows` — bridges the gap
+  //     between `fetchSavesSucceeded` and `defaultEntries` materializing on
+  //     cold load. The `!hasResolvedTrackRows` guard is critical: without
+  //     it, the virtualized table's `fetchMore` (which sets `fetchingMore`
+  //     and thus flips `tracksFetchStatus` to LOADING) would wipe the whole
+  //     table to skeletons during pagination.
   const showTrackTableSkeletons =
-    (tracksLoading || initFetch) && !hasResolvedTrackRows
+    initFetch || (status === Status.LOADING && !hasResolvedTrackRows)
+  const tracksLoading = showTrackTableSkeletons && isEmpty
   const trackSkeletonRowCount =
     expectedTrackCount > 0
       ? Math.min(expectedTrackCount, INITIAL_TRACK_SKELETON_ROWS)
@@ -174,7 +185,7 @@ const LibraryPage = () => {
           ) as unknown as LibraryPageTrack[],
           -1
         ]
-      : status === Status.SUCCESS || entries.length
+      : entries.length
         ? getTracksTableData()
         : [[], -1]
 
@@ -214,7 +225,7 @@ const LibraryPage = () => {
   )
 
   const tracksContent =
-    isEmpty && !tracksLoading ? (
+    isEmpty && !showTrackTableSkeletons ? (
       <EmptyTable
         primaryText={emptyTracksHeader}
         secondaryText={messages.emptyTracksBody}

--- a/packages/web/src/pages/library-page/hooks/useLibraryPage.ts
+++ b/packages/web/src/pages/library-page/hooks/useLibraryPage.ts
@@ -57,6 +57,7 @@ const { makeGetCurrent } = playbackSelectors
 const { getPlaying, getBuffering } = playbackSelectors
 const {
   getLibraryTracksStatus,
+  getInitialFetchStatus,
   hasReachedEnd,
   getTrackSaves,
   getLocalTrackFavorites,
@@ -116,6 +117,7 @@ export const useLibraryPage = () => {
   const localReposts = useSelector(getLocalTrackReposts)
   const localPurchases = useSelector(getLocalTrackPurchases)
   const tracksFetchStatus = useSelector(getLibraryTracksStatus)
+  const initialFetch = useSelector(getInitialFetchStatus)
 
   const libraryTrackIds = useMemo(() => {
     const saveIds = trackSaves
@@ -321,18 +323,27 @@ export const useLibraryPage = () => {
   const tracks = useMemo(() => {
     const hasExpectedTrackRows =
       trackSaves.length > 0 || libraryTrackIds.length > 0
+    // Treat any "we expect rows but `defaultEntries` hasn't materialized"
+    // gap as LOADING. This holds skeletons in place across the saga's
+    // `fetchSavesSucceeded` → tan-query observer re-key → `defaultEntries`
+    // memo recompute chain, eliminating the empty-table flash.
     const hasPendingTrackRows =
       hasExpectedTrackRows && defaultEntries.length === 0
-    const status: Status = !hasRequestedInitialFetch
-      ? Status.LOADING
-      : tracksFetchStatus === Status.SUCCESS &&
-          !isLibraryTracksPending &&
-          !isLibraryUsersPending &&
-          !hasPendingTrackRows
-        ? Status.SUCCESS
-        : tracksFetchStatus === Status.ERROR
-          ? Status.ERROR
-          : Status.LOADING
+    // On a cold mount the saga hasn't yet put `fetchSavesRequested`, so
+    // `tracksFetchStatus` reads SUCCESS while `entries` is still empty —
+    // hold LOADING until either we observe the saga or the cache already
+    // has saves to render.
+    const status: Status =
+      !hasRequestedInitialFetch && trackSaves.length === 0
+        ? Status.LOADING
+        : tracksFetchStatus === Status.SUCCESS &&
+            !isLibraryTracksPending &&
+            !isLibraryUsersPending &&
+            !hasPendingTrackRows
+          ? Status.SUCCESS
+          : tracksFetchStatus === Status.ERROR
+            ? Status.ERROR
+            : Status.LOADING
     if (!sortedOrder) return { entries: defaultEntries, status }
     const byUid = new Map(defaultEntries.map((e) => [e.uid, e]))
     const ordered = sortedOrder
@@ -506,7 +517,6 @@ export const useLibraryPage = () => {
   )
 
   useEffect(() => {
-    setHasRequestedInitialFetch(true)
     fetchLibraryTracks(
       state.filterText,
       tracksCategory,
@@ -515,6 +525,16 @@ export const useLibraryPage = () => {
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // Only run on mount
+
+  // Latch on the first time the saga reports the initial fetch is in flight.
+  // We can't set this synchronously next to `dispatch(fetchSaves)` because the
+  // saga puts `fetchSavesRequested` asynchronously (after `waitForRead` /
+  // `queryCurrentAccount`) — flipping it eagerly would let one render slip
+  // through with `tracksFetchStatus === SUCCESS` and an empty `entries`,
+  // briefly rendering the empty state.
+  useEffect(() => {
+    if (initialFetch) setHasRequestedInitialFetch(true)
+  }, [initialFetch])
 
   useEffect(() => {
     return () => {

--- a/packages/web/src/pages/library-page/hooks/useLibraryPage.ts
+++ b/packages/web/src/pages/library-page/hooks/useLibraryPage.ts
@@ -103,6 +103,8 @@ export const useLibraryPage = () => {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const lastCategoryUrlRef = useRef<string | null>(null)
+  const [hasRequestedInitialFetch, setHasRequestedInitialFetch] =
+    useState(false)
 
   const currentTrack = useCurrentTrack()
 
@@ -116,7 +118,9 @@ export const useLibraryPage = () => {
   const tracksFetchStatus = useSelector(getLibraryTracksStatus)
 
   const libraryTrackIds = useMemo(() => {
-    const saveIds = trackSaves.map((s: any) => s.save_item_id as ID)
+    const saveIds = trackSaves
+      .map((s: any) => s.save_item_id as ID | undefined)
+      .filter((id): id is ID => Boolean(id))
     const localIds = Array.from(
       new Set([
         ...Object.keys(localFavorites).map(Number),
@@ -143,7 +147,8 @@ export const useLibraryPage = () => {
     () => (libraryFetchedTracks ?? []).map((t) => t.owner_id),
     [libraryFetchedTracks]
   )
-  const { byId: libraryUsersById } = useUsers(libraryOwnerIds)
+  const { byId: libraryUsersById, isPending: isLibraryUsersPending } =
+    useUsers(libraryOwnerIds)
 
   const defaultEntries = useMemo(() => {
     return libraryTrackIds
@@ -314,8 +319,16 @@ export const useLibraryPage = () => {
   }, [])
 
   const tracks = useMemo(() => {
-    const status: Status =
-      tracksFetchStatus === Status.SUCCESS && !isLibraryTracksPending
+    const hasExpectedTrackRows =
+      trackSaves.length > 0 || libraryTrackIds.length > 0
+    const hasPendingTrackRows =
+      hasExpectedTrackRows && defaultEntries.length === 0
+    const status: Status = !hasRequestedInitialFetch
+      ? Status.LOADING
+      : tracksFetchStatus === Status.SUCCESS &&
+          !isLibraryTracksPending &&
+          !isLibraryUsersPending &&
+          !hasPendingTrackRows
         ? Status.SUCCESS
         : tracksFetchStatus === Status.ERROR
           ? Status.ERROR
@@ -331,7 +344,16 @@ export const useLibraryPage = () => {
         ordered.length === defaultEntries.length ? ordered : defaultEntries,
       status
     }
-  }, [defaultEntries, sortedOrder, tracksFetchStatus, isLibraryTracksPending])
+  }, [
+    defaultEntries,
+    sortedOrder,
+    tracksFetchStatus,
+    isLibraryTracksPending,
+    isLibraryUsersPending,
+    hasRequestedInitialFetch,
+    trackSaves.length,
+    libraryTrackIds.length
+  ])
 
   const updatePlaylistLastViewedAt = useCallback(
     (playlistId: number) => {
@@ -484,6 +506,7 @@ export const useLibraryPage = () => {
   )
 
   useEffect(() => {
+    setHasRequestedInitialFetch(true)
     fetchLibraryTracks(
       state.filterText,
       tracksCategory,


### PR DESCRIPTION
## Summary

Fixes three loading-state issues on the desktop library tracks page that combined to produce visible jank during the cold-load → content sequence and during category/filter/sort changes.

### 1. Empty-state flash on cold load

`useLibraryPage` was reading `tracksFetchStatus` directly. On a cold mount, the `fetchSaves` saga puts `fetchSavesRequested` *asynchronously* (after `waitForRead` and `queryCurrentAccount`), so for one render frame `tracksFetchStatus` was still `SUCCESS` while `entries` was empty — briefly rendering `EmptyTable` before skeletons took over.

Fix:
- Latch a `hasRequestedInitialFetch` flag off the *observed* `initialFetch` flag (not the dispatch), so we don't promote `SUCCESS` until the saga has actually engaged.
- Hold `LOADING` whenever we expect rows but `defaultEntries` hasn't materialized (`hasExpectedTrackRows && defaultEntries.length === 0`). This bridges the `fetchSavesSucceeded` → tan-query observer re-key → `defaultEntries` recompute chain.
- Fall through the latch when `trackSaves.length > 0`, so the saga's "same-params, cached saves" short-circuit (no `fetchSavesRequested` ever put) doesn't wedge the page on `LOADING`.

### 2. Stale clickable rows during refetch

`FETCH_SAVES_REQUESTED` doesn't clear `trackSaves`. With the previous version's `loading` prop removed, a category/filter/sort change left the previous query's rows fully visible and clickable until the new request resolved.

Fix: replace stale rows with skeletons whenever `initFetch` is true, so users can't click rows that no longer match the active filter.

### 3. Pagination wiped the whole table to skeletons

The virtualized table's `fetchMore` flips `fetchingMore: true` → `tracksFetchStatus: LOADING`. A naïve `status === LOADING` skeleton gate would wipe the entire table to skeletons every time pagination fired, which then changed scroll position and re-fired fetchMore.

Fix: only the `initFetch` arm of the skeleton check is unconditional. The `LOADING` arm is guarded by `!hasResolvedTrackRows`, so once we have real rows the `fetchingMore`-driven LOADING state doesn't hide them.

### CSS

Skeleton rows now opt out of the hover styles and pointer cursor that real rows get.

## Test plan

- [ ] **Cold load with saves**: navigate to `/library/tracks` from elsewhere — skeletons render, then rows fade in. No EmptyTable flash, no empty-table flash.
- [ ] **Cold load, empty library**: same path on an account with zero saves — skeletons → EmptyTable with "Go to Trending" CTA. CTA does not flash earlier than the skeletons clear.
- [ ] **Category change**: switch between All / Favorites / Reposts / Purchased — old rows are replaced by skeletons during the in-flight fetch, then by the new rows. No clickable stale data.
- [ ] **Filter change**: type in the filter input — same as above (debounced).
- [ ] **Sort change**: click a sortable column header — same as above.
- [ ] **Pagination**: scroll to the bottom of a long library — new rows append without the existing rows being replaced by skeletons.
- [ ] **Saga short-circuit (same-params remount)**: navigate away and back to `/library/tracks` with no params change — content loads from cache without getting stuck on skeletons.
- [ ] **Skeleton row hover**: hover a skeleton row — no background highlight, no pointer cursor.

## Known limitations / out of scope

- If every track in `libraryTrackIds` resolves to a deleted/blocked track (so `defaultEntries` is permanently `[]` while saves exist), the table stays on skeletons rather than showing EmptyTable. Rare edge case; better to fix on the saga side by filtering `trackSaves` to resolvable IDs than to weaken the LOADING guard here.
- `FETCH_SAVES_FAILED` and `FETCH_MORE_SAVES_FAILED` still don't reset `initialFetch` / `fetchingMore` in the reducer. Not introduced by this PR; worth a follow-up.