### PR TITLE
Restore CJS build for @audius/sdk

### DIFF
--- a/.changeset/sdk-restore-cjs-build.md
+++ b/.changeset/sdk-restore-cjs-build.md
@@ -1,0 +1,13 @@
+---
+"@audius/sdk": minor
+---
+
+Restore a CommonJS build alongside the existing ESM output. The SDK now ships dual ESM + CJS via the `package.json#exports` map (with `import`/`require`/`browser`/`react-native`/`types` conditions), so Node consumers using `require('@audius/sdk')` no longer hit ESM/CJS interop edges on transitive CJS deps (e.g. `lodash`, `axios`, `commander`, `file-type`, `tus-js-client`).
+
+Resolved entries:
+- Node ESM: `dist/index.esm.js`
+- Node CJS: `dist/index.cjs`
+- Browser ESM: `dist/index.browser.esm.js`
+- Browser CJS: `dist/index.browser.cjs`
+- React Native: `dist/index.native.js`
+- Types: `dist/index.d.ts`

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,11 +16,27 @@
     "decentralized",
     "blockchain"
   ],
-  "main": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.esm.js",
+  "types": "./dist/index.d.ts",
   "browser": {
+    "./dist/index.cjs": "./dist/index.browser.cjs",
     "./dist/index.esm.js": "./dist/index.browser.esm.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "react-native": "./dist/index.native.js",
+      "browser": {
+        "import": "./dist/index.browser.esm.js",
+        "require": "./dist/index.browser.cjs",
+        "default": "./dist/index.browser.esm.js"
+      },
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.esm.js"
+    },
+    "./package.json": "./package.json"
   },
   "browserslist": {
     "production": [

--- a/packages/sdk/rollup.config.ts
+++ b/packages/sdk/rollup.config.ts
@@ -40,8 +40,11 @@ const browserInternal = [
 
 export const outputConfigs = {
   /**
-   * SDK Node Package (ES Module)
-   * Used by third parties using ES Modules
+   * SDK Node Package (ES Module + CommonJS)
+   * Used by third parties consuming the SDK from Node. The `.cjs` output is
+   * resolved via the `require` condition in package.json#exports so legacy
+   * Node consumers (and CJS-heavy stacks) can `require('@audius/sdk')`
+   * without hitting ESM/CJS interop edges on transitive deps.
    */
   sdkConfigEs: {
     input: 'src/index.ts',
@@ -51,6 +54,13 @@ export const outputConfigs = {
         format: 'es',
         sourcemap: true,
         entryFileNames: '[name].esm.js'
+      },
+      {
+        dir: 'dist',
+        format: 'cjs',
+        sourcemap: true,
+        entryFileNames: '[name].cjs',
+        exports: 'named'
       }
     ],
     plugins: [
@@ -92,10 +102,13 @@ export const outputConfigs = {
   },
 
   /**
-   * SDK Browser Package (ES Module)
+   * SDK Browser Package (ES Module + CommonJS)
    * Used by the Audius Web Client and by extension the Desktop Client
    * - Includes polyfills for node libraries
    * - Includes deps that are ignored or polyfilled for browser
+   * The `.browser.cjs` output is resolved via the `browser`/`require`
+   * condition in package.json#exports so bundlers operating in CJS mode get
+   * the polyfilled build instead of the Node one.
    */
   sdkBrowserConfigEs: {
     input: 'src/index.ts',
@@ -105,6 +118,13 @@ export const outputConfigs = {
         format: 'es',
         sourcemap: true,
         entryFileNames: '[name].browser.esm.js'
+      },
+      {
+        dir: 'dist',
+        format: 'cjs',
+        sourcemap: true,
+        entryFileNames: '[name].browser.cjs',
+        exports: 'named'
       }
     ],
     plugins: [


### PR DESCRIPTION
## Summary

- Adds a CommonJS output alongside the existing ESM build for `@audius/sdk`.
- Exposes both through a `package.json#exports` map with `types` / `react-native` / `browser` / `import` / `require` conditions.
- Closes the class of ESM↔CJS interop issues that came up around `lodash` (and could resurface around other CJS-era deps the SDK pins: `axios@0.19.2`, `borsh@0.4.0`, `commander`, `file-type@16`, `tus-js-client`, `micro-aes-gcm`).

The lodash shims that landed earlier (`packages/sdk/src/sdk/utils/objectUtils.ts`, `mergeConfigs.ts`) addressed one specific failure; this PR fixes the underlying category by giving CJS consumers a real CJS bundle instead of forcing them through Node's CJS↔ESM interop.

### Resolved entries

| Condition | File |
|---|---|
| Node ESM | `dist/index.esm.js` |
| Node CJS | `dist/index.cjs` (new) |
| Browser ESM | `dist/index.browser.esm.js` |
| Browser CJS | `dist/index.browser.cjs` (new) |
| React Native | `dist/index.native.js` |
| Types | `dist/index.d.ts` |

### Files changed
- `packages/sdk/rollup.config.ts` — add `format: 'cjs'` outputs to `sdkConfigEs` and `sdkBrowserConfigEs`.
- `packages/sdk/package.json` — add `exports` map; point `main` at the new CJS bundle, keep `module` at ESM for legacy resolvers.
- `.changeset/sdk-restore-cjs-build.md` — `@audius/sdk` minor.

## Test plan

- [x] `npm run build:sdk` emits both `dist/index.esm.js` and `dist/index.cjs`.
- [x] `npm run build:sdk:browser` emits both `dist/index.browser.esm.js` and `dist/index.browser.cjs`.
- [x] From a separate consumer package (`file:` install of the built SDK):
  - [x] `require('@audius/sdk')` resolves and `sdk.sdk` is a function.
  - [x] `import { sdk } from '@audius/sdk'` resolves and `sdk` is a function.
- [ ] Confirm CI build, lint, typecheck, and test pass on this PR.
- [ ] After merge, confirm the resulting `Version Packages` PR bumps `@audius/sdk` and the publish workflow uploads `15.3.0` (or whatever changesets aggregates) to npm.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGJpch9p3HpTmSYbQdpDvU)_