### PR TITLE
[MOB] Restrict explore album sections to Albums tab

### DIFF
--- a/.changeset/fix-explore-album-sections-tab.md
+++ b/.changeset/fix-explore-album-sections-tab.md
@@ -1,0 +1,5 @@
+---
+'@audius/mobile': patch
+---
+
+Restrict the Top Albums This Month, New Album Releases, and Best Selling Albums sections on the Explore page to the Albums tab only, matching web behavior.

--- a/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx
@@ -25,7 +25,7 @@ export const ExploreContent = () => {
   const showUserContextualContent = isCurrentUserIdLoading || !!currentUserId
   const showTrackContent = category === 'tracks' || category === 'all'
   const showPlaylistContent = category === 'playlists' || category === 'all'
-  const showAlbumContent = category === 'albums' || category === 'all'
+  const showAlbumContent = category === 'albums'
   const showUserContent = category === 'users' || category === 'all'
 
   return (


### PR DESCRIPTION
## Summary
- Top Albums This Month, New Album Releases, and Best Selling Albums on native mobile's Explore page were rendering on both the "All" and "Albums" tabs.
- They were intended to live only on the Albums landing page, matching the web (desktop + responsive) behavior where `showAlbumContent = isAlbumsTab`.
- Updated `showAlbumContent` in `packages/mobile/src/screens/explore-screen/components/ExploreContent.tsx` to gate on `category === 'albums'` only.

Web already behaves correctly (`packages/web/src/pages/search-explore-page/components/{desktop,mobile}/SearchExplorePage.tsx`), so no changes were needed there.

## Test plan
- [ ] Open Explore on mobile, "All" tab — confirm Top Albums This Month / New Album Releases / Best Selling Albums no longer appear
- [ ] Switch to "Albums" tab — confirm all three sections still render
- [ ] Other tabs (Tracks, Playlists, Users) unchanged

https://claude.ai/code/session_01AWWyVSzea32U89DrMtE4hN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWWyVSzea32U89DrMtE4hN)_