### PR TITLE
feat: tag queue new-feature-badge variation as Amplitude user property

### DIFF
--- a/packages/common/src/hooks/useQueueNewFeatureBadge.ts
+++ b/packages/common/src/hooks/useQueueNewFeatureBadge.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { useDispatch } from 'react-redux'
 
 import { useAppContext } from '~/context/appContext'
 import { FeatureFlags } from '~/services/remote-config/feature-flags'
@@ -6,6 +8,10 @@ import { FeatureFlags } from '~/services/remote-config/feature-flags'
 import { useFeatureFlag } from './useFeatureFlag'
 
 const QUEUE_NEW_BADGE_DISMISSED_KEY = '@queue-new-feature-badge-dismissed'
+// Mirrors the IDENTIFY action type in common/store/analytics/actions.
+// Dispatching this triggers the analytics saga to forward traits to Amplitude
+// as user properties, so the A/B variation can be sliced in Amplitude charts.
+const ANALYTICS_IDENTIFY = 'ANALYTICS/IDENTIFY'
 
 /**
  * Drives the "New" indicator on the play queue button.
@@ -22,6 +28,17 @@ export const useQueueNewFeatureBadge = () => {
     FeatureFlags.QUEUE_NEW_FEATURE_BADGE
   )
   const [hasDismissed, setHasDismissed] = useState<boolean | null>(null)
+  const dispatch = useDispatch()
+  const hasIdentifiedRef = useRef(false)
+
+  useEffect(() => {
+    if (!isLoaded || hasIdentifiedRef.current) return
+    hasIdentifiedRef.current = true
+    dispatch({
+      type: ANALYTICS_IDENTIFY,
+      traits: { queue_new_feature_badge: isEnabled ? 'on' : 'off' }
+    })
+  }, [isLoaded, isEnabled, dispatch])
 
   useEffect(() => {
     let cancelled = false

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -21,6 +21,7 @@ export type IdentifyTraits = {
   name?: string
   email?: string
   userId?: ID
+  queue_new_feature_badge?: 'on' | 'off'
 }
 
 export type AnalyticsEvent = {


### PR DESCRIPTION
## Summary

Sets an Amplitude user property `queue_new_feature_badge` = `'on' | 'off'` so the A/B test for the play-queue "New" badge ([#14254](https://github.com/AudiusProject/apps/pull/14254)) can be sliced in Amplitude. Currently nothing surfaces the variation to Amplitude, so charts can't filter by treatment vs. control.

- Adds `queue_new_feature_badge?: 'on' | 'off'` to `IdentifyTraits`.
- In `useQueueNewFeatureBadge`, dispatches `ANALYTICS/IDENTIFY` once when the feature flag has loaded, with the variation as a trait. The existing analytics saga forwards it to both web and mobile Amplitude SDKs as a user property via `Identify.set(...)`.
- Per-mount `useRef` guard so it dispatches at most once per mount; Amplitude `Identify.set` is idempotent so re-fires across mounts are harmless.

## Optimizely setup (separate, not in this PR)

Create a flag named `queue_new_feature_badge` (lowercase, exact) with a Targeted Delivery rule at 50% included → variation `on`. The flag default is `false` ([feature-flags.ts](packages/common/src/services/remote-config/feature-flags.ts)), so until the rule is on, all users get tagged `'off'`.

## Test plan

- [ ] In dev with the flag forced on, confirm an `Identify` call fires once with `queue_new_feature_badge: 'on'` (Amplitude network panel / Redux DevTools `ANALYTICS/IDENTIFY` action).
- [ ] In dev with the flag forced off, same check with `'off'`.
- [ ] Verify on web (`QueueButton`) and mobile (`ActionsBar`) — both consume the hook.
- [ ] Verify in Amplitude that the user property shows up on the next event after the dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)