### PR TITLE
Auto-create USDC userbank on gated track upload/edit

### DIFF
--- a/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
@@ -18,6 +18,7 @@ import {
   isContentTokenGated,
   isContentUSDCPurchaseGated
 } from '~/models/Track'
+import { createUserBankIfNeeded } from '~/services/audius-backend'
 import { CommonState } from '~/store/commonStore'
 import { stemsUploadSelectors } from '~/store/stems-upload'
 import { replaceTrackProgressModalActions } from '~/store/ui/modals/replace-track-progress-modal'
@@ -29,6 +30,7 @@ import { formatMusicalKey } from '~/utils/musicalKeys'
 import { TQTrack } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
 import { addPremiumMetadata } from '../upload/usePublishTracks'
+import { useCurrentAccountUser } from '../users/account/accountSelectors'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { getUserQueryKey } from '../users/useUser'
 import { handleStemUpdates } from '../utils/handleStemUpdates'
@@ -107,6 +109,7 @@ export const useUpdateTrack = () => {
   const store = useStore()
   const { mutate: deleteTrack } = useDeleteTrack()
   const { data: userId } = useCurrentUserId()
+  const { data: accountUser } = useCurrentAccountUser()
 
   return useMutation({
     mutationFn: async ({
@@ -133,6 +136,21 @@ export const useUpdateTrack = () => {
         metadata as TrackMetadataForUpload
       )
       const sdkMetadata = trackMetadataForUploadToSdk(metadataWithSplits)
+
+      const ethAddress = accountUser?.wallet
+      if (
+        ethAddress &&
+        (isContentUSDCPurchaseGated(metadataWithSplits.stream_conditions) ||
+          isContentUSDCPurchaseGated(metadataWithSplits.download_conditions))
+      ) {
+        createUserBankIfNeeded(sdk, {
+          mint: 'USDC',
+          ethAddress,
+          recordAnalytics: analytics.track
+        }).catch((err) => {
+          console.warn('Failed to ensure USDC userbank during track edit', err)
+        })
+      }
 
       const response = await sdk.tracks.updateTrack({
         audioFile,

--- a/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useUpdateTrack.ts
@@ -147,8 +147,13 @@ export const useUpdateTrack = () => {
           mint: 'USDC',
           ethAddress,
           recordAnalytics: analytics.track
-        }).catch((err) => {
-          console.warn('Failed to ensure USDC userbank during track edit', err)
+        }).catch((error) => {
+          reportToSentry({
+            error,
+            additionalInfo: { trackId, userId, ethAddress },
+            feature: Feature.Edit,
+            name: 'Ensure USDC userbank on track edit'
+          })
         })
       }
 

--- a/packages/common/src/api/tan-query/upload/usePublishTracks.ts
+++ b/packages/common/src/api/tan-query/upload/usePublishTracks.ts
@@ -73,8 +73,13 @@ export const publishTracks = async (
       mint: 'USDC',
       ethAddress,
       recordAnalytics: track
-    }).catch((err) => {
-      console.warn('Failed to ensure USDC userbank during track upload', err)
+    }).catch((error) => {
+      reportToSentry({
+        error,
+        additionalInfo: { userId, ethAddress },
+        feature: Feature.Upload,
+        name: 'Ensure USDC userbank on track upload'
+      })
     })
   }
 

--- a/packages/common/src/api/tan-query/upload/usePublishTracks.ts
+++ b/packages/common/src/api/tan-query/upload/usePublishTracks.ts
@@ -8,6 +8,7 @@ import {
   Name,
   Feature
 } from '~/models'
+import { createUserBankIfNeeded } from '~/services/audius-backend'
 import { ProgressStatus, uploadActions } from '~/store'
 import type { TrackMetadataForUpload } from '~/store'
 
@@ -28,6 +29,7 @@ type PublishTracksContext = Pick<
   'audiusSdk' | 'analytics' | 'dispatch' | 'reportToSentry'
 > & {
   userId: number
+  ethAddress?: string | null
   kind?: 'tracks' | 'album' | 'playlist'
 }
 
@@ -45,6 +47,7 @@ export const publishTracks = async (
 ) => {
   const {
     userId,
+    ethAddress,
     kind,
     audiusSdk,
     dispatch,
@@ -57,6 +60,23 @@ export const publishTracks = async (
   }
 
   const sdk = await audiusSdk()
+
+  if (
+    ethAddress &&
+    params.some(
+      (p) =>
+        isContentUSDCPurchaseGated(p.metadata.stream_conditions) ||
+        isContentUSDCPurchaseGated(p.metadata.download_conditions)
+    )
+  ) {
+    createUserBankIfNeeded(sdk, {
+      mint: 'USDC',
+      ethAddress,
+      recordAnalytics: track
+    }).catch((err) => {
+      console.warn('Failed to ensure USDC userbank during track upload', err)
+    })
+  }
 
   return await Promise.all(
     params.map(async (param) => {
@@ -189,6 +209,7 @@ export const usePublishTracks = (
     ...getPublishTracksOptions({
       ...queryContext,
       userId: userId!,
+      ethAddress: accountUser?.wallet,
       kind
     }),
     onSuccess: async (data) => {


### PR DESCRIPTION
## Summary
- When a user uploads or edits a track with USDC stream/download gating, fire `createUserBankIfNeeded(mint: 'USDC')` in parallel with the SDK call so the seller's userbank exists as a side effect of listing gated content — not just after they open Add Cash, withdraw, or claim flows.
- Best-effort: errors are logged but never block the save. Underlying `getOrCreateUserBank` is idempotent, so duplicate triggers (e.g. album publish that fans out to `publishTracks`) are safe.

## Scope
- `useUpdateTrack` (track edit) — `packages/common/src/api/tan-query/tracks/useUpdateTrack.ts`
- `publishTracks` (track upload, also reused by album upload) — `packages/common/src/api/tan-query/upload/usePublishTracks.ts`

## Why not the album-level hooks
- `usePublishCollection` already delegates to `publishTracks` for each child track of a premium album, so the trigger fires there.
- `useUpdateCollection` only edits the album's price metadata; the album was already gated at upload time, so the userbank trigger has already fired via the original track publish.

## Test plan
- [ ] Upload a track with USDC download gating → seller's USDC userbank exists after upload (verify via Solana account lookup or a follow-up purchase)
- [ ] Edit an existing non-gated track to enable USDC downloads → userbank exists after save
- [ ] Edit a USDC-gated track's price (no gate change) → no error, userbank trigger short-circuits via `didExist`
- [ ] Upload a premium album → seller userbank exists once, even with multiple child tracks
- [ ] Upload/edit a non-USDC (free / follow-gated / token-gated) track → no userbank call fires
- [ ] Network failure on userbank creation → upload/edit still succeeds; warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)