### PR TITLE
feat: show all search filters on the All tab (web + mobile)

### DIFF
--- a/packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx
@@ -63,7 +63,15 @@ const SearchCategory = (props: SearchCategoryProps) => {
 }
 
 const filtersByCategory: Record<SearchCategoryType, SearchFilter[]> = {
-  all: [],
+  all: [
+    'genre',
+    'mood',
+    'key',
+    'bpm',
+    'isPremium',
+    'hasDownloads',
+    'isVerified'
+  ],
   users: ['genre', 'isVerified'],
   tracks: [
     'genre',

--- a/packages/web/src/pages/search-page/categories.ts
+++ b/packages/web/src/pages/search-page/categories.ts
@@ -3,7 +3,17 @@ import { IconAlbum, IconNote, IconPlaylists, IconUser } from '@audius/harmony'
 import { Category } from './types'
 
 export const categories = {
-  all: { filters: [] },
+  all: {
+    filters: [
+      'genre',
+      'mood',
+      'key',
+      'bpm',
+      'isPremium',
+      'hasDownloads',
+      'isVerified'
+    ]
+  },
   profiles: { icon: IconUser, filters: ['genre', 'isVerified'] },
   tracks: {
     icon: IconNote,


### PR DESCRIPTION
## Summary
- The Search **All** tab now shows the same filter buttons that appear on the Tracks/Albums/Playlists sub-tabs (genre, mood, key, bpm, premium, downloads available, verified) on both web and mobile.
- Implementation: extends the `all` entry in the categories/filters mapping (`packages/web/src/pages/search-page/categories.ts` and `packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx`) from an empty list to the union of sub-tab filters. The filters were already wired through `useSearchAllResults` in `packages/common/src/api/tan-query/search/useSearchResults.ts`, so no API plumbing was needed.

## Test plan
- [ ] Web: `npm run web:prod`, navigate to `/search`, confirm the All tab shows all 7 filter buttons in the header bottom bar
- [ ] Web: select a genre / mood / key / bpm / premium / downloads / verified filter on the All tab and verify results across all four sections (Profiles, Tracks, Albums, Playlists) update accordingly
- [ ] Web: switching from All to Tracks/Albums/Playlists preserves applied filters where they overlap
- [ ] Web: when genre is `Podcasts`, key + bpm filters are hidden (existing behavior)
- [ ] Mobile (iOS + Android): open Search, confirm All tab shows the full set of filter pills, scroll horizontally
- [ ] Mobile: applying any filter on All tab updates the All results (sections re-fetch)
- [ ] Mobile: switching categories still clears filters (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)