### PR TITLE
Honor "Request Desktop Site" on mobile browsers

### DIFF
--- a/.changeset/honor-request-desktop-site.md
+++ b/.changeset/honor-request-desktop-site.md
@@ -1,0 +1,5 @@
+---
+'@audius/web': patch
+---
+
+Honor "Request Desktop Site" on mobile browsers: when a mobile browser flips its User-Agent to a desktop one (via the browser's "Request Desktop Site" toggle, or iPadOS Safari's default Mac UA), serve the desktop web app instead of the mobile experience.

--- a/packages/web/src/common/utils/isMobileWeb.ts
+++ b/packages/web/src/common/utils/isMobileWeb.ts
@@ -3,6 +3,9 @@
 // isNativeMobile from storeContext first.
 
 /** This check CANNOT be used in the mobile app (React Native). It should only be run once we already know that we are NOT on the native mobile app. */
+// Respect the User-Agent so "Request Desktop Site" works: when a mobile
+// browser flips its UA to desktop, we serve the desktop app. Avoid
+// platform/touchPoints heuristics that would override that explicit choice.
 export const isMobileWeb = () => {
   let check = false
   ;(function (a) {
@@ -17,9 +20,6 @@ export const isMobileWeb = () => {
     )
       check = true
   })(navigator.userAgent || navigator.vendor || window.opera)
-  // iPad iOS 13
-  if (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
-    check = true
 
   return check
 }

--- a/packages/web/src/utils/clientUtil.ts
+++ b/packages/web/src/utils/clientUtil.ts
@@ -44,20 +44,15 @@ export const isMobile = () => {
     // localStorage may be unavailable (private mode, SSR); fall through.
   }
 
-  let check = false
-  if (
+  // Respect the User-Agent so that "Request Desktop Site" works: when a
+  // mobile browser toggles desktop mode the UA flips to a desktop one, and
+  // we should serve the desktop app. Avoid platform/touchPoints heuristics
+  // (e.g. iPadOS sending a Mac UA) that would override that explicit choice.
+  // @ts-ignore -- TODO fix mobile imports causing type errors
+  return isMobileUserAgent(
     // @ts-ignore -- TODO fix mobile imports causing type errors
-    isMobileUserAgent(navigator.userAgent || navigator.vendor || window.opera)
-  ) {
-    check = true
-  }
-
-  // iPad iOS 13
-  if (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) {
-    check = true
-  }
-
-  return check
+    navigator.userAgent || navigator.vendor || window.opera
+  )
 }
 
 export const isElectron = () => {


### PR DESCRIPTION
## Summary

Today, when a user on a mobile browser toggles "Request Desktop Site", the User-Agent flips to a desktop one — but the web client still serves the mobile experience. The cause is a fallback in `isMobile()` (and the duplicate `isMobileWeb()`) that flags any device with `navigator.platform === 'MacIntel'` and `maxTouchPoints > 1` as mobile, overriding the UA. iPadOS 13+ Safari sends a Mac UA by default, so iPads always tripped this branch regardless of what the browser claimed to be.

This PR removes that override. The User-Agent regex on its own already returns `false` once a mobile browser advertises a desktop UA, so we now serve the desktop app whenever the browser asks for it.

- `packages/web/src/utils/clientUtil.ts`: drop the `MacIntel` + touchPoints branch in `isMobile()`; rely on `isMobileUserAgent()` only.
- `packages/web/src/common/utils/isMobileWeb.ts`: drop the same branch in the duplicate web copy.

The dev-only `localStorage.__FORCE_MOBILE__` override is preserved.

## Test plan

- [ ] On an iPhone, Safari with default settings → mobile site (UA contains "iPhone").
- [ ] On an iPhone, Safari → "Request Desktop Website" → desktop site is served.
- [ ] On an iPad (iPadOS 13+) with default Safari settings → desktop site (matches the browser's stated UA).
- [ ] On an iPad with "Request Mobile Website" toggled → mobile site (UA flips to iPad).
- [ ] On Android Chrome, default → mobile site.
- [ ] On Android Chrome, "Desktop site" toggled → desktop site.
- [ ] On a regular desktop browser → desktop site (no regression).
- [ ] Dev-only `localStorage.__FORCE_MOBILE__ = '1'` still forces mobile mode in a desktop browser.

https://claude.ai/code/session_01AJfWVtxfhkeoypc9x1Lvez

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJfWVtxfhkeoypc9x1Lvez)_