### PR TITLE
Send running OTA bundle label to Optimizely as a flag attribute

### DIFF
--- a/.changeset/ota-version-flag-attribute.md
+++ b/.changeset/ota-version-flag-attribute.md
@@ -1,0 +1,6 @@
+---
+'@audius/common': patch
+'@audius/mobile': patch
+---
+
+Forward the running CodePush bundle label to Optimizely as an `otaVersion` attribute (or `"native"` when no OTA is applied), so feature flags can be gated on a specific OTA cut in addition to the native binary version.

--- a/packages/common/src/services/remote-config/remote-config.ts
+++ b/packages/common/src/services/remote-config/remote-config.ts
@@ -41,6 +41,11 @@ type MobileClientInfo = {
   /** This is the type of Platform.OS, but we only expect ios or android here */
   mobilePlatform: 'ios' | 'android' | 'web' | 'windows' | 'macos'
   mobileAppVersion: string
+  /**
+   * Running CodePush bundle label (e.g. "v17"), or "native" when the app is
+   * running the binary's embedded bundle with no OTA applied.
+   */
+  otaVersion?: string
 }
 
 export type RemoteConfigOptions<Client> = {
@@ -245,7 +250,8 @@ export const remoteConfig = <
         appVersion,
         platform,
         mobilePlatform: mobileClientInfo?.mobilePlatform ?? null,
-        mobileAppVersion: mobileClientInfo?.mobileAppVersion ?? null
+        mobileAppVersion: mobileClientInfo?.mobileAppVersion ?? null,
+        otaVersion: mobileClientInfo?.otaVersion ?? null
         // Note: this actually returns `undefined` if optimizely data has not been requested
       }) as boolean | undefined
     }

--- a/packages/mobile/src/services/remote-config/remote-config-instance.ts
+++ b/packages/mobile/src/services/remote-config/remote-config-instance.ts
@@ -1,6 +1,7 @@
 import { ErrorLevel } from '@audius/common/models'
 import type { Environment } from '@audius/common/services'
 import { remoteConfig } from '@audius/common/services'
+import CodePush from '@bravemobile/react-native-code-push'
 import * as optimizely from '@optimizely/optimizely-sdk'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
@@ -19,13 +20,31 @@ const { version: appVersion } = packageInfo
 const OPTIMIZELY_KEY = env.OPTIMIZELY_KEY
 const DATA_FILE_URL = 'https://experiments.audius.co/datafiles/%s.json'
 
+/**
+ * Sentinel returned when no OTA bundle is applied (the app is running its
+ * embedded binary bundle). Lets Optimizely audiences target "native vs OTA"
+ * without distinguishing missing data from a real value.
+ */
+const OTA_VERSION_NATIVE = 'native'
+
+const getOtaVersion = async (): Promise<string> => {
+  try {
+    const pkg = await CodePush.getUpdateMetadata(CodePush.UpdateState.RUNNING)
+    return pkg?.label ?? OTA_VERSION_NATIVE
+  } catch {
+    return OTA_VERSION_NATIVE
+  }
+}
+
 const getMobileClientInfo = async () => {
   const mobilePlatform = Platform.OS
   const mobileAppVersion = VersionNumber.appVersion
+  const otaVersion = await getOtaVersion()
 
   return {
     mobilePlatform,
-    mobileAppVersion
+    mobileAppVersion,
+    otaVersion
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a new `otaVersion` attribute on the Optimizely feature-flag evaluation payload so flags can be gated on the running CodePush bundle (not just the native `mobileAppVersion`).
- On mobile, fetches `CodePush.getUpdateMetadata(RUNNING).label` during remote-config init and forwards it via `getMobileClientInfo`. When no OTA is applied (running the embedded binary bundle), sends the sentinel string `"native"` so audiences can distinguish "no OTA" from "value missing."

## Why
Currently the only mobile-version signal available to Optimizely audiences is the native binary version. After we ship a binary, every OTA on top of it looks identical to the flag system, so we can't gate a feature on a specific OTA cut. This adds the missing dimension with the smallest possible change to the existing attribute plumbing.

## Notes
- `CodePush.getUpdateMetadata` is async and may briefly delay flag readiness; it's awaited inside `getMobileClientInfo` which is already awaited during `init()`.
- Errors / unavailable CodePush environments fall through to `"native"` rather than failing flag eval.
- Optimizely audience targeting is string-based; for "≥ vN" style targeting you'll want labels that compare correctly as strings, or a separate numeric attribute later.

## Test plan
- [ ] Build the mobile app and confirm flag evaluation still works with no OTA applied (attribute should be `"native"`).
- [ ] Apply an OTA bundle, relaunch, and confirm the running label (e.g. `v17`) reaches Optimizely (verify via Optimizely's event/decision logs or a temporary audience targeting `otaVersion = "vN"`).
- [ ] Confirm `mobileAppVersion` and `mobilePlatform` attributes are still set as before.
- [ ] Confirm web/desktop flag eval is unaffected (no `otaVersion` sent, no errors).

https://claude.ai/code/session_01EdfwteTMmW6EfipydJ4EbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdfwteTMmW6EfipydJ4EbD)_