### PR TITLE
Fix tooltip alignment by defaulting mount to body

### DIFF
--- a/packages/harmony/src/components/tooltip/Tooltip.tsx
+++ b/packages/harmony/src/components/tooltip/Tooltip.tsx
@@ -135,7 +135,11 @@ export const Tooltip = ({
   className = '',
   color = 'secondary',
   disabled = false,
-  mount = 'parent',
+  // `position: fixed` coordinates are skewed inside any transformed ancestor
+  // (e.g. the sidebar-shift `transform: translateX` on the main app wrapper),
+  // so default to portaling outside the React tree rather than into the
+  // trigger's parent.
+  mount = 'body',
   getPopupContainer,
   mouseEnterDelay = 0.5,
   mouseLeaveDelay = 0,


### PR DESCRIPTION
## Summary
- The repost / favorite / share tooltips on the giant track tile (and elsewhere) appeared to the right of their target icons, offset by ~240px.
- Root cause: `WebPlayer.module.css` puts `transform: translateX(var(--nav-shift))` on `.mainContentWrapper` for the sidebar shift animation. CSS `transform` creates a containing block for `position: fixed` descendants, so any tooltip portaled inside that wrapper has its viewport-relative coordinates interpreted relative to the wrapper instead of the viewport.
- Tooltip already routed `mount='page'` to `document.body` for this exact reason, but the default `mount='parent'` still portaled into the trigger's parent — inside the transformed wrapper.
- Fix: change the default `mount` to `'body'`. Every Tooltip that didn't explicitly opt out is now aligned correctly. The opt-in `parentMount` on `TokenHoverTooltip` continues to work.

## Test plan
- [x] Hovered Share on the giant track tile in a headless browser; tooltip center matched button center exactly (`offset = 0.0px`) and screenshot showed it centered above the icon.
- [x] Spot-check Repost/Favorite/Share on a track page while signed in.
- [x] Spot-check other Tooltip call sites (play bar, table headers, rewards page) for any regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)