### PR TITLE
Persist allowed_api_keys on track upload/edit

### DIFF
--- a/.changeset/persist-allowed-api-keys.md
+++ b/.changeset/persist-allowed-api-keys.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Add `allowedApiKeys` to `UploadTrackMetadataSchema` so it's preserved when uploading or updating tracks. Previously the strict schema stripped the field, which prevented the "Disallow Streaming via the API" setting from being saved.

--- a/packages/common/src/adapters/track.test.ts
+++ b/packages/common/src/adapters/track.test.ts
@@ -1,0 +1,33 @@
+import { Genre } from '@audius/sdk'
+import { describe, expect, it } from 'vitest'
+
+import type { TrackMetadataForUpload } from '~/store/upload/types'
+
+import { trackMetadataForUploadToSdk } from './track'
+
+const makeMetadata = (
+  overrides: Partial<TrackMetadataForUpload> = {}
+): TrackMetadataForUpload =>
+  ({
+    title: 'Test Track',
+    genre: Genre.ELECTRONIC,
+    ...overrides
+  }) as TrackMetadataForUpload
+
+describe('trackMetadataForUploadToSdk', () => {
+  it('forwards allowed_api_keys as allowedApiKeys', () => {
+    const result = trackMetadataForUploadToSdk(
+      makeMetadata({ allowed_api_keys: ['some-api-key'] })
+    )
+
+    expect(result.allowedApiKeys).toEqual(['some-api-key'])
+  })
+
+  it('forwards null allowed_api_keys', () => {
+    const result = trackMetadataForUploadToSdk(
+      makeMetadata({ allowed_api_keys: null })
+    )
+
+    expect(result.allowedApiKeys).toBeNull()
+  })
+})

--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -287,7 +287,8 @@ export const trackMetadataForUploadToSdk = (
         'is_custom_musical_key',
         'comments_disabled',
         'ddex_release_ids',
-        'parental_warning_type'
+        'parental_warning_type',
+        'allowed_api_keys'
       ])
     ),
     trackId: OptionalId.parse(input.track_id),

