### PR TITLE
Show Audius logo on iOS nested screen headers

### DIFF
--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -7,7 +7,7 @@ import type {
   NativeStackNavigationProp
 } from '@react-navigation/native-stack'
 import { CardStyleInterpolators } from '@react-navigation/stack'
-import { Platform, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 
 import {
   IconAudiusLogoHorizontal,
@@ -132,26 +132,15 @@ export const useAppScreenOptions = <
               </Text>
             )
           }
-          // Android: render the Audius logo as the centered header title on
-          // root screens. Android's stack transition doesn't snapshot/cross-
-          // fade the header the way UIKit does, so a per-screen logo here
-          // doesn't fade awkwardly on push/pop.
-          //
-          // iOS: rendered as a top-level overlay in AppDrawerScreen instead
-          // (positioned behind the Dynamic Island, only visible in App Store
-          // screenshots) so it stays put during stack transitions.
-          if (Platform.OS === 'android') {
-            return (
-              <View>
-                <IconAudiusLogoHorizontal
-                  height={24}
-                  width={100}
-                  color='subdued'
-                />
-              </View>
-            )
-          }
-          return null
+          return (
+            <View>
+              <IconAudiusLogoHorizontal
+                height={24}
+                width={100}
+                color='subdued'
+              />
+            </View>
+          )
         },
         headerRightContainerStyle: styles.headerRight,
         headerRight: () => {


### PR DESCRIPTION
## Summary
- Restores the Audius logo as the default header title on iOS for nested stack screens (Track, Collection, Profile, etc.), matching existing Android behavior
- Previously the logo was only rendered on iOS as a screenshot-only overlay behind the Dynamic Island in `AppDrawerScreen`, leaving nested page headers blank
- The platform branch in `useAppScreenOptions` (introduced in #14205) is removed; both platforms now fall through to the same `IconAudiusLogoHorizontal` default when a screen doesn't supply its own header title

## Test plan
- [ ] iOS: open Track screen — logo appears centered in the header
- [ ] iOS: open Collection screen — logo appears centered in the header
- [ ] iOS: confirm screens that pass an explicit header title (e.g. settings sub-screens) still render the title text, not the logo
- [ ] iOS: confirm screens that pass `headerTitle="none"` still render no title
- [ ] iOS: verify swipe-to-pop and stack push/pop transitions still feel right with the logo in the header
- [ ] Android: regression check — logo still appears as before on root and nested screens

---
_Generated by [Claude Code](https://claude.ai/code/session_016M7ZvBqEwCQdvTDAGaFNqc)_