### PR TITLE
Fix mobile dark mode initial load and SelectablePill theme repaint

### DIFF
--- a/.changeset/fix-mobile-dark-mode-loading.md
+++ b/.changeset/fix-mobile-dark-mode-loading.md
@@ -1,0 +1,5 @@
+---
+'@audius/mobile': patch
+---
+
+Fix initial dark mode load on the mobile app: with theme set to Auto and the system in dark mode, the app launched in light and only flipped after backgrounding. Also fix SelectablePill components keeping the previous palette's colors after a theme flip.

--- a/packages/mobile/src/app/ThemeProvider.tsx
+++ b/packages/mobile/src/app/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import {
   Theme,
@@ -12,7 +12,7 @@ import { themeActions, themeSelectors } from '@audius/common/store'
 import type { Nullable } from '@audius/common/utils'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useAppState } from '@react-native-community/hooks'
-import { useDarkMode } from 'react-native-dynamic'
+import { Appearance, useColorScheme } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
@@ -66,6 +66,14 @@ const resolveToHarmonyTheme = (
   return resolvedMode === 'light' ? 'classic-light' : 'classic-dark'
 }
 
+// Fallback to the live system value when redux hasn't been seeded yet
+// (e.g. on the very first render before ThemeProvider's effect has fired).
+// Without this the first paint would force light even when the OS is dark.
+const getCurrentSystemAppearance = (): SystemAppearance =>
+  Appearance.getColorScheme() === 'dark'
+    ? SystemAppearance.DARK
+    : SystemAppearance.LIGHT
+
 const selectHarmonyTheme = (state: AppState): HarmonyThemeName => {
   const theme = getTheme(state)
   const themePalette = getThemePalette(state)
@@ -80,9 +88,7 @@ const selectHarmonyTheme = (state: AppState): HarmonyThemeName => {
         : theme === Theme.DARK
           ? ThemeMode.DARK
           : ThemeMode.AUTO)
-    const sysAppearance =
-      systemAppearance ??
-      (theme === Theme.DARK ? SystemAppearance.DARK : SystemAppearance.LIGHT)
+    const sysAppearance = systemAppearance ?? getCurrentSystemAppearance()
     return resolveToHarmonyTheme(themePalette, mode, sysAppearance)
   }
 