--- a/packages/docs/docs/pages/sdk/tracks.mdx
+++ b/packages/docs/docs/pages/sdk/tracks.mdx
@@ -649,6 +649,7 @@ Metadata object for creating a new track. Fields marked **Required** must be pro
 | `isStreamGated`                | `boolean`                                               | Whether streaming is behind an access gate        | _Optional_   |
 | `streamConditions`             | [`AccessGate`](#accessgate)                             | Conditions for stream access gating               | _Optional_   |
 | `downloadConditions`           | [`AccessGate`](#accessgate)                             | Conditions for download access gating             | _Optional_   |
+| `allowedApiKeys`               | `string[]`                                              | API keys allowed to stream this track             | _Optional_   |
 | `fieldVisibility`              | [`FieldVisibility`](#fieldvisibility)                   | Controls visibility of individual track fields    | _Optional_   |
 | `placementHosts`               | `string`                                                | Preferred storage node placement hosts            | _Optional_   |
 | `stemOf`                       | [`StemParent`](#stemparent)                             | Parent track if this track is a stem              | _Optional_   |
@@ -698,6 +699,7 @@ you want to change. Omitted fields retain their current values.
 | `isStreamGated`       | `boolean`                               | Whether streaming is behind an access gate        |
 | `streamConditions`    | [`AccessGate`](#accessgate)             | Conditions for stream access gating               |
 | `downloadConditions`  | [`AccessGate`](#accessgate)             | Conditions for download access gating             |
+| `allowedApiKeys`      | `string[]`                              | API keys allowed to stream this track             |
 | `fieldVisibility`     | [`FieldVisibility`](#fieldvisibility)   | Controls visibility of individual track fields    |
 | `placementHosts`      | `string`                                | Preferred storage node placement hosts            |
 | `stemOf`              | [`StemParent`](#stemparent)             | Parent track if this track is a stem              |

--- a/packages/docs/docs/public/openapi.yaml
+++ b/packages/docs/docs/public/openapi.yaml
@@ -610,6 +610,100 @@ paths:
         "500":
           description: Server error
           content: {}
+  /fan_club/feed:
+    get:
+      tags:
+        - fan_club
+      description: Get the fan club feed for a given artist, including text posts and comments
+      operationId: Get Fan Club Feed
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: mint
+          in: query
+          description: The mint address of the artist's fan club token
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/track_comments_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /fan-club/feed:
+    get:
+      tags:
+        - fan_club
+      description: Get the fan club feed for a given artist (hyphenated alias), including text posts and comments
+      operationId: Get Fan Club Feed Alias
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: mint
+          in: query
+          description: The mint address of the artist's fan club token
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/track_comments_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
   /developer-apps:
     post:
       tags:
@@ -1099,6 +1193,327 @@ paths:
         "500":
           description: Server error
           content: {}
+  /events/remix-contests:
+    get:
+      tags:
+        - events
+      summary: Get all remix contests
+      description:
+        Get remix contest events ordered with currently-active contests first
+        (by soonest-ending), followed by ended contests (most-recently-ended
+        first). Active contests are those whose end_date is null or in the
+        future.
+      operationId: Get Remix Contests
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+        - name: status
+          in: query
+          description: Filter contests by status
+          schema:
+            type: string
+            default: all
+            enum:
+              - active
+              - ended
+              - all
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/remix_contests_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/comments:
+    get:
+      tags:
+        - events
+      summary: Get event comments
+      description:
+        Paginated stream of top-level comments (with nested replies) for a
+        remix-contest event. Host-authored top-level comments represent
+        "post updates"; everything else is a community comment.
+      operationId: Get Event Comments
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+        - name: sort_method
+          in: query
+          description: The sort method
+          schema:
+            type: string
+            default: newest
+            enum:
+              - top
+              - newest
+              - timestamp
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/track_comments_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/follow:
+    post:
+      tags:
+        - events
+      summary: Follow event
+      description:
+        Subscribe to a remix-contest event. Emits a Subscribe/Event
+        ManageEntity transaction so the indexer records the follow.
+      operationId: Follow Event
+      security:
+        - BearerAuth: []
+        - BasicAuth: []
+        - OAuth2:
+            - write
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Event followed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/write_response"
+        "401":
+          description: Unauthorized
+          content: {}
+        "404":
+          description: Event not found
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+    delete:
+      tags:
+        - events
+      summary: Unfollow event
+      description:
+        Unsubscribe from a remix-contest event. Emits an
+        Unsubscribe/Event ManageEntity transaction.
+      operationId: Unfollow Event
+      security:
+        - BearerAuth: []
+        - BasicAuth: []
+        - OAuth2:
+            - write
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Event unfollowed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/write_response"
+        "401":
+          description: Unauthorized
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/follow_state:
+    get:
+      tags:
+        - events
+      summary: Get event follow state
+      description:
+        Returns whether the current user is subscribed to (follows) a given
+        remix-contest event, plus the total follower count. Useful for
+        rendering the Follow / Following button.
+      operationId: Get Event Follow State
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/event_follow_state_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/follow-state:
+    get:
+      tags:
+        - events
+      summary: Get event follow state (hyphenated alias)
+      description: Hyphenated alias of /events/{eventId}/follow_state.
+      operationId: Get Event Follow State Alias
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/event_follow_state_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/followers:
+    get:
+      tags:
+        - events
+      summary: Get event followers
+      description:
+        Returns the list of users subscribed to a given remix-contest
+        event, ordered by each follower's own follower count so the
+        most-followed fans surface first. Used by the contest page's
+        Followers card (avatar stack + leaderboard).
+      operationId: Get Event Followers
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/followers_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
   /events/unclaimed_id:
     get:
       tags:
@@ -1331,6 +1746,51 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/playlist_search_result"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /playlists/new-releases:
+    get:
+      tags:
+        - playlists
+      description: Returns recently released playlists or albums
+      operationId: Get Playlists New Releases
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+        - name: type
+          in: query
+          description: The type of content to filter by
+          schema:
+            type: string
+            default: playlist
+            enum:
+              - playlist
+              - album
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/trending_playlists_response"
         "400":
           description: Bad request
           content: {}
@@ -2659,6 +3119,52 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/track_search"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /tracks/latest:
+    get:
+      tags:
+        - tracks
+      description: Gets the most recent tracks on Audius, ordered by creation date
+      operationId: Get Latest Tracks
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+        - name: genre
+          in: query
+          description: Filter to a specified genre
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/tracks_response"
         "400":
           description: Bad request
           content: {}
@@ -7694,9 +8200,12 @@ paths:
                 - fan_remix_contest_ended
                 - fan_remix_contest_ending_soon
                 - fan_remix_contest_winners_selected
+                - fan_remix_contest_submission
                 - artist_remix_contest_ended
                 - artist_remix_contest_ending_soon
                 - artist_remix_contest_submissions
+                - fan_club_text_post
+                - remix_contest_update
       responses:
         "200":
           description: Success
@@ -10452,6 +10961,12 @@ components:
           items:
             type: string
           description: Wallet addresses that can sign to authorize stream access (programmable distribution). When empty or omitted, the track is public and validator/creator nodes can serve it.
+        allowed_api_keys:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: API keys allowed to stream this track
         stream_conditions:
           nullable: true
           allOf:
@@ -10577,6 +11092,11 @@ components:
           items:
             type: integer
             example: 67890
+        videoUrl:
+          type: string
+          nullable: true
+          maxLength: 2048
+          description: Optional URL for a video attachment (stored on the comment record)
     dashboard_wallet_users_response:
       type: object
       properties:
@@ -10676,6 +11196,12 @@ components:
           items:
             type: string
           description: Wallet addresses that can sign to authorize stream access (programmable distribution). When empty or omitted, the track is public and validator/creator nodes can serve it.
+        allowed_api_keys:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: API keys allowed to stream this track
         stream_conditions:
           nullable: true
           allOf:
@@ -11280,6 +11806,54 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/event"
+    remix_contests_related:
+      type: object
+      properties:
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/user"
+        tracks:
+          type: array
+          items:
+            $ref: "#/components/schemas/track"
+        entry_counts:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int64
+          description:
+            Per-contest entry counts keyed by the contest's parent track id
+            (hashid). Lets the discovery UI render entry counts without
+            issuing an extra `/tracks/{id}/remixes?limit=0` per card.
+    remix_contests_response:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/event"
+        related:
+          $ref: "#/components/schemas/remix_contests_related"
+    event_follow_state:
+      required:
+        - is_followed
+        - follower_count
+      type: object
+      properties:
+        is_followed:
+          type: boolean
+          description:
+            Whether the authenticated / requested user is currently
+            subscribed to this event.
+        follower_count:
+          type: integer
+          description: Total number of users following this event.
+    event_follow_state_response:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/event_follow_state"
     version_metadata:
       required:
         - service
@@ -14681,6 +15255,8 @@ components:
       description: Type of entity that can be commented on
       enum:
         - Track
+        - FanClub
+        - Event
     top_listener:
       type: object
       properties:
@@ -14743,6 +15319,12 @@ components:
           type: boolean
         is_tombstone:
           type: boolean
+        is_members_only:
+          type: boolean
+        video_url:
+          type: string
+          nullable: true
+          description: Optional URL for a video attachment on this comment
         is_muted:
           type: boolean
         created_at:
@@ -16046,6 +16628,10 @@ components:
           type: string
         updated_at:
           type: string
+        video_url:
+          type: string
+          nullable: true
+          description: Optional URL for a video attachment on this reply
         parent_comment_id:
           type: integer
     user_playlist_library:
@@ -16239,6 +16825,11 @@ components:
           type: number
           description: The balance of the coin in the user's account in USD
           example: 1.23
+        accounts:
+          type: array
+          description: Per-token-account breakdown of the user's holdings for this coin. Populated by GET /v1/users/{id}/coins; omitted by GET /v1/wallet/{walletId}/coins.
+          items:
+            $ref: "#/components/schemas/user_coin_account"
     track_feed_item:
       required:
         - item
@@ -16346,6 +16937,9 @@ components:
         - $ref: "#/components/schemas/artist_remix_contest_ending_soon_notification"
         - $ref: "#/components/schemas/artist_remix_contest_submissions_notification"
         - $ref: "#/components/schemas/fan_remix_contest_winners_selected_notification"
+        - $ref: "#/components/schemas/remix_contest_update_notification"
+        - $ref: "#/components/schemas/fan_remix_contest_submission_notification"
+        - $ref: "#/components/schemas/fan_club_text_post_notification"
       discriminator:
         propertyName: type
         mapping:
@@ -16390,6 +16984,9 @@ components:
           artist_remix_contest_ending_soon: "#/components/schemas/artist_remix_contest_ending_soon_notification"
           artist_remix_contest_submissions: "#/components/schemas/artist_remix_contest_submissions_notification"
           fan_remix_contest_winners_selected: "#/components/schemas/fan_remix_contest_winners_selected_notification"
+          remix_contest_update: "#/components/schemas/remix_contest_update_notification"
+          fan_remix_contest_submission: "#/components/schemas/fan_remix_contest_submission_notification"
+          fan_club_text_post: "#/components/schemas/fan_club_text_post_notification"
     save_notification:
       required:
         - actions
@@ -16538,6 +17135,46 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/fan_remix_contest_winners_selected_notification_action"
+    remix_contest_update_notification:
+      required:
+        - actions
+        - group_id
+        - is_seen
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+        group_id:
+          type: string
+        is_seen:
+          type: boolean
+        seen_at:
+          type: integer
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/remix_contest_update_notification_action"
+    fan_remix_contest_submission_notification:
+      required:
+        - actions
+        - group_id
+        - is_seen
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+        group_id:
+          type: string
+        is_seen:
+          type: boolean
+        seen_at:
+          type: integer
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/fan_remix_contest_submission_notification_action"
     tier_change_notification:
       required:
         - actions
@@ -16966,6 +17603,38 @@ components:
           type: integer
         data:
           $ref: "#/components/schemas/fan_remix_contest_winners_selected_notification_action_data"
+    remix_contest_update_notification_action:
+      required:
+        - data
+        - specifier
+        - timestamp
+        - type
+      type: object
+      properties:
+        specifier:
+          type: string
+        type:
+          type: string
+        timestamp:
+          type: integer
+        data:
+          $ref: "#/components/schemas/remix_contest_update_notification_action_data"
+    fan_remix_contest_submission_notification_action:
+      required:
+        - data
+        - specifier
+        - timestamp
+        - type
+      type: object
+      properties:
+        specifier:
+          type: string
+        type:
+          type: string
+        timestamp:
+          type: integer
+        data:
+          $ref: "#/components/schemas/fan_remix_contest_submission_notification_action_data"
     send_tip_notification_action:
       required:
         - data
@@ -17235,6 +17904,26 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/supporter_rank_up_notification_action"
+    fan_club_text_post_notification:
+      required:
+        - actions
+        - group_id
+        - is_seen
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+        group_id:
+          type: string
+        is_seen:
+          type: boolean
+        seen_at:
+          type: integer
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/fan_club_text_post_notification_action"
     fan_remix_contest_started_notification:
       required:
         - actions
@@ -17516,6 +18205,41 @@ components:
         entity_user_id:
           type: string
         entity_id:
+          type: string
+    remix_contest_update_notification_action_data:
+      required:
+        - event_id
+        - entity_id
+        - entity_user_id
+        - comment_id
+      type: object
+      properties:
+        event_id:
+          type: string
+        entity_id:
+          type: string
+        entity_user_id:
+          type: string
+        comment_id:
+          type: string
+    fan_remix_contest_submission_notification_action_data:
+      required:
+        - event_id
+        - entity_id
+        - entity_user_id
+        - submission_track_id
+        - submitter_user_id
+      type: object
+      properties:
+        event_id:
+          type: string
+        entity_id:
+          type: string
+        entity_user_id:
+          type: string
+        submission_track_id:
+          type: string
+        submitter_user_id:
           type: string
     trending_notification_action:
       required:
@@ -18346,6 +19070,9 @@ components:
           type: string
         route:
           type: string
+        notification_campaign_id:
+          type: string
+          nullable: true
     supporter_rank_up_notification_action:
       required:
         - data
@@ -18498,6 +19225,22 @@ components:
           type: integer
         data:
           $ref: "#/components/schemas/track_added_to_playlist_notification_action_data"
+    fan_club_text_post_notification_action:
+      required:
+        - data
+        - specifier
+        - timestamp
+        - type
+      type: object
+      properties:
+        specifier:
+          type: string
+        type:
+          type: string
+        timestamp:
+          type: integer
+        data:
+          $ref: "#/components/schemas/fan_club_text_post_notification_action_data"
     fan_remix_contest_started_notification_action:
       required:
         - data
@@ -18550,6 +19293,16 @@ components:
         entity_user_id:
           type: string
         entity_id:
+          type: string
+    fan_club_text_post_notification_action_data:
+      required:
+        - entity_user_id
+        - comment_id
+      type: object
+      properties:
+        entity_user_id:
+          type: string
+        comment_id:
           type: string
     fan_remix_contest_started_notification_action_data:
       required:

--- a/packages/sdk/src/sdk/api/generated/default/models/CreateTrackRequestBody.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/CreateTrackRequestBody.ts
@@ -219,6 +219,12 @@ export interface CreateTrackRequestBody {
      */
     accessAuthorities?: Array<string> | null;
     /**
+     * API keys allowed to stream this track
+     * @type {Array<string>}
+     * @memberof CreateTrackRequestBody
+     */
+    allowedApiKeys?: Array<string> | null;
+    /**
      * 
      * @type {AccessGate}
      * @memberof CreateTrackRequestBody
@@ -385,6 +391,7 @@ export function CreateTrackRequestBodyFromJSONTyped(json: any, ignoreDiscriminat
         'isUnlisted': !exists(json, 'is_unlisted') ? undefined : json['is_unlisted'],
         'isStreamGated': !exists(json, 'is_stream_gated') ? undefined : json['is_stream_gated'],
         'accessAuthorities': !exists(json, 'access_authorities') ? undefined : json['access_authorities'],
+        'allowedApiKeys': !exists(json, 'allowed_api_keys') ? undefined : json['allowed_api_keys'],
         'streamConditions': !exists(json, 'stream_conditions') ? undefined : AccessGateFromJSON(json['stream_conditions']),
         'downloadConditions': !exists(json, 'download_conditions') ? undefined : AccessGateFromJSON(json['download_conditions']),
         'fieldVisibility': !exists(json, 'field_visibility') ? undefined : FieldVisibilityFromJSON(json['field_visibility']),
@@ -440,6 +447,7 @@ export function CreateTrackRequestBodyToJSON(value?: CreateTrackRequestBody | nu
         'is_unlisted': value.isUnlisted,
         'is_stream_gated': value.isStreamGated,
         'access_authorities': value.accessAuthorities,
+        'allowed_api_keys': value.allowedApiKeys,
         'stream_conditions': AccessGateToJSON(value.streamConditions),
         'download_conditions': AccessGateToJSON(value.downloadConditions),
         'field_visibility': FieldVisibilityToJSON(value.fieldVisibility),

--- a/packages/sdk/src/sdk/api/generated/default/models/UpdateTrackRequestBody.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/UpdateTrackRequestBody.ts
@@ -189,6 +189,12 @@ export interface UpdateTrackRequestBody {
      */
     accessAuthorities?: Array<string> | null;
     /**
+     * API keys allowed to stream this track
+     * @type {Array<string>}
+     * @memberof UpdateTrackRequestBody
+     */
+    allowedApiKeys?: Array<string> | null;
+    /**
      * 
      * @type {AccessGate}
      * @memberof UpdateTrackRequestBody
@@ -279,6 +285,7 @@ export function UpdateTrackRequestBodyFromJSONTyped(json: any, ignoreDiscriminat
         'isUnlisted': !exists(json, 'is_unlisted') ? undefined : json['is_unlisted'],
         'isStreamGated': !exists(json, 'is_stream_gated') ? undefined : json['is_stream_gated'],
         'accessAuthorities': !exists(json, 'access_authorities') ? undefined : json['access_authorities'],
+        'allowedApiKeys': !exists(json, 'allowed_api_keys') ? undefined : json['allowed_api_keys'],
         'streamConditions': !exists(json, 'stream_conditions') ? undefined : AccessGateFromJSON(json['stream_conditions']),
         'downloadConditions': !exists(json, 'download_conditions') ? undefined : AccessGateFromJSON(json['download_conditions']),
         'fieldVisibility': !exists(json, 'field_visibility') ? undefined : FieldVisibilityFromJSON(json['field_visibility']),
@@ -321,6 +328,7 @@ export function UpdateTrackRequestBodyToJSON(value?: UpdateTrackRequestBody | nu
         'is_unlisted': value.isUnlisted,
         'is_stream_gated': value.isStreamGated,
         'access_authorities': value.accessAuthorities,
+        'allowed_api_keys': value.allowedApiKeys,
         'stream_conditions': AccessGateToJSON(value.streamConditions),
         'download_conditions': AccessGateToJSON(value.downloadConditions),
         'field_visibility': FieldVisibilityToJSON(value.fieldVisibility),

--- a/packages/sdk/src/sdk/api/tracks/types.ts
+++ b/packages/sdk/src/sdk/api/tracks/types.ts
@@ -153,6 +153,7 @@ export const UploadTrackMetadataSchema = z.object({
     )
     .nullable(),
   accessAuthorities: z.optional(z.array(z.string()).nullable()),
+  allowedApiKeys: z.optional(z.array(z.string()).nullable()),
   isDownloadGated: z.optional(z.boolean()),
   downloadConditions: z
     .optional(


### PR DESCRIPTION
## Summary

Fixes a bug where the **Disallow Streaming via the API** toggle on the track edit/upload form did not persist. The `allowed_api_keys` value was being silently dropped at two layers between the form and the entity manager:

- `trackMetadataForUploadToSdk` (in `packages/common/src/adapters/track.ts`) uses a fixed `pick(...)` allowlist when converting form metadata to SDK shape, and `allowed_api_keys` was missing from it.
- `UploadTrackMetadataSchema` (in `packages/sdk/src/sdk/api/tracks/types.ts`) is `.strict()` and didn't define `allowedApiKeys`, so even if the adapter forwarded it, `parseParams` would have stripped or rejected it before the entity-manager call.

The discovery-provider entity manager already handles `allowed_api_keys` correctly, so the fix is purely on the client/SDK side.

Also documents `allowedApiKeys` in the hand-crafted SDK reference for both `CreateTrackRequestBody` and `UpdateTrackRequestBody` in `packages/docs/docs/pages/sdk/tracks.mdx`.

## Test plan

- [ ] Open a gated or non-gated track in the edit form
- [ ] Toggle **Disallow Streaming via the API** on, save
- [ ] Reload the page and confirm the toggle is still on
- [ ] Toggle off, save, reload — confirm it's off
- [ ] Repeat on the upload form for a new track

🤖 Generated with [Claude Code](https://claude.com/claude-code)