### PR TITLE
[Mobile] Fix queue drawer drag conflict and refine header

### DIFF
--- a/.changeset/fix-mobile-queue-drag.md
+++ b/.changeset/fix-mobile-queue-drag.md
@@ -1,0 +1,5 @@
+---
+'@audius/mobile': patch
+---
+
+Fix the mobile play queue drag-to-reorder gesture: dragging a track row was being claimed by the queue drawer's swipe-to-dismiss pan responder, so reorder attempts dragged the drawer down instead. The drawer now suspends its pan responder while a row is being dragged. Also adds a grabber bar above the Queue title and a bit more breathing room in the header.

--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -135,6 +135,12 @@ export type DrawerProps = {
    */
   isGestureSupported?: boolean
   /**
+   * When true, the drawer's pan responder will refuse to claim new gestures.
+   * Use this to defer to nested gesture-driven UI (e.g. drag-to-reorder lists)
+   * without tearing down the pan responder entirely.
+   */
+  gesturesDisabled?: boolean
+  /**
    * Whether or not the background behind the drawer should dim
    */
   shouldBackgroundDim?: boolean
@@ -276,6 +282,7 @@ export const Drawer: DrawerComponent = ({
   isFullscreen,
   shouldBackgroundDim = true,
   isGestureSupported = true,
+  gesturesDisabled = false,
   animationStyle = DrawerAnimationStyle.SPRINGY,
   initialOffsetPosition = 0,
   shouldCloseToInitialOffset,
@@ -322,6 +329,13 @@ export const Drawer: DrawerComponent = ({
   // want to capture the users previous intent so that our next pan gesture can be
   // handled properly.
   const isOpenIntent = useRef(isOpen)
+
+  // Mirror gesturesDisabled into a ref so the pan responder always reads the
+  // latest value without needing to be recreated.
+  const gesturesDisabledRef = useRef(gesturesDisabled)
+  useEffect(() => {
+    gesturesDisabledRef.current = gesturesDisabled
+  }, [gesturesDisabled])
 
   const slideIn = useCallback(
     (position: number, velocity?: number, onFinished?: () => void) => {
@@ -464,6 +478,7 @@ export const Drawer: DrawerComponent = ({
     () =>
       PanResponder.create({
         onMoveShouldSetPanResponder: (e, gestureState) => {
+          if (gesturesDisabledRef.current) return false
           return Math.abs(gestureState.dy) > ON_MOVE_RESPONDER_DY
         },
         /**

--- a/packages/mobile/src/components/queue-drawer/QueueDrawer.tsx
+++ b/packages/mobile/src/components/queue-drawer/QueueDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useTrack, useUser } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
@@ -78,6 +78,7 @@ type RowProps = {
   onPlay?: () => void
   onRemove?: () => void
   drag?: () => void
+  onDragHandleLongPress?: () => void
 }
 
 const MiniTrackRow = ({
@@ -87,7 +88,8 @@ const MiniTrackRow = ({
   onPlayPause,
   onPlay,
   onRemove,
-  drag
+  drag,
+  onDragHandleLongPress
 }: RowProps) => {
   const { color, spacing } = useTheme()
   const { data: track } = useTrack(trackId, {
@@ -189,6 +191,7 @@ const MiniTrackRow = ({
             {drag ? (
               <Pressable
                 onLongPress={() => {
+                  onDragHandleLongPress?.()
                   haptics.medium()
                   drag()
                 }}
@@ -263,8 +266,35 @@ export const QueueDrawer = () => {
   const queue = useSelector(getPlaybackQueue)
   const index = useSelector(getPlaybackIndex)
   const isPlaying = useSelector(getIsPlaying)
-  const { spacing } = useTheme()
+  const { spacing, color } = useTheme()
   const { trackIds: nextFromIds, sourceKey } = useNextFromSourceMobile()
+
+  // Suspend the parent drawer's swipe-to-dismiss gesture while the user is
+  // reordering items. Without this, the drawer's PanResponder claims the
+  // vertical drag and the drawer slides instead of the row.
+  const [isItemDragging, setIsItemDragging] = useState(false)
+  const dragResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const handleDragHandleLongPress = useCallback(() => {
+    if (dragResetTimeout.current) {
+      clearTimeout(dragResetTimeout.current)
+      dragResetTimeout.current = null
+    }
+    setIsItemDragging(true)
+  }, [])
+  const handleDragRelease = useCallback(() => {
+    // Defer slightly so the drawer's PanResponder can't grab the tail end of
+    // the gesture as the finger lifts.
+    if (dragResetTimeout.current) clearTimeout(dragResetTimeout.current)
+    dragResetTimeout.current = setTimeout(() => {
+      setIsItemDragging(false)
+      dragResetTimeout.current = null
+    }, 150)
+  }, [])
+  useEffect(() => {
+    return () => {
+      if (dragResetTimeout.current) clearTimeout(dragResetTimeout.current)
+    }
+  }, [])
 
   const nowPlaying: PlaybackTrack | null =
     index >= 0 && index < queue.length ? queue[index] : null
@@ -359,10 +389,17 @@ export const QueueDrawer = () => {
           onPlay={() => handlePlayQueueItem(item.queueIndex)}
           onRemove={() => handleRemove(item.queueIndex)}
           drag={drag}
+          onDragHandleLongPress={handleDragHandleLongPress}
         />
       )
     },
-    [isPlaying, handleTogglePlay, handlePlayQueueItem, handleRemove]
+    [
+      isPlaying,
+      handleTogglePlay,
+      handlePlayQueueItem,
+      handleRemove,
+      handleDragHandleLongPress
+    ]
   )
 
   const draggableData = useMemo<ListItem[]>(() => {
@@ -381,14 +418,25 @@ export const QueueDrawer = () => {
       drawerName={DRAWER_NAME}
       onClose={onClose}
       drawerStyle={{ paddingHorizontal: 0, paddingVertical: 0 }}
+      gesturesDisabled={isItemDragging}
     >
       <View style={{ width: '100%', paddingBottom: spacing.l }}>
+        <Flex alignItems='center' pt='s' pb='xs'>
+          <View
+            style={{
+              width: 36,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: color.neutral.n200
+            }}
+          />
+        </Flex>
         <Flex
           direction='row'
           alignItems='center'
           justifyContent='space-between'
           ph='l'
-          pv='m'
+          pv='l'
         >
           <Text variant='title' size='l' strength='strong' color='default'>
             {messages.queue}
@@ -417,8 +465,12 @@ export const QueueDrawer = () => {
                     : `un-${item.trackId}-${i}`
               }
               renderItem={renderQueuedItem as any}
-              onDragBegin={() => haptics.medium()}
+              onDragBegin={() => {
+                setIsItemDragging(true)
+                haptics.medium()
+              }}
               onDragEnd={({ from, to }) => {
+                handleDragRelease()
                 // The first item is always the now-playing track (not draggable).
                 // Adjust indices to match the queuedListData (which excludes
                 // now-playing).


### PR DESCRIPTION
## Summary

- Trying to drag-reorder a track in the mobile play queue ended up dragging the drawer down instead — the queue drawer's parent `Drawer` `PanResponder` was claiming vertical gestures before `DraggableFlatList` could.
- Adds a `gesturesDisabled` prop to `Drawer` (mirrored to a ref so the existing `useMemo`'d pan responder picks it up without rebuilding) that makes `onMoveShouldSetPanResponder` return `false`. The queue drawer flips this on the row's long-press and `onDragBegin`, and clears it shortly after `onDragEnd` so the drawer's pan responder can't grab the tail of the gesture.
- Refines the header: adds a small grabber bar above "Queue" so the swipe-to-dismiss affordance is visible, and a bit more vertical room around the title row.

## Test plan

- [ ] On iOS and Android, open the now-playing queue, long-press the drag handle on a track, and reorder — the row should follow your finger rather than the drawer dragging away.
- [ ] After reordering, the drawer's swipe-to-dismiss still works (drag down on the drawer body).
- [ ] Tapping (without long-pressing) the drag handle does not break drawer dismiss.
- [ ] The Queue header shows a grabber bar centered above the title and looks less cramped.
- [ ] Empty-queue state and "Up Next" section still render correctly.

https://claude.ai/code/session_01XKixvNgPmpzxZQcrdHxjHS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKixvNgPmpzxZQcrdHxjHS)_