### PR TITLE
Bump @audius/sdk dependent pins to 15.3.1 to unblock publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132760,7 +132760,7 @@
       "dependencies": {
         "@audius/fixed-decimal": "0.2.1",
         "@audius/hedgehog": "3.0.0-alpha.1",
-        "@audius/sdk": "15.3.0",
+        "@audius/sdk": "15.3.1",
         "@audius/spl": "2.1.0",
         "@babel/core": "^7.23.7",
         "@babel/plugin-proposal-class-static-block": "7.21.0",
@@ -132882,6 +132882,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "packages/libs/node_modules/@audius/sdk/node_modules/multiformats": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
+      "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==",
+      "extraneous": true,
+      "license": "Apache-2.0 OR MIT"
     },
     "packages/libs/node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.11",
@@ -137830,7 +137837,7 @@
         "@apollo/client": "3.3.7",
         "@audius/common": "*",
         "@audius/harmony": "*",
-        "@audius/sdk": "15.3.0",
+        "@audius/sdk": "15.3.1",
         "@audius/sdk-legacy": "6.0.28",
         "@audius/stems": "0.3.10",
         "@emotion/react": "11.14.0",
@@ -137935,6 +137942,52 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
+    "packages/protocol-dashboard/node_modules/@audius/sdk/node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "extraneous": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "packages/protocol-dashboard/node_modules/@audius/sdk/node_modules/form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/protocol-dashboard/node_modules/@audius/sdk/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "packages/protocol-dashboard/node_modules/@audius/sdk/node_modules/url": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.1.tgz",
+      "integrity": "sha512-rWS3H04/+mzzJkv0eZ7vEDGiQbgquI1fGfOad6zKvgYQi1SzMmhl7c/DdRGxhaWrVH6z0qWITo8rpnxK/RfEhA==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.11.0"
+      }
     },
     "packages/protocol-dashboard/node_modules/@babel/compat-data": {
       "version": "7.28.5",
@@ -140538,7 +140591,7 @@
     },
     "packages/sdk": {
       "name": "@audius/sdk",
-      "version": "15.3.0",
+      "version": "15.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@audius/eth": "1.0.0",

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@audius/fixed-decimal": "0.2.1",
     "@audius/hedgehog": "3.0.0-alpha.1",
-    "@audius/sdk": "15.3.0",
+    "@audius/sdk": "15.3.1",
     "@audius/spl": "2.1.0",
     "@babel/core": "^7.23.7",
     "@babel/plugin-proposal-class-static-block": "7.21.0",

--- a/packages/protocol-dashboard/package.json
+++ b/packages/protocol-dashboard/package.json
@@ -39,7 +39,7 @@
     "@apollo/client": "3.3.7",
     "@audius/common": "*",
     "@audius/harmony": "*",
-    "@audius/sdk": "15.3.0",
+    "@audius/sdk": "15.3.1",
     "@audius/sdk-legacy": "6.0.28",
     "@audius/stems": "0.3.10",
     "@emotion/react": "11.14.0",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @audius/sdk
 
+## 15.3.1
+
+### Patch Changes
+
+- Add a `files` field to `package.json` so the published tarball actually ships the built `dist/` directory. 15.3.0 was published with no `dist/` because the package's `.gitignore` excludes `dist`, and without an explicit `files` whitelist npm fell back to that ignore file and skipped every built artifact. Republish-only fix; no SDK code changes vs. 15.3.0.
+
 ## 15.3.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/sdk",
-  "version": "15.3.0",
+  "version": "15.3.1",
   "type": "module",
   "audius": {
     "releaseSHA": "f1d70a2a0643c5c84d8ab053f70c1e0a2ec3ad49"
@@ -15,6 +15,9 @@
     "web3",
     "decentralized",
     "blockchain"
+  ],
+  "files": [
+    "dist"
   ],
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
## Summary

The `Publish Packages` workflow for 15.3.1 ([failed run](https://github.com/AudiusProject/apps/actions/runs/25233161280)) crashed inside `sp-actions`'s `prepack` while turbo was building its transitive dep `@audius/sdk-legacy`. Root cause: two workspace packages had exact-version pins on `@audius/sdk@15.3.0`:

- `packages/libs/package.json` (sdk-legacy)
- `packages/protocol-dashboard/package.json`

When PR #14212 bumped the workspace SDK to `15.3.1`, those exact pins stopped matching the workspace package, so npm fell back to installing **15.3.0 from the npm registry** — i.e. the broken tarball with no `dist/`. Then sdk-legacy's rollup tried to resolve `@audius/sdk` and hit:

```
Error: Could not load packages/libs/node_modules/@audius/sdk/dist/index.esm.js
ENOENT: no such file or directory
```

## Fix

- Bump `packages/libs/package.json` `@audius/sdk` pin: `15.3.0` → `15.3.1`
- Bump `packages/protocol-dashboard/package.json` `@audius/sdk` pin: `15.3.0` → `15.3.1`
- Refresh `package-lock.json`

Now the workspace SDK satisfies the constraint and `node_modules/@audius/sdk` symlinks back into `packages/sdk` (built in-tree by turbo before sdk-legacy runs), instead of pulling the empty 15.3.0 from npm.

## Verification

```
$ ls -la node_modules/@audius/sdk
node_modules/@audius/sdk -> ../../packages/sdk     ✅ symlink

$ ls node_modules/@audius/sdk/dist/index.esm.js
…/dist/index.esm.js                                ✅ resolves through workspace

$ cd packages/libs && npm run build
created dist in 53s            (libs)
created dist in 12.1s          (web-libs)
created dist in 10.5s          (native-libs)
created dist in 5.3s           (core)
✅ all four sdk-legacy rollup outputs build clean
```

## Test plan

- [x] `npm install` symlinks `node_modules/@audius/sdk` to the workspace.
- [x] `npm run build -w @audius/sdk-legacy` succeeds end-to-end.
- [ ] Once merged, the `Publish Packages` workflow runs `changeset publish`, the prepack turbo build of sdk-legacy passes, and `@audius/sdk@15.3.1` lands on npm with `dist/` populated.
- [ ] `npm view @audius/sdk version` reports `15.3.1`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGJpch9p3HpTmSYbQdpDvU)_