### PR TITLE
search: surface all sub-tab filters on the All tab

### DIFF
--- a/packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx
@@ -63,7 +63,15 @@ const SearchCategory = (props: SearchCategoryProps) => {
 }
 
 const filtersByCategory: Record<SearchCategoryType, SearchFilter[]> = {
-  all: [],
+  all: [
+    'genre',
+    'mood',
+    'key',
+    'bpm',
+    'isPremium',
+    'hasDownloads',
+    'isVerified'
+  ],
   users: ['genre', 'isVerified'],
   tracks: [
     'genre',

--- a/packages/web/src/pages/search-page/categories.ts
+++ b/packages/web/src/pages/search-page/categories.ts
@@ -3,7 +3,17 @@ import { IconAlbum, IconNote, IconPlaylists, IconUser } from '@audius/harmony'
 import { Category } from './types'
 
 export const categories = {
-  all: { filters: [] },
+  all: {
+    filters: [
+      'genre',
+      'mood',
+      'key',
+      'bpm',
+      'isPremium',
+      'hasDownloads',
+      'isVerified'
+    ]
+  },
   profiles: { icon: IconUser, filters: ['genre', 'isVerified'] },
   tracks: {
     icon: IconNote,


### PR DESCRIPTION
## Summary
- Adds the full filter set (genre, mood, key, bpm, isPremium, hasDownloads, isVerified) to the **All** tab on both web (`packages/web/src/pages/search-page/categories.ts`) and mobile (`packages/mobile/src/screens/search-screen/SearchCategoriesAndFilters.tsx`).
- The union covers every filter used by the Tracks/Albums/Playlists/Profiles sub-tabs, so users can refine the combined results page without first switching tabs.
- No backend or query-shape change needed — `useSearchAllResults` already plumbs each filter through `useSearchQueryProps`.

## Test plan
- [ ] Open `/search?query=...`, confirm filter pills (Genre, Mood, Key, BPM, Premium, Downloads Available, Verified) render on the All tab on desktop.
- [ ] Apply each filter on the All tab and confirm Tracks/Albums/Playlists/Profiles results update accordingly.
- [ ] Verify the existing Podcasts-genre rule still hides BPM and Key filters.
- [ ] Mobile: open Search, stay on All, confirm the same filter pills appear horizontally next to the category pills and are scrollable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)