### PR TITLE
Republish @audius/sdk as 15.3.1 with built dist/ in tarball

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @audius/sdk
 
+## 15.3.1
+
+### Patch Changes
+
+- Add a `files` field to `package.json` so the published tarball actually ships the built `dist/` directory. 15.3.0 was published with no `dist/` because the package's `.gitignore` excludes `dist`, and without an explicit `files` whitelist npm fell back to that ignore file and skipped every built artifact. Republish-only fix; no SDK code changes vs. 15.3.0.
+
 ## 15.3.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/sdk",
-  "version": "15.3.0",
+  "version": "15.3.1",
   "type": "module",
   "audius": {
     "releaseSHA": "f1d70a2a0643c5c84d8ab053f70c1e0a2ec3ad49"
@@ -15,6 +15,9 @@
     "web3",
     "decentralized",
     "blockchain"
+  ],
+  "files": [
+    "dist"
   ],
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
## Summary

15.3.0 was published with **no `dist/` files**. The empty-tarball mistake happened because:

1. `packages/sdk/.gitignore` excludes `dist`.
2. `packages/sdk/package.json` had no `files` field and no `.npmignore`.
3. With no `files` whitelist, npm falls back to `.gitignore`, which stripped every built artifact from the tarball.

The build itself succeeded in CI (turbo cache log inside the published tarball confirms `created dist, dist in 45.5s`), but those files never made it into the package npm uploaded.

## Fix

- Add `"files": ["dist"]` to `packages/sdk/package.json` so the published tarball whitelists the built output regardless of `.gitignore`.
- Bump to `15.3.1` since npm doesn't allow republishing the same version. No SDK code changes vs 15.3.0.
- Adds a 15.3.1 entry to `CHANGELOG.md` documenting the republish-only fix.

Once this lands on `main`, the existing `Publish Packages` workflow will run `changeset publish`, see `15.3.1` is ahead of npm, and republish via OIDC with the (now-included) `dist/` files.

## Verification

Locally ran `npm run build` then `npm pack --dry-run --json`:

| File | Present in tarball? |
|---|---|
| `dist/index.cjs` | ✅ |
| `dist/index.esm.js` | ✅ |
| `dist/index.browser.cjs` | ✅ |
| `dist/index.browser.esm.js` | ✅ |
| `dist/index.native.js` | ✅ |
| `dist/index.d.ts` | ✅ |
| `dist/sdk.min.js` | ✅ |

Smoke tests against the freshly built artifacts:

```
$ node -e "console.log(typeof require('./dist/index.cjs').sdk)"
function

$ node --input-type=module -e "import { sdk } from './dist/index.esm.js'; console.log(typeof sdk)"
function
```

## Test plan

- [x] `npm run build` populates `dist/` with all expected outputs (verified locally).
- [x] `npm pack --dry-run` includes `dist/index.cjs` and `dist/index.esm.js`.
- [x] CJS `require()` and ESM `import` both resolve and return a callable `sdk`.
- [ ] After merge, confirm `Publish Packages` workflow uploads `15.3.1` to npm and the resulting tarball contains `dist/`.
- [ ] `npm view @audius/sdk version` reports `15.3.1`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGJpch9p3HpTmSYbQdpDvU)_