### PR TITLE
mobile: re-add Sentry with conservative sampling and ignore list

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -77,6 +77,7 @@
     "@react-navigation/stack": "^7.4.2",
     "@redux-devtools/remote": "0.8.0",
     "@reduxjs/toolkit": "1.6.1",
+    "@sentry/react-native": "^6.20.0",
     "@shopify/flash-list": "^1.8.3",
     "@snapchat/snap-kit-react-native": "0.4.0",
     "@solana-mobile/mobile-wallet-adapter-protocol": "2.2.5",

--- a/packages/mobile/src/app/sentry.ts
+++ b/packages/mobile/src/app/sentry.ts
@@ -1,8 +1,44 @@
-// Sentry removed from mobile - using only console logging and other error tracking
+import * as Sentry from '@sentry/react-native'
 
-export const navigationIntegration = null
+import { env } from 'app/services/env'
+
+import packageJson from '../../package.json'
+
+const { version: appVersion } = packageJson
+
+export const navigationIntegration = Sentry.reactNavigationIntegration({
+  enableTimeToInitialDisplay: true
+})
 
 export const initSentry = () => {
-  // No-op: Sentry disabled for mobile
-  // console.log('Sentry disabled for mobile app')
+  if (!env.SENTRY_DSN) return
+
+  Sentry.init({
+    dsn: env.SENTRY_DSN,
+    release: appVersion,
+    integrations: [
+      navigationIntegration,
+      Sentry.reactNativeTracingIntegration()
+    ],
+    enableUserInteractionTracing: true,
+    tracesSampleRate: 0.1,
+    ignoreErrors: [
+      'Network request failed',
+      'Network Error',
+      'NetworkError',
+      'The Internet connection appears to be offline',
+      'No internet connection',
+      'Connection lost',
+      /timeout.*exceeded/i,
+      'AbortError',
+      'User cancelled',
+      'Login cancelled',
+      'cancelled by user',
+      'Non-Error promise rejection captured'
+    ]
+  })
+  Sentry.setTag('platform', 'mobile')
+  if (process.env.VITE_CURRENT_GIT_SHA) {
+    Sentry.setTag('commit_sha', process.env.VITE_CURRENT_GIT_SHA)
+  }
 }


### PR DESCRIPTION
## Summary
- Re-introduces `@sentry/react-native` (^6.20.0) to `packages/mobile`, replacing the no-op `initSentry()` left behind after the RN 0.77 upgrade.
- Reuses the existing `env.SENTRY_DSN` (same DSN as web; events are tagged `platform=mobile` so they're filterable in the Sentry UI).
- Drops `tracesSampleRate` from `1.0` (previous config) to `0.1` to preserve quota.
- Adds an `ignoreErrors` list for known-noisy transient/cancellation cases (network failures, AbortError, "User cancelled", non-Error rejections, etc.).
- Restores `navigationIntegration` so React Navigation route changes register as transactions.

## Context
Sentry was removed from mobile in [`da4fd75f`](https://github.com/AudiusProject/apps/commit/da4fd75fbaa0c800845a1fa546ad6ea257aa312f) (the RN 0.77 upgrade) — likely because `@sentry/react-native@6.11.0` wasn't yet compatible. RN has since moved to 0.78.3 + React 19, and recent 6.x versions of the SDK support that combination. The `initSentry()` wrapper and its `App.tsx` callsite were preserved during removal, so re-enabling is mostly a content swap inside one file.

## Follow-ups (not in this PR)
This PR only restores the JS-side integration. To get the full pipeline working, the following native pieces still need to be wired up:

- **iOS:** add Sentry to `ios/Podfile`, run `pod install`, drop a `sentry.properties` next to the project, and add the source-map upload build phase.
- **Android:** apply the Sentry Gradle plugin in `android/app/build.gradle`, add a matching `sentry.properties`.
- **CI:** verify the existing `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` secrets referenced in `.github/workflows/mobile.yml` still resolve to the right project for the upload step.
- **Version pin:** `^6.20.0` was picked as a recent 6.x supporting RN 0.78 / React 19, but please confirm against your install/build before merging — adjust if `npm install` flags peer-dep issues.

Without the native side, the JS will still call `Sentry.init` and report errors over the network, but stacks won't be symbolicated and releases won't be associated with uploaded source maps.

## Test plan
- [ ] `npm install` from repo root resolves `@sentry/react-native@^6.20.0` cleanly against RN 0.78.3 / React 19.
- [ ] iOS dev build (`npm run ios:dev`) launches without runtime errors from Sentry init.
- [ ] Android dev build (`npm run android:dev`) launches without runtime errors from Sentry init.
- [ ] Trigger a thrown error in dev and confirm it lands in the Sentry project tagged `platform=mobile`.
- [ ] Confirm a sampled transaction appears for a navigation event (10% sample rate, may need a few attempts).
- [ ] Verify `Network request failed` and `User cancelled` errors are filtered out (do not appear in Sentry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)