### PR TITLE
feat: add Amplitude analytics to play queue UI interactions

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -292,6 +292,15 @@ export enum Name {
   // Playback performance metrics
   BUFFERING_TIME = 'Buffering Time',
 
+  // Play Queue
+  PLAY_QUEUE_OPEN = 'Play Queue: Open',
+  PLAY_QUEUE_CLOSE = 'Play Queue: Close',
+  PLAY_QUEUE_ADD_TRACK = 'Play Queue: Add Track',
+  PLAY_QUEUE_REMOVE_TRACK = 'Play Queue: Remove Track',
+  PLAY_QUEUE_REORDER_TRACK = 'Play Queue: Reorder Track',
+  PLAY_QUEUE_PLAY_TRACK = 'Play Queue: Play Track',
+  PLAY_QUEUE_CLEAR = 'Play Queue: Clear',
+
   // Navigation
   PAGE_VIEW = 'Page View',
   ON_FIRST_PAGE = 'nav-on-first-page',
@@ -1496,6 +1505,47 @@ type PlaylistPlay = {
 type BufferingTime = {
   eventName: Name.BUFFERING_TIME
   duration: number
+}
+
+// Play Queue
+type PlayQueueOpen = {
+  eventName: Name.PLAY_QUEUE_OPEN
+  source: 'queue'
+  queueLength?: number
+}
+type PlayQueueClose = {
+  eventName: Name.PLAY_QUEUE_CLOSE
+  source: 'queue'
+}
+type PlayQueueAddTrack = {
+  eventName: Name.PLAY_QUEUE_ADD_TRACK
+  source: 'queue'
+  trackId: string
+  from?: 'overflow menu' | 'queue'
+}
+type PlayQueueRemoveTrack = {
+  eventName: Name.PLAY_QUEUE_REMOVE_TRACK
+  source: 'queue'
+  trackId: string
+  position: number
+}
+type PlayQueueReorderTrack = {
+  eventName: Name.PLAY_QUEUE_REORDER_TRACK
+  source: 'queue'
+  trackId: string
+  fromPosition: number
+  toPosition: number
+}
+type PlayQueuePlayTrack = {
+  eventName: Name.PLAY_QUEUE_PLAY_TRACK
+  source: 'queue'
+  trackId: string
+  position: number
+}
+type PlayQueueClear = {
+  eventName: Name.PLAY_QUEUE_CLEAR
+  source: 'queue'
+  queueLength: number
 }
 
 // Linking
@@ -3202,6 +3252,13 @@ export type AllTrackingEvents =
   | PlaybackPause
   | PlaylistPlay
   | BufferingTime
+  | PlayQueueOpen
+  | PlayQueueClose
+  | PlayQueueAddTrack
+  | PlayQueueRemoveTrack
+  | PlayQueueReorderTrack
+  | PlayQueuePlayTrack
+  | PlayQueueClear
   | Follow
   | Unfollow
   | LinkClicking

--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -13,7 +13,8 @@ import {
   RepostSource,
   FavoriteSource,
   FollowSource,
-  ModalSource
+  ModalSource,
+  Name
 } from '@audius/common/models'
 import type { ID } from '@audius/common/models'
 import {
@@ -35,6 +36,7 @@ import {
   useHostRemixContestModal
 } from '@audius/common/store'
 import type { OverflowActionCallbacks } from '@audius/common/store'
+import { make, useRecord } from 'common/store/analytics/actions'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useDrawer } from 'app/hooks/useDrawer'
@@ -71,6 +73,7 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
   const navigation = useNavigation({ customNavigation: contextNavigation })
   const dispatch = useDispatch()
   const { toast } = useToast()
+  const record = useRecord()
   const { id: modalId, contextPlaylistId } = useSelector(getMobileOverflowModal)
   const id = modalId as ID
   const { onOpen: openPremiumContentPurchaseModal } =
@@ -237,12 +240,26 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
           track: { trackId: id, source: QueueSource.RECOMMENDED_TRACKS }
         })
       )
