### PR TITLE
chore(web): filter non-critical errors from Sentry

### DIFF
--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -17,6 +17,32 @@ const analyticsBlacklist = [
 
 const MAX_BREADCRUMBS = 300
 
+// Noisy, non-actionable error patterns we don't want clogging Sentry.
+// Each entry is matched against the event's error message and exception value.
+const NOISY_ERROR_PATTERNS: RegExp[] = [
+  // Code-splitting / dynamic import failures. Almost always a stale deploy or
+  // flaky network — not a real bug we can fix in code.
+  /ChunkLoadError/i,
+  /Loading chunk [\w-]+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  // ResizeObserver loop warnings. Browsers fire these spuriously and they
+  // don't represent real errors — ignored by all major frameworks.
+  /ResizeObserver loop limit exceeded/i,
+  /ResizeObserver loop completed with undelivered notifications/i,
+  // Aborted fetches. Caused by user navigation or component unmount, not bugs.
+  /AbortError/i,
+  /The user aborted a request/i,
+  // Generic network failures — user offline, captive portal, ad blocker, etc.
+  /Failed to fetch/i,
+  /NetworkError/i,
+  /Load failed/i,
+  /The network connection was lost/i,
+  // Browser permission denials (mic, camera, clipboard, notifications) —
+  // expected user choices, not bugs.
+  /NotAllowedError/i
+]
+
 let sentryInitialized = false
 let sentryInitPromise: Promise<void> | null = null
 
@@ -61,6 +87,48 @@ export const initializeSentry = async () => {
 
         normalizeDepth: 5,
         maxBreadcrumbs: MAX_BREADCRUMBS,
+        beforeSend: (event, hint) => {
+          const exception = event.exception?.values?.[0]
+          const message =
+            (typeof hint?.originalException === 'object' &&
+            hint?.originalException !== null &&
+            'message' in hint.originalException
+              ? String(
+                  (hint.originalException as { message?: unknown }).message ??
+                    ''
+                )
+              : '') ||
+            exception?.value ||
+            event.message ||
+            ''
+          const stack = exception?.stacktrace?.frames?.length ?? 0
+
+          // Drop known-noisy error patterns (chunk load, ResizeObserver,
+          // network/abort, permission denials). See NOISY_ERROR_PATTERNS above
+          // for the full rationale.
+          if (NOISY_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
+            if (env.ENVIRONMENT !== 'production') {
+              console.warn('[sentry] dropped noisy error:', message)
+            }
+            return null
+          }
+
+          // Drop unhandled rejections / exceptions that have no stack and
+          // either an empty message or a message too short to be actionable
+          // (e.g. "true", "null", "Error"). These are almost always thrown
+          // non-Error values from third-party scripts.
+          if (stack === 0 && message.trim().length < 10) {
+            if (env.ENVIRONMENT !== 'production') {
+              console.warn(
+                '[sentry] dropped low-signal error (no stack, short message):',
+                JSON.stringify(message)
+              )
+            }
+            return null
+          }
+
+          return event
+        },
         beforeBreadcrumb: (breadCrumb, hint) => {
           // filter out info and debug logs
           if (


### PR DESCRIPTION
## Summary

Adds a `beforeSend` filter to the web Sentry init in `packages/web/src/services/sentry.ts` that drops noisy, non-actionable error categories before they're sent. Goal: cut Sentry event volume so we stay within the cheap plan and so the remaining events are signal, not noise.

## What gets dropped

- **Code-splitting failures**: `ChunkLoadError`, `Loading chunk N failed`, `Failed to fetch dynamically imported module`, `Importing a module script failed`. Almost always stale-deploy/CDN-cache/network — not a code bug.
- **ResizeObserver loop warnings**: `ResizeObserver loop limit exceeded`, `ResizeObserver loop completed with undelivered notifications`. Spurious browser warnings; ignored by every major framework.
- **Aborted fetches**: `AbortError`, `The user aborted a request`. Caused by user navigation / component unmount.
- **Generic network failures**: `Failed to fetch`, `NetworkError`, `Load failed`, `The network connection was lost`. User offline, captive portal, ad blocker.
- **Permission denials**: `NotAllowedError`. User declined mic/camera/clipboard/notifications — expected, not a bug.
- **Low-signal events**: any event with no stack frames AND a message shorter than 10 chars (e.g. thrown non-Error values from third-party scripts).

In non-production, dropped events are surfaced via `console.warn` so developers can still see what got filtered locally.

## Sample rates

No `tracesSampleRate` is currently set, so traces aren't being sent — nothing to tune. `replaysSessionSampleRate` is already `0` (replays only on errors), and `replaysOnErrorSampleRate` is driven by the `SENTRY_REPLAY_ERROR_SAMPLE_RATE` remote-config double, so that's already runtime-tunable without a deploy. Left both alone.

## Test plan

- [ ] Trigger a `ChunkLoadError` on a stage build and confirm it does not appear in Sentry
- [ ] Trigger a real uncaught exception and confirm it still appears in Sentry
- [ ] On `npm run web:dev`, throw a noisy error from the console and confirm `[sentry] dropped noisy error:` appears in console.warn
- [ ] Confirm typecheck + lint still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)