### PR TITLE
Fix missing right padding on desktop play bar

### DIFF
--- a/packages/web/src/components/play-bar/desktop/PlayBar.module.css
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.module.css
@@ -87,6 +87,7 @@
   flex: 0 1 230px;
   display: inline-flex;
   align-items: center;
+  padding-right: 16px;
 }
 
 .narrow .playBarPlayingInfo {


### PR DESCRIPTION
## Summary

- The favorite (heart) button on the right side of the desktop play bar was sitting flush against the browser edge with no padding
- Added `padding-right: 16px` to `.optionsRight` in `PlayBar.module.css` to match the `padding-left: 16px` already present on the left side (`.info` in `PlayingTrackInfo.module.css`)

## What changed

**`packages/web/src/components/play-bar/desktop/PlayBar.module.css`**
- Added `padding-right: 16px` to `.optionsRight` so the right edge of the play bar is symmetrical with the left

## Reviewer notes

The narrow breakpoint already had `padding-right: 16px` on `.narrow .optionsRight` — this just brings the default (non-narrow) state in line with the same value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)