+      record(
+        make(Name.PLAY_QUEUE_ADD_TRACK, {
+          source: 'queue',
+          trackId: String(id),
+          from: 'overflow menu'
+        })
+      )
       toast({ content: messages.willPlayNext })
     },
     [OverflowAction.ADD_TO_QUEUE]: () => {
       dispatch(
         playbackActions.addToQueue({
           tracks: [{ trackId: id, source: QueueSource.RECOMMENDED_TRACKS }]
+        })
+      )
+      record(
+        make(Name.PLAY_QUEUE_ADD_TRACK, {
+          source: 'queue',
+          trackId: String(id),
+          from: 'overflow menu'
         })
       )
       toast({ content: messages.addedToQueue })

--- a/packages/mobile/src/components/queue-drawer/QueueDrawer.tsx
+++ b/packages/mobile/src/components/queue-drawer/QueueDrawer.tsx
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useTrack, useUser } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
-import { SquareSizes } from '@audius/common/models'
+import { Name, SquareSizes } from '@audius/common/models'
 import type { PlaybackTrack, QueueSource } from '@audius/common/store'
 import { playbackActions, playbackSelectors } from '@audius/common/store'
 import { useQueryClient } from '@tanstack/react-query'
+import { make, useRecord } from 'common/store/analytics/actions'
 import { Pressable, View } from 'react-native'
 import DraggableFlatList from 'react-native-draggable-flatlist'
 import { useDispatch, useSelector } from 'react-redux'
@@ -261,13 +262,33 @@ const sourceLabel = (key: string | null) =>
   SOURCE_LABELS[key ?? ''] ?? 'Up Next'
 
 export const QueueDrawer = () => {
-  const { onClose } = useDrawer(DRAWER_NAME)
+  const { isOpen, onClose } = useDrawer(DRAWER_NAME)
   const dispatch = useDispatch()
   const queue = useSelector(getPlaybackQueue)
   const index = useSelector(getPlaybackIndex)
   const isPlaying = useSelector(getIsPlaying)
   const { spacing, color } = useTheme()
   const { trackIds: nextFromIds, sourceKey } = useNextFromSourceMobile()
+  const record = useRecord()
+
+  const queueLengthRef = useRef(queue.length)
+  useEffect(() => {
+    queueLengthRef.current = queue.length
+  }, [queue.length])
+  const wasOpenRef = useRef(false)
+  useEffect(() => {
+    if (isOpen && !wasOpenRef.current) {
+      record(
+        make(Name.PLAY_QUEUE_OPEN, {
+          source: 'queue',
+          queueLength: queueLengthRef.current
+        })
+      )
+    } else if (!isOpen && wasOpenRef.current) {
+      record(make(Name.PLAY_QUEUE_CLOSE, { source: 'queue' }))
+    }
+    wasOpenRef.current = isOpen
+  }, [isOpen, record])
 
   // Suspend the parent drawer's swipe-to-dismiss gesture while the user is
   // reordering items. Without this, the drawer's PanResponder claims the
@@ -321,20 +342,47 @@ export const QueueDrawer = () => {
   const handlePlayQueueItem = useCallback(
     (queueIndex: number) => {
       dispatch(playTrackAt({ index: queueIndex }))
+      const trackId = queue[queueIndex]?.trackId
+      if (trackId !== undefined) {
+        record(
+          make(Name.PLAY_QUEUE_PLAY_TRACK, {
+            source: 'queue',
+            trackId: String(trackId),
+            position: queueIndex
+          })
+        )
+      }
     },
-    [dispatch]
+    [dispatch, queue, record]
   )
 
   const handleRemove = useCallback(
     (queueIndex: number) => {
+      const trackId = queue[queueIndex]?.trackId
       dispatch(removeFromQueue({ index: queueIndex }))
+      if (trackId !== undefined) {
+        record(
+          make(Name.PLAY_QUEUE_REMOVE_TRACK, {
+            source: 'queue',
+            trackId: String(trackId),
+            position: queueIndex
+          })
+        )
+      }
     },
-    [dispatch]
+    [dispatch, queue, record]
   )
 
   const handleClear = useCallback(() => {
+    const upcomingLength = Math.max(queue.length - upNextStart, 0)
     dispatch(clearUpcoming())
-  }, [dispatch])
+    record(
+      make(Name.PLAY_QUEUE_CLEAR, {
+        source: 'queue',
+        queueLength: upcomingLength
+      })
+    )
+  }, [dispatch, queue.length, upNextStart, record])
 
   const handleReorder = useCallback(
     ({ from, to }: { from: number; to: number }) => {
@@ -348,8 +396,21 @@ export const QueueDrawer = () => {
           orderedIndices: [...orderedIndices.slice(0, upNextStart), ...movable]
         })
       )
