### PR TITLE
[Contests] Use per-user endpoint for profile tab + has-contest gate

### DIFF
--- a/packages/common/src/api/tan-query/events/useUserHasRemixContest.ts
+++ b/packages/common/src/api/tan-query/events/useUserHasRemixContest.ts
@@ -12,7 +12,11 @@ const PAGE_SIZE = 1
  */
 export const useUserHasRemixContest = (hostUserId: ID | null | undefined) => {
   const enabled = hostUserId != null
-  const { data: trackIds, isPending, isFetching } = useUserRemixContests(
+  const {
+    data: trackIds,
+    isPending,
+    isFetching
+  } = useUserRemixContests(
     { userId: hostUserId, pageSize: PAGE_SIZE },
     { enabled }
   )

--- a/packages/web/src/test/mocks/local-storage.ts
+++ b/packages/web/src/test/mocks/local-storage.ts
@@ -1,3 +1,5 @@
+import type { LocalStorage } from '@audius/common/services'
+
 export const createMockLocalStorage = () => {
   const storage = new Map<string, string>()
   const mockLocalStorage = {
@@ -87,5 +89,5 @@ export const createMockLocalStorage = () => {
     setAudiusUserWalletAddress: async () => {},
     clearAudiusUserWalletAddress: async () => {},
     clearPlaybackRate: async () => {}
-  }
+  } as unknown as LocalStorage
 }


### PR DESCRIPTION
## Summary
- The profile Contests tab and the `useUserHasRemixContest` gate both fetched the global remix-contests list and filtered client-side by host userId, paginating up to 5 pages of 50 to avoid false-empty rendering.
- Switch both to the new `GET /v1/users/{id}/contests` endpoint via a new `useUserRemixContests` hook. The has-contest gate becomes a single `pageSize=1` query, and the tab drops the per-row `HostedContestCard` filter and the auto-pagination effect.
- SDK regen picked up `users.getContestsByUser` and `GetContestsByUserStatusEnum`.

## Companion PR
- Backend: AudiusProject/api#791

## Test plan
- [ ] Visit a profile that hosts an active contest — Contests tab renders with the contest card.
- [ ] Visit a profile that hosts only an ended contest — tab renders with the ended card.
- [ ] Visit a profile that hosts no contests — empty state shows immediately (no spinner waiting on global pagination).
- [ ] Confirm the tab strip itself only appears for hosts (`useUserHasRemixContest` gate).
- [ ] DevTools: confirm the request is `/v1/users/{id}/contests` and not `/v1/events/remix-contests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)