### PR TITLE
[Mobile] Fix lineup skeleton artwork size to match real tile

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileSkeleton.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileSkeleton.tsx
@@ -16,8 +16,8 @@ export const LineupTileSkeleton = ({ noShimmer }: LineupTileSkeletonProps) => {
   return (
     <Paper>
       <Flex flex={1} justifyContent='space-between'>
-        <Flex direction='row' alignItems='center' p='s' gap='m'>
-          <Skeleton height={80} width={80} noShimmer={noShimmer} />
+        <Flex direction='row' alignItems='center' p='s' gap='s'>
+          <Skeleton height={72} width={72} noShimmer={noShimmer} />
           <Flex gap='s' flex={1}>
             <Skeleton width='80%' height={20} noShimmer={noShimmer} />
             <Skeleton width='60%' height={20} noShimmer={noShimmer} />

--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -379,12 +379,7 @@ export const ContestScreen = () => {
           into the title/CTA/countdown stack. Same pattern
           `ProfileHeader` uses for the bio section below the cover
           photo. */}
-      <Flex
-        p='l'
-        gap='l'
-        pointerEvents='box-none'
-        backgroundColor='white'
-      >
+      <Flex p='l' gap='l' pointerEvents='box-none' backgroundColor='white'>
         {/* Title — pure display; `pointerEvents='none'` wrapper so
             scroll gestures that land on the title pass through. */}
         <Flex pointerEvents='none'>


### PR DESCRIPTION
## Summary

- Skeleton artwork was 80×80 but the real `TrackTile` renders a 72×72 image
- Gap between artwork and text was 12 px (`m`) in skeleton vs 8 px in the real tile
- These mismatches caused a visible layout shift during the skeleton→content swap on cold-start

## Test plan

- [ ] Cold-start the app and observe the Trending screen skeleton
- [ ] Verify artwork size and gap match the real tiles when content loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)