+      const fromAbsolute = upNextStart + from
+      const toAbsolute = upNextStart + to
+      const movedTrackId = queue[fromAbsolute]?.trackId
+      if (movedTrackId !== undefined) {
+        record(
+          make(Name.PLAY_QUEUE_REORDER_TRACK, {
+            source: 'queue',
+            trackId: String(movedTrackId),
+            fromPosition: fromAbsolute,
+            toPosition: toAbsolute
+          })
+        )
+      }
     },
-    [dispatch, queue.length, upNextStart]
+    [dispatch, queue, upNextStart, record]
   )
 
   const handleAddNextFromToQueue = useCallback(
@@ -360,8 +421,15 @@ export const QueueDrawer = () => {
           tracks: [{ trackId, source: sourceTag as unknown as QueueSource }]
         })
       )
+      record(
+        make(Name.PLAY_QUEUE_ADD_TRACK, {
+          source: 'queue',
+          trackId: String(trackId),
+          from: 'queue'
+        })
+      )
     },
-    [dispatch, sourceKey]
+    [dispatch, sourceKey, record]
   )
 
   const renderQueuedItem = useCallback(

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -11,7 +11,8 @@ import {
   RepostSource,
   FavoriteSource,
   PlayableType,
-  ID
+  ID,
+  Name
 } from '@audius/common/models'
 import {
   cacheCollectionsActions,
@@ -33,6 +34,7 @@ import { pick } from 'lodash'
 import { connect, useDispatch, useSelector } from 'react-redux'
 import { Dispatch } from 'redux'
 
+import { make } from 'common/store/analytics/actions'
 import * as embedModalActions from 'components/embed-modal/store/actions'
 import { ToastContext } from 'components/toast/ToastContext'
 import { push } from 'utils/navigation'
@@ -338,6 +340,13 @@ const TrackMenu = ({
             track: { trackId, source: QueueSource.RECOMMENDED_TRACKS }
           })
         )
+        dispatch(
+          make(Name.PLAY_QUEUE_ADD_TRACK, {
+            source: 'queue',
+            trackId: String(trackId),
+            from: 'overflow menu'
+          })
+        )
         toast(messages.willPlayNext)
       }
     }
