### PR TITLE
Fix profile/track cover photo banner clipped horizontally

### DIFF
--- a/.changeset/fix-banner-clipping.md
+++ b/.changeset/fix-banner-clipping.md
@@ -1,0 +1,5 @@
+---
+'@audius/web': patch
+---
+
+Fix profile and track cover photo banners being clipped horizontally. An inline `position: relative` on the inner photo div was overriding the CSS module's `position: absolute`, which dropped the photo into the parent flex container alongside the edit button — both flex items competed for space, shrinking the banner below full width.

--- a/packages/web/src/components/cover-photo/CoverPhoto.tsx
+++ b/packages/web/src/components/cover-photo/CoverPhoto.tsx
@@ -108,7 +108,6 @@ const CoverPhoto = ({
         aria-label={messages.altText}
         className={styles.photo}
         style={{
-          position: 'relative',
           backgroundImage: imageSettings.backgroundImage,
           ...imageSettings.backgroundStyle
         }}


### PR DESCRIPTION
## Summary

The cover photo banner on profiles (and the track page, which uses the same `CoverPhoto` component) was clipped on the right edge — the image only filled part of the 376px-tall banner area instead of the full page width.

The image-consolidation refactor in #14196 replaced the legacy `DynamicImage` with a single `<div>` and added an inline `position: 'relative'` to give the blur overlay a positioning context. That inline rule overrode the `.photo` CSS class's `position: absolute`, which silently changed the layout: with `position: absolute`, the photo div was taken out of the parent `.coverPhoto`'s flex layout and sized to fill it. With `position: relative`, the photo became a flex sibling of the `.button` div (also `width: 100%`), so the two flex items competed for space and the banner shrank below full width.

Removing the inline `position: 'relative'` lets the CSS class's `position: absolute` take effect again. The blur overlay's `position: absolute; inset: 0` still anchors correctly because `position: absolute` is itself a containing block for descendants.

This was missed during the #14234 image-loading fix follow-up; this PR addresses it.

## Test plan

- [ ] Visit a profile with a cover photo set on desktop — banner image fills the full viewport width
- [ ] Visit a track page on desktop — same
- [ ] Visit a profile with no cover photo (fallback to blurred profile picture) — banner still spans the full width and the blur overlay sits flush over the image
- [ ] Edit-mode profile (own profile) — the cover photo edit button still appears in the top-right of the banner

---
_Generated by [Claude Code](https://claude.ai/code/session_013L5gBvHwVjzABPTBKPJL2T)_