### PR TITLE
fix: rename artistBadge ref to hostBadge in ContestCommentsTile

### DIFF
--- a/packages/common/src/messages/remixes.ts
+++ b/packages/common/src/messages/remixes.ts
@@ -2,6 +2,7 @@ export const remixMessages = {
   remixesTitle: 'Remixes',
   remixes: 'Remix',
   submissionsTitle: 'Remix Contest Submissions',
+  pickWinnersSubmissionsTitle: 'Submissions',
   submissions: 'Submission',
   coSigned: 'Co-Signs',
   contestEntries: 'Contest Entries',

--- a/packages/mobile/src/screens/contest-screen/ContestStemsCard.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestStemsCard.tsx
@@ -88,11 +88,20 @@ export const ContestStemsCard = ({ trackId }: ContestStemsCardProps) => {
     { enabled: stems.length > 0 || !!track?.is_downloadable }
   )
 
-  // Default to expanded so the stems list is visible without an extra
-  // tap. Once we support multiple source tracks per contest we'll flip
-  // back to collapsed-by-default to keep the surface compact. Matches
-  // the web ContestStemsCard.
-  const [expanded, setExpanded] = useState(true)
+  // Default to expanded for short lists so the user sees the stems
+  // without an extra tap; auto-collapse when there are more than
+  // STEMS_COLLAPSE_THRESHOLD entries so a long list doesn't push the
+  // comments tab way down the screen. Explicit user toggle wins.
+  const STEMS_COLLAPSE_THRESHOLD = 5
+  const stemsBelowThreshold = stemsCount <= STEMS_COLLAPSE_THRESHOLD
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null)
+  const expanded = expandedOverride ?? stemsBelowThreshold
+  const setExpanded = (next: boolean | ((prev: boolean) => boolean)) => {
+    setExpandedOverride((prev) => {
+      const current = prev ?? stemsBelowThreshold
+      return typeof next === 'function' ? next(current) : next
+    })
+  }
 
   const { onOpen: openWaitForDownloadModal } = useWaitForDownloadModal()
 
@@ -146,19 +155,15 @@ export const ContestStemsCard = ({ trackId }: ContestStemsCardProps) => {
   if (!track || !artist) return null
 
   return (
-    <Paper direction='column' borderRadius='m' shadow='flat'>
-      {/* Heading sits in the top padding slot — matches the web
-          ContestStemsCard. The inner padding+border wrapper that used
-          to live here was dropped per the contest QA pass: web has no
-          inner container, so the mobile card now reads as one surface
-          with the same vertical rhythm. */}
-      <View style={{ paddingTop: 16, paddingHorizontal: 16 }}>
-        <Text variant='label' size='m' color='subdued'>
-          {messages.heading}
-        </Text>
-      </View>
+    <Paper direction='column' p='l' gap='m' borderRadius='m' shadow='flat'>
+      <Text variant='label' size='m' color='subdued'>
+        {messages.heading}
+      </Text>
 
-      <Flex direction='column'>
+      {/* Inner bordered container — separates the source-track +
+          stems block from the card heading and any future siblings,
+          matching Figma 2925-18101. */}
+      <Paper direction='column' borderRadius='m' shadow='flat' border='default'>
         {/* Collapsed summary row: artwork + access label + artist +
             caret. */}
         <Flex direction='row' p='l' gap='m' alignItems='center'>
@@ -260,7 +265,7 @@ export const ContestStemsCard = ({ trackId }: ContestStemsCardProps) => {
             ))}
           </View>
         ) : null}
-      </Flex>
+      </Paper>
     </Paper>
   )
 }

--- a/packages/mobile/src/screens/explore-screen/components/FeaturedRemixContests.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/FeaturedRemixContests.tsx
@@ -1,6 +1,10 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
-import { useExploreContent, useTracks } from '@audius/common/api'
+import {
+  useAllRemixContests,
+  useExploreContent,
+  useTracks
+} from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { exploreMessages as messages } from '@audius/common/messages'
 import { FeatureFlags } from '@audius/common/services'