@@ -348,6 +357,13 @@ const TrackMenu = ({
         dispatch(
           playbackActions.addToQueue({
             tracks: [{ trackId, source: QueueSource.RECOMMENDED_TRACKS }]
+          })
+        )
+        dispatch(
+          make(Name.PLAY_QUEUE_ADD_TRACK, {
+            source: 'queue',
+            trackId: String(trackId),
+            from: 'overflow menu'
           })
         )
         toast(messages.addedToQueue)

--- a/packages/web/src/components/play-bar/queue-button/QueueButton.tsx
+++ b/packages/web/src/components/play-bar/queue-button/QueueButton.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 
+import { Name } from '@audius/common/models'
 import { playbackSelectors } from '@audius/common/store'
 import {
   Box,
@@ -11,6 +12,7 @@ import {
 } from '@audius/harmony'
 import { useSelector } from 'react-redux'
 
+import { make, useRecord } from 'common/store/analytics/actions'
 import { QueuePopover } from 'components/queue-popover'
 
 const { getPlaybackQueue } = playbackSelectors
@@ -25,14 +27,33 @@ export const QueueButton = () => {
   const queue = useSelector(getPlaybackQueue)
   const hasItems = queue.length > 0
   const { color } = useTheme()
+  const record = useRecord()
 
   const handleToggle = useCallback(() => {
-    setIsOpen((open) => !open)
-  }, [])
+    setIsOpen((open) => {
+      const next = !open
+      if (next) {
+        record(
+          make(Name.PLAY_QUEUE_OPEN, {
+            source: 'queue',
+            queueLength: queue.length
+          })
+        )
+      } else {
+        record(make(Name.PLAY_QUEUE_CLOSE, { source: 'queue' }))
+      }
+      return next
+    })
+  }, [record, queue.length])
 
   const handleClose = useCallback(() => {
-    setIsOpen(false)
-  }, [])
+    setIsOpen((open) => {
+      if (open) {
+        record(make(Name.PLAY_QUEUE_CLOSE, { source: 'queue' }))
+      }
+      return false
+    })
+  }, [record])
 
   return (
     <>

--- a/packages/web/src/components/queue-popover/QueueTab.tsx
+++ b/packages/web/src/components/queue-popover/QueueTab.tsx
@@ -145,11 +145,25 @@ const QueueRow = ({
 
   const handlePlayNext = useCallback(() => {
     dispatch(playNext({ track: { trackId, source: 'queue-popover' } }))
+    dispatch(
+      make(Name.PLAY_QUEUE_ADD_TRACK, {
+        source: 'queue',
+        trackId: String(trackId),
+        from: 'queue'
+      })
+    )
     toast('Will play next')
   }, [dispatch, trackId, toast])
 
   const handleAddToQueue = useCallback(() => {
     dispatch(addToQueue({ tracks: [{ trackId, source: 'queue-popover' }] }))
+    dispatch(
+      make(Name.PLAY_QUEUE_ADD_TRACK, {
+        source: 'queue',
+        trackId: String(trackId),
+        from: 'queue'
+      })
+    )
     toast('Added to queue')
   }, [dispatch, trackId, toast])
 
@@ -221,26 +235,53 @@ export const QueueTab = ({ onClose }: QueueTabProps) => {
   const handlePlayAt = useCallback(
     (queueIndex: number) => {
       dispatch(playTrackAt({ index: queueIndex }))
+      const trackId = queue[queueIndex]?.trackId
       dispatch(
         make(Name.PLAYBACK_PLAY, {
-          id: queue[queueIndex]?.trackId ?? null,
+          id: trackId ?? null,
           source: PlaybackSource.PLAYBAR
         })
       )
+      if (trackId !== undefined) {
+        dispatch(
+          make(Name.PLAY_QUEUE_PLAY_TRACK, {
+            source: 'queue',
+            trackId: String(trackId),
+            position: queueIndex
+          })
+        )
+      }
     },
     [dispatch, queue]
   )
 
   const handleRemove = useCallback(
     (queueIndex: number) => {
+      const trackId = queue[queueIndex]?.trackId
       dispatch(removeFromQueue({ index: queueIndex }))
+      if (trackId !== undefined) {
+        dispatch(
+          make(Name.PLAY_QUEUE_REMOVE_TRACK, {
+            source: 'queue',
+            trackId: String(trackId),
+            position: queueIndex
+          })
+        )
+      }
     },
-    [dispatch]
+    [dispatch, queue]
   )
 
   const handleClear = useCallback(() => {
+    const upcomingLength = nextInQueue.length
     dispatch(clearUpcoming())
-  }, [dispatch])
+    dispatch(
+      make(Name.PLAY_QUEUE_CLEAR, {
+        source: 'queue',
+        queueLength: upcomingLength
+      })
+    )
+  }, [dispatch, nextInQueue.length])
 
   const handlePlayNext = useCallback(
     (trackId: ID) => {
@@ -249,6 +290,13 @@ export const QueueTab = ({ onClose }: QueueTabProps) => {
         addToQueue({
           tracks: [{ trackId, source: sourceTag }],
           index: nextInQueueStart
+        })
+      )
+      dispatch(
+        make(Name.PLAY_QUEUE_ADD_TRACK, {
+          source: 'queue',
+          trackId: String(trackId),
+          from: 'queue'
         })
       )
     },
@@ -273,8 +321,21 @@ export const QueueTab = ({ onClose }: QueueTabProps) => {
           ]
         })
       )
