### PR TITLE
[MOB] Fix white gap on contest pull-to-refresh

### DIFF
--- a/.changeset/fix-contest-pull-refresh.md
+++ b/.changeset/fix-contest-pull-refresh.md
@@ -1,0 +1,5 @@
+---
+'@audius/mobile': patch
+---
+
+Fix a thin white sliver appearing above the cover image when pulling to refresh on the mobile contest page. `ContestHero` was clipping its scaled cover image with `overflow: 'hidden'`, so the existing scale + translate over-scroll interpolation could only stretch within the 220px hero box and never bled upward into the over-scroll gap. The clip is removed (mirroring `ProfileCoverPhoto`), and the title/CTA/countdown section gets its own opaque background to cover the downward bleed — same sibling-with-bg pattern `ProfileHeader` uses below the cover photo.

--- a/packages/mobile/src/screens/contest-screen/ContestHero.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestHero.tsx
@@ -81,17 +81,20 @@ export const ContestHero = ({ trackId }: ContestHeroProps) => {
     ]
   }))
 
-  // `overflow: 'hidden'` on the container clips the scaled image so
-  // it doesn't bleed past the hero edges into the body of the page
-  // when the over-scroll snaps back. `pointerEvents='none'` keeps
-  // touches falling through to the underlying scroll view.
+  // No `overflow: 'hidden'` here — on pull-to-refresh the scaled
+  // image needs to bleed *upward* past the hero's layout box to fill
+  // the gap above, exactly the way `ProfileCoverPhoto` does. Downward
+  // bleed into the body is hidden by the next sibling's own
+  // `backgroundColor='white'`, mirroring the profile header's pattern
+  // where the bio section's solid bg covers the cover-photo bleed.
+  // `pointerEvents='none'` keeps touches falling through to the
+  // underlying scroll view.
   return (
     <View
       pointerEvents='none'
       style={{
         width: '100%',
-        height: CONTEST_HERO_HEIGHT,
-        overflow: 'hidden'
+        height: CONTEST_HERO_HEIGHT
       }}
     >
       {src ? (

--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -371,7 +371,20 @@ export const ContestScreen = () => {
       <ContestScrollBridge />
       <ContestHero trackId={track.track_id} />
 
-      <Flex p='l' gap='l' pointerEvents='box-none'>
+      {/* `backgroundColor='white'` here is what makes the hero's
+          pull-to-refresh stretch read cleanly: the scaled cover image
+          intentionally bleeds past `ContestHero`'s layout box (no
+          overflow:hidden anymore) so it can fill the over-scroll gap
+          above, and this section's solid bg hides the downward bleed
+          into the title/CTA/countdown stack. Same pattern
+          `ProfileHeader` uses for the bio section below the cover
+          photo. */}
+      <Flex
+        p='l'
+        gap='l'
+        pointerEvents='box-none'
+        backgroundColor='white'
+      >
         {/* Title — pure display; `pointerEvents='none'` wrapper so
             scroll gestures that land on the title pass through. */}
         <Flex pointerEvents='none'>


### PR DESCRIPTION
## Summary

On the mobile contest screen, pulling down to refresh exposed a thin
white sliver above the cover image instead of stretching the cover
art to fill the gap (the way the profile cover photo does).

`ContestHero` was clipping its scaled cover image with
`overflow: 'hidden'`, so the existing scale + translate interpolation
only stretched within the 220px hero box and never bled upward into
the over-scroll area.

This PR mirrors the `ProfileCoverPhoto` / `ProfileHeader` pattern:

- Drop `overflow: 'hidden'` on `ContestHero` so the scaled image can
  bleed upward into the over-scroll gap.
- Give the title / CTA / countdown / hosted-by `Flex` its own
  `backgroundColor='white'` to cover the downward bleed. The renderHeader's
  outer `Flex` bg sits *behind* the hero in z-order, so it can't hide the
  bleed on its own — profile dodges this by making the bio section a
  sibling with its own opaque bg, and we're doing the equivalent here.

## Test plan

- [ ] Open a remix contest page on iOS, pull down — cover art expands smoothly with no white sliver above it.
- [ ] Pull-to-refresh still triggers the refetch (event + comments queries invalidated).
- [ ] Title / countdown / hosted-by section renders normally with no image bleed-through.
- [ ] Theme flip (light → dark) still re-tints the header backdrop correctly.
- [ ] Scroll the contest page up to collapse the header — tab bar still docks correctly with no visual artifact from the removed clip.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QyArm7VBxJ26oA854xAJQC)_