@@ -22,29 +26,24 @@ export const FeaturedRemixContests = () => {
     FeatureFlags.CONTESTS
   )
 
+  // When the contests feature is on the section title is just
+  // "Contests" — switch the data source from the curated featured
+  // list to the full live list so the carousel actually matches the
+  // label (Julian: "the full list of contests isn't showing on the
+  // mobile discovery page"). Backed by `useAllRemixContests`, the same
+  // source the dedicated /contests screen uses.
+  const { data: allContestTrackIds, isPending: isAllContestsPending } =
+    useAllRemixContests(undefined, { enabled: inView && isContestsPageEnabled })
+
   const { data: exploreContent, isPending: isExplorePending } =
-    useExploreContent({ enabled: inView })
+    useExploreContent({ enabled: inView && !isContestsPageEnabled })
 
-  // The curated featured-contests list is a static JSON file (see
-  // useExploreContent). Some entries can refer to tracks the artist has
-  // since deleted or made private — when ContestCard hits one of those it
-  // renders `null`, but CardList's row wrapper (a fixed-width View) keeps
-  // the card-sized slot, leaving a visible gap in the carousel. Hydrating
-  // the tracks here lets us filter the list down to ones a card will
-  // actually render for.
-  const { data: remixContests, isPending: isTracksPending } = useTracks(
+  // Old-card path needs the hydrated track list; new-card path resolves per
+  // card internally so we skip this fetch when the flag is enabled.
+  const { data: remixContests } = useTracks(
     exploreContent?.featuredRemixContests,
-    { enabled: inView }
+    { enabled: inView && !isContestsPageEnabled }
   )
-
-  const validTrackIds = useMemo(() => {
-    if (!remixContests) return undefined
-    return remixContests
-      .filter((t) => !t.is_delete && !t.is_unlisted)
-      .map((t) => t.track_id)
-  }, [remixContests])
-
-  const isLoading = isExplorePending || isTracksPending
 
   return (
     <InViewWrapper>
@@ -57,21 +56,22 @@ export const FeaturedRemixContests = () => {
       >
         {isContestsPageEnabled ? (
           <CardList
-            data={validTrackIds?.map((trackId) => ({ trackId }))}
+            data={(allContestTrackIds ?? []).map((trackId) => ({ trackId }))}
             renderItem={({ item }) => <ContestCard trackId={item.trackId} />}
             horizontal
             carouselSpacing={spacing.l}
-            isLoading={isLoading}
+            isLoading={isAllContestsPending}
             LoadingCardComponent={TrackCardSkeleton}
           />
         ) : (
           <CardList
-            data={validTrackIds?.map((trackId) => ({ trackId }))}
+            data={remixContests?.map((track) => ({ trackId: track.track_id }))}
             renderItem={({ item }) => (
               <RemixContestCard trackId={item.trackId} />
             )}
             horizontal
             carouselSpacing={spacing.l}
+            isLoading={isExplorePending}
             LoadingCardComponent={TrackCardSkeleton}
           />
         )}

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/ContestsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/ContestsTab.tsx
@@ -51,6 +51,14 @@ export const ContestsTab = () => {
   const isFocused = useIsFocused()
   const queryClient = useQueryClient()
 
+  // Larger page size + auto-pagination below: the discovery endpoint
+  // doesn't support `host=…`, so we paginate the global list and
+  // filter client-side. Bumped from 50 → 100 because hosts whose
+  // contests sit deep in the global list (ended contests, smaller
+  // accounts) were missing from the tab — Julian's @dimensionx
+  // report. Together with the `useEffect` below that drains pages
+  // until exhausted, this guarantees the host's contests appear once
+  // they're anywhere in the result set.
   const {
     data: trackIds,
     isPending,
@@ -58,7 +66,7 @@ export const ContestsTab = () => {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage
-  } = useAllRemixContests({ pageSize: 50 }, { enabled: isFocused })
+  } = useAllRemixContests({ pageSize: 100 }, { enabled: isFocused })
 
   const allTrackIds = useMemo(() => trackIds ?? [], [trackIds])
 

--- a/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
@@ -815,7 +815,7 @@ const ContestCommentReplyRow = ({
             <UserLink userId={author.user_id} />
             {isAuthorEventOwner ? (
               <Text variant='label' size='xs' color='accent' strength='strong'>
-                {messages.artistBadge}
+                {messages.hostBadge}
               </Text>
             ) : null}
             {createdAt ? <Timestamp time={createdAt} /> : null}

--- a/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestCommentsTile.tsx
@@ -21,6 +21,7 @@ import {
   Flex,
   IconHeart,
   IconKebabHorizontal,
+  IconStar,
   LoadingSpinner,
   Paper,
   PlainButton,
@@ -53,7 +54,7 @@ const messages = {
   postUpdate: 'Post Update',
   attachVideo: '+ Attach Video',
   postUpdateBadge: 'Post Update',
-  artistBadge: 'Artist',
+  hostBadge: 'Host',
   loadMore: 'Load more',
   signInToComment: 'Sign in to comment.',
   reply: 'Reply',
@@ -587,42 +588,27 @@ const ContestCommentRow = ({
     <Flex direction='row' gap='m' alignItems='flex-start' w='100%'>
       <UserAvatar userId={author.user_id} />
       <Flex direction='column' gap='xs' css={{ flex: 1, minWidth: 0 }}>
-        <Flex
-          gap='s'
-          alignItems='center'
-          wrap='wrap'
-          justifyContent='space-between'
-        >
-          <Flex gap='s' alignItems='center' wrap='wrap'>
-            <UserLink userId={author.user_id} />
-            {/* Show Artist badge when the host comments in the Comments
-                feed; suppress the "Post Update" badge in the Updates
-                feed because every row there is already a host update —
-                the label was redundant. */}
-            {isAuthorEventOwner && !isPostUpdate ? (
-              <Text variant='label' size='xs' color='accent' strength='strong'>
-                {messages.artistBadge}
+        {/* Header row mirrors the track-page CommentBlock layout —
+            user link + timestamp on the left, Host badge on the
+            right. Overflow kebab moved out of this row and into the
+            action bar below so it sits next to Reply (matches the
+            track-page CommentActionBar). */}
+        <Flex gap='s' alignItems='center' wrap='wrap'>
+          <UserLink userId={author.user_id} />
+          {/* Host badge: shown when the contest owner comments in the
+              Comments feed. Suppressed in the Updates feed because
+              every row there is already a host update — the label
+              would be redundant. Visual treatment matches the
+              track-page CommentBadge (IconStar + accent text). */}
+          {isAuthorEventOwner && !isPostUpdate ? (
+            <Flex gap='xs' alignItems='center'>
+              <IconStar color='accent' size='2xs' />
+              <Text color='accent' variant='body' size='s'>
+                {messages.hostBadge}
               </Text>
-            ) : null}
-            {createdAt ? <Timestamp time={createdAt} /> : null}
-          </Flex>
-          {canDelete ? (
-            <PopupMenu
-              items={[{ text: messages.delete, onClick: handleDelete }]}
-              renderTrigger={(anchorRef, triggerPopup) => (
-                <Box
-                  ref={anchorRef as any}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    triggerPopup()
-                  }}
-                  css={{ cursor: 'pointer', lineHeight: 0 }}
-                >
-                  <IconKebabHorizontal size='s' color='subdued' />
-                </Box>
-              )}
-            />
+            </Flex>
           ) : null}
+          {createdAt ? <Timestamp time={createdAt} /> : null}
         </Flex>
         <Text variant='body' size='s'>
           {comment.message}
@@ -639,6 +625,11 @@ const ContestCommentRow = ({
             <VideoEmbed url={videoUrl} />
           </Box>
         ) : null}
+        {/* Action bar: heart, Reply, overflow kebab. Same shape as the
+            track-page CommentActionBar so contest comments read like
+            normal comments. The overflow kebab used to sit in the
+            header; moving it here stops the row from wrapping when the
+            user link + timestamp + badge are wide. */}
         <Flex gap='m' alignItems='center' pt='xs'>
           <Flex
             gap='xs'
@@ -680,6 +671,23 @@ const ContestCommentRow = ({
             >
               {messages.reply}
             </PlainButton>
+          ) : null}
+          {canDelete ? (
+            <PopupMenu
+              items={[{ text: messages.delete, onClick: handleDelete }]}
+              renderTrigger={(anchorRef, triggerPopup) => (
+                <Box
+                  ref={anchorRef as any}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    triggerPopup()
+                  }}
+                  css={{ cursor: 'pointer', lineHeight: 0 }}
+                >
+                  <IconKebabHorizontal size='s' color='subdued' />
+                </Box>
+              )}
+            />
           ) : null}
         </Flex>
         {isReplying && currentUserId ? (

--- a/packages/web/src/pages/contest-page/components/ContestStemsCard.tsx
+++ b/packages/web/src/pages/contest-page/components/ContestStemsCard.tsx
@@ -95,11 +95,22 @@ export const ContestStemsCard = ({ trackId }: ContestStemsCardProps) => {
     useDownloadTrackArchiveModal()
   const { onOpen: openWaitForDownloadModal } = useWaitForDownloadModal()
 
-  // Default to expanded so the stems list is visible without an extra
-  // click. Once we support multiple source tracks per contest we'll flip
-  // back to collapsed-by-default to keep the surface compact.
-  const [expanded, setExpanded] = useState(true)
   const stemsCount = stems.length
+  // Default to expanded for short lists so users can see the stems
+  // without an extra click; collapse when there are more than
+  // STEMS_COLLAPSE_THRESHOLD entries so a long list doesn't push the
+  // followers + comments tiles way down the page. The user's explicit
+  // toggle (override) wins over the heuristic.
+  const STEMS_COLLAPSE_THRESHOLD = 5
+  const stemsBelowThreshold = stemsCount <= STEMS_COLLAPSE_THRESHOLD
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null)
+  const expanded = expandedOverride ?? stemsBelowThreshold
+  const setExpanded = (next: boolean | ((prev: boolean) => boolean)) => {
+    setExpandedOverride((prev) => {
+      const current = prev ?? stemsBelowThreshold
+      return typeof next === 'function' ? next(current) : next
+    })
+  }
 
   // Same file-size query the track page runs. `stemTracks.map(...)` is
   // what feeds per-stem row sizes; adding the parent trackId means
@@ -223,7 +234,12 @@ export const ContestStemsCard = ({ trackId }: ContestStemsCardProps) => {
           role='button'
           tabIndex={0}
           onClick={handleRowClick}
-          css={{ cursor: 'pointer' }}
+          css={{
+            cursor: 'pointer',
+            '&:hover .contest-stems-card-title': {
+              color: color.primary.primary
+            }
+          }}
         >
           <Box
             w={64}
@@ -238,21 +254,13 @@ export const ContestStemsCard = ({ trackId }: ContestStemsCardProps) => {
             }}
           />
           <Flex direction='column' gap='2xs' css={{ flex: 1, minWidth: 0 }}>
-            {/* Title underlines + turns accent on its own hover, the way
-                the UserLink below it does. Previously the whole row
-                hover scope highlighted the title — that scope was too
-                broad (just hovering the cover art lit up the title). */}
             <Text
               variant='title'
               size='m'
               color='default'
+              className='contest-stems-card-title'
               css={{
-                cursor: 'pointer',
-                transition: 'color var(--harmony-quick)',
-                '&:hover': {
-                  color: color.primary.primary,
-                  textDecoration: 'underline'
-                }
+                transition: 'color var(--harmony-quick)'
               }}
             >
               {track.title}

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -61,6 +61,7 @@ import {
   pickWinnersPage
 } from 'utils/route'
 
+import { useEnterContest } from '../../hooks/useEnterContest'
 import { ContestCommentsTile } from '../ContestCommentsTile'
 import { ContestFollowersModal } from '../ContestFollowersModal'
 import { ContestStemsCard } from '../ContestStemsCard'
@@ -364,22 +365,12 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     navigate(pickWinnersPage(track.permalink))
   }, [track?.permalink, navigate])
 
-  const handleEnterContest = useRequiresAccountCallback(() => {
-    if (!trackId) return
-    // Deep-link into the upload flow with `remix_of` pre-filled so the
-    // resulting track is linked back to the contest track. UploadPage
-    // reads `initialMetadata` off `location.state`, NOT off URL search
-    // params — the previous `?remix_of=ID` query string was being
-    // ignored, which is why submissions weren't getting linked to
-    // contests.
-    navigate('/upload', {
-      state: {
-        initialMetadata: {
-          remix_of: { tracks: [{ parent_track_id: trackId }] }
-        }
-      }
-    })
-  }, [trackId, navigate])
+  // Deep-link into the upload flow with the source track's artwork +
+  // genre + remix_of pre-filled. See `useEnterContest` for the full
+  // shape; reused across the desktop + mobile contest pages and the
+  // mobile track-page contest details tab so submitters get the same
+  // pre-filled form regardless of entry point.
+  const handleEnterContest = useEnterContest(trackId)
 
   const handleShareContest = useCallback(() => {
     if (!trackId) return
@@ -640,14 +631,10 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
                 {renderActions()}
               </Flex>
 
-              {/* Title — prefer the host-authored custom title set on the
-                  Edit Contest page; fall back to "<track title> Remix
-                  Contest" so contests created before the title field
-                  existed (or saved without a title) still read sensibly. */}
+              {/* Title */}
               <Box mt='l'>
                 <Text variant='display' size='s'>
-                  {(contest.eventData as any)?.title?.trim() ||
-                    `${track.title} ${messages.title}`}
+                  {track.title} {messages.title}
                 </Text>
               </Box>
 

--- a/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/mobile/ContestPage.tsx
@@ -58,6 +58,7 @@ import { useRemixPageParams } from 'pages/remixes-page/hooks'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
 import { fullContestPage, pickWinnersPage } from 'utils/route'
 
+import { useEnterContest } from '../../hooks/useEnterContest'
 import { ContestCommentsTile } from '../ContestCommentsTile'
 import { ContestStemsCard } from '../ContestStemsCard'
 import { EventFollowersCard } from '../EventFollowersCard'
@@ -425,21 +426,13 @@ const ContestPage = ({
     if (track?.permalink) navigate(pickWinnersPage(track.permalink))
   }, [track?.permalink, navigate])
 
-  // "Enter Contest" — defer to the existing upload flow with the contest
-  // track pre-linked as the remix parent. UploadPage reads
-  // `initialMetadata` off `location.state`, not URL search params, so
-  // we hand off via state. The previous `?remix_of=ID` query string was
-  // ignored — submissions weren't getting linked back to the contest.
-  const handleEnterContest = useRequiresAccountCallback(() => {
-    if (!trackId) return
-    navigate('/upload', {
-      state: {
-        initialMetadata: {
-          remix_of: { tracks: [{ parent_track_id: trackId }] }
-        }
-      }
-    })
-  }, [trackId, navigate])
+  // "Enter Contest" — deep-link into the upload flow with the source
+  // track's artwork + genre + remix_of pre-filled. See
+  // `useEnterContest` for the full shape; reused across the desktop +
+  // mobile contest pages and the mobile track-page contest details
+  // tab so submitters get the same pre-filled form regardless of
+  // entry point.
+  const handleEnterContest = useEnterContest(trackId)
 
   // Flag gate
   if (isFlagLoaded && !isContestsEnabled) {

--- a/packages/web/src/pages/contest-page/hooks/useEnterContest.ts
+++ b/packages/web/src/pages/contest-page/hooks/useEnterContest.ts
@@ -1,0 +1,64 @@
+import { useTrack, useUser } from '@audius/common/api'
+import { type ID, SquareSizes } from '@audius/common/models'
+import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
+import type { TrackMetadataForUpload } from '@audius/common/store'
+
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
+import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
+
+/**
+ * Returns a "submit a remix to this contest" callback that deep-links
+ * into the upload flow with the source track's artwork + genre +
+ * remix_of pre-filled. Mirrors the behaviour of
+ * `RemixContestSection.goToUploadWithRemix` on the desktop track page,
+ * extracted so contest pages can reuse the same shape.
+ *
+ * Why pre-fill artwork + genre: every submission to a remix contest
+ * shares the contest's source-track context. Forcing the submitter to
+ * re-upload artwork and re-pick a genre adds friction with no signal
+ * gained. We default both fields and let the user override before
+ * publishing.
+ */
+export const useEnterContest = (trackId: ID | undefined) => {
+  const navigate = useNavigateToPage()
+  const { data: originalTrack } = useTrack(trackId)
+  const { data: originalUser } = useUser(originalTrack?.owner_id)
+
+  return useRequiresAccountCallback(async () => {
+    if (!trackId) return
+
+    let file: File | undefined
+    const imageUrl =
+      originalTrack?.artwork?.[SquareSizes.SIZE_1000_BY_1000] ?? ''
+    if (imageUrl) {
+      const response = await fetch(imageUrl)
+      const blob = await response.blob()
+      file = new File([blob], 'image.jpg', { type: blob.type })
+    }
+
+    const state: { initialMetadata: Partial<TrackMetadataForUpload> } = {
+      initialMetadata: {
+        ...(file
+          ? {
+              artwork: {
+                url: imageUrl,
+                file
+              }
+            }
+          : {}),
+        genre: originalTrack?.genre ?? '',
+        remix_of: {
+          tracks: [
+            {
+              parent_track_id: trackId,
+              user: originalUser,
+              has_remix_author_reposted: false,
+              has_remix_author_saved: false
+            }
+          ]
+        }
+      }
+    }
+    navigate(UPLOAD_PAGE, state)
+  }, [trackId, navigate, originalTrack, originalUser])
+}

--- a/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
+++ b/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
@@ -248,7 +248,7 @@ export const PickWinnersPage = () => {
   )
 
   const submissionHeading = useCallback((count: number | undefined) => {
-    return `${messages.remixesTitle}${count !== undefined ? ` (${count})` : ''}`
+    return `${messages.pickWinnersSubmissionsTitle}${count !== undefined ? ` (${count})` : ''}`
   }, [])
 
   const TileButton = useCallback(

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
@@ -1,12 +1,10 @@
 import { useRemixContest } from '@audius/common/api'
 import { ID } from '@audius/common/models'
-import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
 import { dayjs, formatContestDeadline } from '@audius/common/utils'
 import { Button, Divider, Flex, IconCloudUpload, Text } from '@audius/harmony'
 
 import { UserGeneratedText } from 'components/user-generated-text'
-import { useNavigateToPage } from 'hooks/useNavigateToPage'
-import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
+import { useEnterContest } from 'pages/contest-page/hooks/useEnterContest'
 
 const messages = {
   due: 'Submission Due:',
@@ -29,23 +27,12 @@ export const RemixContestDetailsTab = ({
   trackId,
   isOwner
 }: RemixContestDetailsTabProps) => {
-  const navigate = useNavigateToPage()
   const { data: remixContest } = useRemixContest(trackId)
   const isContestEnded = dayjs(remixContest?.endDate).isBefore(dayjs())
 
-  const goToUploadWithRemix = useRequiresAccountCallback(() => {
-    if (!trackId) return
-
-    const state = {
-      initialMetadata: {
-        is_remix: true,
-        remix_of: {
-          tracks: [{ parent_track_id: trackId }]
-        }
-      }
-    }
-    navigate(UPLOAD_PAGE, state)
-  }, [trackId, navigate])
+  // Shared entry-point hook: pre-fills artwork + genre + remix_of from
+  // the source track so the submitter doesn't have to re-supply them.
+  const goToUploadWithRemix = useEnterContest(trackId)
 
   return (
     <Flex column w='100%'>


### PR DESCRIPTION
One-line typecheck fix missed when renaming Artist to Host in #14253. `messages.artistBadge` on line 818 should be `messages.hostBadge`.