### PR TITLE
Fix mobile web trending page header spacing

### DIFF
--- a/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.module.css
+++ b/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.module.css
@@ -1,4 +1,5 @@
 .lineupContainer {
+  margin-top: 12px;
   margin-bottom: 8px;
   padding: 0px 12px;
   min-width: 0;


### PR DESCRIPTION
## Summary
- Add `margin-top: 12px` to the mobile trending page's `.lineupContainer` so the gap between the filter row and the first track tile matches the feed page.

## Test plan
- [x] Open the mobile web trending page; verify there is a 12px gap above the first tile
- [x] Compare against the feed page; spacing should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)