+      const fromAbsolute = nextInQueueStart + result.source.index
+      const toAbsolute = nextInQueueStart + result.destination.index
+      const movedTrackId = queue[fromAbsolute]?.trackId
+      if (movedTrackId !== undefined) {
+        dispatch(
+          make(Name.PLAY_QUEUE_REORDER_TRACK, {
+            source: 'queue',
+            trackId: String(movedTrackId),
+            fromPosition: fromAbsolute,
+            toPosition: toAbsolute
+          })
+        )
+      }
     },
-    [dispatch, nextInQueueStart, nextInQueue.length, queue.length]
+    [dispatch, nextInQueueStart, nextInQueue.length, queue]
   )
 
   if (queue.length === 0) {


### PR DESCRIPTION
## Summary
- Add seven new `Name.PLAY_QUEUE_*` Amplitude events (open, close, add, remove, reorder, play, clear) to `packages/common/src/models/Analytics.ts`, with typed property shapes and inclusion in `AllTrackingEvents`.
- Wire web tracking in `QueueButton` (open/close), `QueueTab` (play, remove, reorder, clear, add-from-popover), and `TrackMenu` overflow menu (Play Next / Add to Queue).
- Wire mobile tracking in `QueueDrawer` (open/close via `useDrawer.isOpen`, plus play, remove, reorder, clear, add-next-from) and `TrackOverflowMenuDrawer` (Play Next / Add to Queue).
- All events use `source: 'queue'` per spec; `add` events carry `from: 'queue' | 'overflow menu'` to disambiguate the surface; play/remove/reorder include `trackId` and absolute queue `position`; clear includes the upcoming queue length.

Repeat and shuffle toggles were intentionally **not** instrumented — both live on the play bar (web) / now-playing drawer (mobile), not in the queue UI itself, and the spec scoped them to "if in queue UI".

## Test plan
- [ ] Web: open queue popover via the playbar button → expect `Play Queue: Open` with `queueLength`.
- [ ] Web: close popover via X / outside-click / Escape / re-clicking the queue button → expect `Play Queue: Close`.
- [ ] Web: in the popover, click a track in "Next in Queue" → expect `Play Queue: Play Track` (alongside the existing `Playback: Play`) with the right `trackId` + `position`.
- [ ] Web: click the X on a queued track → expect `Play Queue: Remove Track` with `trackId` + `position`.
- [ ] Web: drag a track to a new slot in "Next in Queue" → expect `Play Queue: Reorder Track` with `fromPosition`/`toPosition` matching absolute queue indices.
- [ ] Web: click "Clear" → expect `Play Queue: Clear` with `queueLength` reflecting cleared tracks.
- [ ] Web: from a track tile overflow menu, click "Add to Queue" or "Play Next" → expect `Play Queue: Add Track` with `from: 'overflow menu'`.
- [ ] Web: from the queue popover's "Next from" section, use the row's overflow → "Add to Queue" or "Play Next" → expect `Play Queue: Add Track` with `from: 'queue'`.
- [ ] Mobile: open and close the queue drawer → expect open/close events, with `queueLength` on open.
- [ ] Mobile: tap a queued track → expect `Play Queue: Play Track`.
- [ ] Mobile: tap the close (X) icon on a queued track → expect `Play Queue: Remove Track`.
- [ ] Mobile: long-press + drag a queued track → expect `Play Queue: Reorder Track`.
- [ ] Mobile: tap "Clear" → expect `Play Queue: Clear`.
- [ ] Mobile: from the track overflow drawer, "Add to Queue" / "Play Next" → expect `Play Queue: Add Track` with `from: 'overflow menu'`.
- [ ] Mobile: from the "Up Next" / "Next from" section in the queue drawer, tap a row → expect `Play Queue: Add Track` with `from: 'queue'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)