### PR TITLE
Fix artist hover card blur overlay overflowing the card

### DIFF
--- a/.changeset/fix-hover-card-blur-overflow.md
+++ b/.changeset/fix-hover-card-blur-overflow.md
@@ -1,0 +1,5 @@
+---
+'@audius/web': patch
+---
+
+Fix artist hover card blur overlay overflowing the card. The `.artistCoverPhoto` banner div lacked a positioning context, so the blur overlay's `position: absolute; inset: 0` escaped to the nearest positioned ancestor and bled outside the cover photo banner. Adding `position: relative` (and `overflow: hidden`) to the banner contains the blur to the intended 136px header.

--- a/packages/web/src/components/artist/ArtistCardCover.module.css
+++ b/packages/web/src/components/artist/ArtistCardCover.module.css
@@ -1,4 +1,5 @@
 .artistCoverPhoto {
+  position: relative;
   height: 136px !important;
   background-size: cover;
   background-position: center;
@@ -6,6 +7,7 @@
   border-radius: 6px 6px 0px 0px;
   width: calc(100% + 2px) !important;
   margin-left: -1px;
+  overflow: hidden;
 }
 
 .coverPhotoContentContainer {


### PR DESCRIPTION
## Summary

The artist hover card's blurred-fallback cover photo was bleeding outside the card boundaries — the blurred profile picture extended well past the 136px banner header and even past the card's outer edges (see issue screenshot).

`.artistCoverPhoto` had no positioning context, so the blur overlay's `position: absolute; inset: 0` escaped up the DOM tree to the nearest positioned ancestor (the popup wrapper) and stretched across that area instead.

Fix: add `position: relative` and `overflow: hidden` to `.artistCoverPhoto`. Same class of bug as #14243 — that PR fixed the equivalent issue in the full-page `CoverPhoto` component.

## Test plan

- [ ] Hover an artist link whose cover photo falls back to a blurred profile picture (i.e. user with no cover photo set) — the blur is contained to the 136px banner; the rest of the card shows the normal white background, stats, bio, and follow button
- [ ] Hover an artist link whose user has a real cover photo — banner renders normally, no regression
- [ ] Hover an artist with no profile picture either — fallback still renders inside the banner

---
_Generated by [Claude Code](https://claude.ai/code/session_01SshpSsEvEq3abqMc4gVumc)_