@@ -96,7 +102,7 @@ const selectHarmonyTheme = (state: AppState): HarmonyThemeName => {
       return 'matrix'
     case Theme.AUTO:
     default:
-      switch (systemAppearance) {
+      switch (systemAppearance ?? getCurrentSystemAppearance()) {
         case SystemAppearance.DARK:
           return 'default-dark'
         case SystemAppearance.LIGHT:
@@ -108,10 +114,15 @@ const selectHarmonyTheme = (state: AppState): HarmonyThemeName => {
 
 export const ThemeProvider = (props: ThemeProviderProps) => {
   const { children } = props
-  const isDarkMode = useDarkMode()
+  // useColorScheme from react-native synchronously returns the current
+  // system value on first render (unlike react-native-dynamic's
+  // useDarkMode, which can report stale `light` until its listener fires).
+  const colorScheme = useColorScheme()
+  const isDarkMode = colorScheme === 'dark'
   const dispatch = useDispatch()
   const appState = useAppState()
   const theme = useSelector(selectHarmonyTheme)
+  const hasInitializedSystemAppearanceRef = useRef(false)
 
   useAsync(async () => {
     const [savedTheme, savedPalette, savedMode] = await Promise.all([
@@ -160,16 +171,24 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
   }, [dispatch])
 
   useEffect(() => {
-    // react-native-dynamic incorrectly sets dark-mode when in background
-    if (appState === 'active') {
-      dispatch(
-        setSystemAppearance({
-          systemAppearance: isDarkMode
+    // iOS briefly reports dark-mode while generating the app-switcher
+    // snapshot, so ignore changes when backgrounded. The very first
+    // dispatch must always run so the initial render picks up the
+    // system value even if appState hasn't settled to 'active' yet.
+    if (appState !== 'active' && hasInitializedSystemAppearanceRef.current) {
+      return
+    }
+    hasInitializedSystemAppearanceRef.current = true
+    const currentScheme =
+      Appearance.getColorScheme() ?? (isDarkMode ? 'dark' : 'light')
+    dispatch(
+      setSystemAppearance({
+        systemAppearance:
+          currentScheme === 'dark'
             ? SystemAppearance.DARK
             : SystemAppearance.LIGHT
-        })
-      )
-    }
+      })
+    )
   }, [isDarkMode, dispatch, appState])
 
   return (

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -56,6 +56,12 @@ export const SelectablePill = (props: SelectablePillProps) => {
 
   const pressed = useSharedValue(0)
   const selected = useSharedValue(isSelected ? 1 : 0)
+  // Bumped whenever the theme palette changes so the animated style
+  // worklets below re-execute on the UI thread and pick up the new
+  // color values. Reanimated only re-runs a worklet when a shared
+  // value it reads changes; updating useAnimatedStyle's dependency
+  // array alone is not enough to force a repaint.
+  const themeNudge = useSharedValue(0)
 
   const handlePressIn = useCallback(() => {
     pressed.value = withTiming(1, motion.press)
@@ -117,41 +123,37 @@ export const SelectablePill = (props: SelectablePillProps) => {
     disableUnselectAnimation
   ])
 
-  // Force animated styles to repaint with the new theme colors when the
-  // theme changes. Updating the dependency arrays below refreshes the
-  // worklet closures, but Reanimated only re-renders the view when a
-  // shared value it reads actually changes. Nudging `selected` here
-  // triggers that re-render so the interpolated colors pick up the new
-  // theme values instead of staying cached on the previous palette.
   useEffect(() => {
-    const target = isSelected ? 1 : 0
-    selected.value = 1 - target
-    selected.value = target
+    themeNudge.value = themeNudge.value + 1
   }, [
+    themeNudge,
     color.background.white,
     color.secondary.s400,
     color.border.strong,
     color.text.default,
-    color.static.white,
-    selected,
-    isSelected
+    color.static.white
   ])
 
   const animatedRootStyles = useAnimatedStyle(
-    () => ({
-      opacity: withTiming(disabled ? 0.45 : 1, motion.press),
-      backgroundColor: interpolateColor(
-        selected.value,
-        [0, 1],
-        [color.background.white, color.secondary.s400]
-      ),
-      borderColor: interpolateColor(
-        selected.value,
-        [0, 1],
-        [color.border.strong, color.secondary.s400]
-      ),
-      transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.95]) }]
-    }),
+    () => {
+      // Subscribe to themeNudge so this worklet re-runs whenever the
+      // theme palette changes and picks up the latest closure colors.
+      themeNudge.value
+      return {
+        opacity: withTiming(disabled ? 0.45 : 1, motion.press),
+        backgroundColor: interpolateColor(
+          selected.value,
+          [0, 1],
+          [color.background.white, color.secondary.s400]
+        ),
+        borderColor: interpolateColor(
+          selected.value,
+          [0, 1],
+          [color.border.strong, color.secondary.s400]
+        ),
+        transform: [{ scale: interpolate(pressed.value, [0, 1], [1, 0.95]) }]
+      }
+    },
     [
       disabled,
       color.background.white,
@@ -161,13 +163,16 @@ export const SelectablePill = (props: SelectablePillProps) => {
   )
 
   const animatedTextStyles = useAnimatedStyle(
-    () => ({
-      color: interpolateColor(
-        selected.value,
-        [0, 1],
-        [color.text.default, color.static.white]
-      )
-    }),
+    () => {
+      themeNudge.value
+      return {
+        color: interpolateColor(
+          selected.value,
+          [0, 1],
+          [color.text.default, color.static.white]
+        )
+      }
+    },
     [color.text.default, color.static.white]
   )
 

--- a/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
@@ -8,7 +8,7 @@ import {
   updateRouteOnCompletion,
   setValueField
 } from 'common/store/pages/signon/actions'
-import { useDarkMode } from 'react-native-dynamic'
+import { useColorScheme } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import {
@@ -90,7 +90,7 @@ export const SignOnScreen = (props: SignOnScreenProps) => {
     setScreen(screenParam)
   }, [guestEmail, routeOnCompletion, screenParam])
 
-  const isDarkMode = useDarkMode()
+  const isDarkMode = useColorScheme() === 'dark'
   const signOnThemeName = isDarkMode ? 'default-dark' : 'default-light'
 
   if (!isSplashScreenDismissed) return null


### PR DESCRIPTION
## Summary

Two related mobile theming bugs:

- **Initial dark mode not detected on launch.** With `theme: auto` and a dark system, the app rendered in light mode until backgrounded/foregrounded. `react-native-dynamic`'s `useDarkMode()` returns a stale `light` value on first render until its native listener fires; the `appState === 'active'` guard then prevented the redux dispatch from re-running until backgrounding nudged it. Switched the mobile `ThemeProvider` (and `SignOnScreen`) to React Native's built-in `useColorScheme()`, which returns the correct value synchronously on first render. The selector also now falls back to `Appearance.getColorScheme()` while redux is unseeded, so the very first paint matches the OS. The first dispatch is forced regardless of `appState` so the value is always seeded; the iOS app-switcher snapshot guard remains for subsequent updates.

- **SelectablePill kept old palette colors after a theme flip.** The previous workaround set `selected.value = 1 - target` then `selected.value = target` synchronously. Reanimated batches shared-value writes, so the UI thread saw a single no-op write and the worklets never re-executed with the new closure colors. Introduced a `themeNudge` shared value that increments when any of the relevant theme colors change; both `useAnimatedStyle` worklets read it, so they re-run on the UI thread and pick up the latest palette.

## Test plan

- [ ] On iOS with system in **Dark** + theme set to **Auto**, force-quit and relaunch the app — should render in dark immediately (not flip after backgrounding).
- [ ] Same scenario on Android.
- [ ] Toggle the system between Light/Dark while the app is foregrounded — theme should follow.
- [ ] Background the app on iOS — theme must not flicker to dark from the app-switcher snapshot.
- [ ] With Selectable Pills visible (e.g. trending/feed filters), switch theme palette/mode — pill background, border, and text colors should all update without needing to re-mount the screen.
- [ ] Tap a pill to select/deselect — selection animation still smooth across both palettes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017qjBspRqS66o8zY3oXVZMn)_