### PR TITLE
Show crown for top ten in trending lineups

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileRankIcon.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileRankIcon.tsx
@@ -26,7 +26,7 @@ export const LineupTileRankIcon = (props: LineupTileRankIconProps) => {
   const styles = useStyles()
   const trackTileStyles = useTrackTileStyles()
   const { secondary } = useThemeColors()
-  const Icon = index < 5 ? IconCrown : IconTrending
+  const Icon = index < 10 ? IconCrown : IconTrending
   return (
     <View style={trackTileStyles.statItem}>
       <Icon fill={secondary} style={styles.icon} height={14} width={14} />

--- a/packages/web/src/components/lineup/EntityRank.tsx
+++ b/packages/web/src/components/lineup/EntityRank.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text, IconCrown, IconTrending } from '@audius/harmony'
 
-const RANK_ICON_COUNT = 5
+const RANK_ICON_COUNT = 10
 
 type EntityRankType = {
   index: number
@@ -8,7 +8,7 @@ type EntityRankType = {
 
 export const EntityRank = (props: EntityRankType) => {
   const { index } = props
-  const Icon = RANK_ICON_COUNT <= 5 ? IconCrown : IconTrending
+  const Icon = index < RANK_ICON_COUNT ? IconCrown : IconTrending
 
   return (
     <Flex gap='xs' alignItems='center'>

--- a/packages/web/src/components/track/desktop/CollectionTile.tsx
+++ b/packages/web/src/components/track/desktop/CollectionTile.tsx
@@ -536,7 +536,7 @@ export const CollectionTile = ({
         <Flex gap='s'>
           {hasOrdering && (
             <Flex column gap='2xs' alignItems='center' justifyContent='center'>
-              {!isLoading && order <= 5 && (
+              {!isLoading && order <= 10 && (
                 <IconCrown color='default' size='s' />
               )}
               <Text variant='label' color='default'>

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -336,7 +336,7 @@ export const TrackTile = ({
         {/* prefix ordering */}
         {tileOrder && (
           <Flex column gap='2xs' alignItems='center' justifyContent='center'>
-            {!isLoading && tileOrder <= 5 && (
+            {!isLoading && tileOrder <= 10 && (
               <IconCrown color='default' size='s' />
             )}
             <Text variant='label' color='default'>


### PR DESCRIPTION
## Summary
- Extends the crown indicator on Trending tabs from the top 5 to the top 10, matching the recent change in trending size.
- Updates web `TrackTile`, `CollectionTile`, and `EntityRank`, and mobile `LineupTileRankIcon`.
- Fixes a latent bug in `EntityRank` where the crown/trending icon choice compared the constant to itself (`RANK_ICON_COUNT <= 5`) instead of against the row `index`. With the constant alone bumped to 10, that comparison would have flipped to false and removed all crowns; the fix uses `index < RANK_ICON_COUNT` so ranks 1–10 get the crown.

## Files changed
- `packages/web/src/components/lineup/EntityRank.tsx`
- `packages/web/src/components/track/desktop/TrackTile.tsx`
- `packages/web/src/components/track/desktop/CollectionTile.tsx`
- `packages/mobile/src/components/lineup-tile/LineupTileRankIcon.tsx`

## Test plan
- [ ] Open the web Trending page and verify a crown icon appears next to ranks 1–10 (and not on rank 11+).
- [ ] Verify the same on Trending Playlists / Underground Trending where `CollectionTile` and `EntityRank` render.
- [ ] Open the mobile Trending tab on iOS and Android and confirm the crown appears for the top 10 lineup tiles.
- [ ] Confirm non-trending lineups (no `tileOrder`/`order` passed) are unaffected.

https://claude.ai/code/session_01VRWJWnfrBEBigUv8YZXcbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRWJWnfrBEBigUv8YZXcbq)_