### PR TITLE
fix: handle remixes/contest page shape in mobile play queue drawer

### DIFF
--- a/packages/mobile/src/components/queue-drawer/QueueDrawer.tsx
+++ b/packages/mobile/src/components/queue-drawer/QueueDrawer.tsx
@@ -231,9 +231,15 @@ const useNextFromSourceMobile = () => {
 
   return useMemo<{ trackIds: ID[]; sourceKey: string | null }>(() => {
     if (!querySource) return { trackIds: [], sourceKey: null }
-    const data = queryClient.getQueryData<{
-      pages: Array<Array<{ id: number | string; type?: string }>>
-    }>(querySource.queryKey as any)
+    type LineupItem = { id: number | string; type?: string }
+    // Most lineup pages are `LineupItem[]`. The remixes/contest lineup wraps
+    // its items in `{ count, tracks: LineupItem[] }` — without this branch,
+    // `for (const item of page)` would throw on the object and crash the
+    // drawer when a contest track is playing.
+    type LineupPage = LineupItem[] | { tracks: LineupItem[] }
+    const data = queryClient.getQueryData<{ pages: LineupPage[] }>(
+      querySource.queryKey as any
+    )
     const sourceKey =
       Array.isArray(querySource.queryKey) && querySource.queryKey[0]
         ? String(querySource.queryKey[0])
@@ -243,7 +249,12 @@ const useNextFromSourceMobile = () => {
     const inQueue = new Set(queue.map((t) => t.trackId))
     const upcoming: ID[] = []
     for (const page of data.pages) {
-      for (const item of page) {
+      const items: LineupItem[] = Array.isArray(page)
+        ? page
+        : Array.isArray(page?.tracks)
+          ? page.tracks
+          : []
+      for (const item of items) {
         if (!item) continue
         if (item.type && item.type !== 'track') continue
         const id = typeof item.id === 'number' ? item.id : Number(item.id)


### PR DESCRIPTION
## Summary

Fixes a crash in the mobile play queue drawer when a contest track is the source of playback.

## Root cause

`QueueDrawer.useNextFromSourceMobile` reads the source lineup from the tan-query cache and iterates each page with `for (const item of page)`. This works for lineups whose page shape is `Array<{id, type}>` (feed, trending, profile, search, history, etc.), but the **remixes/contest** lineup — built by `useRemixes` / `useRemixesLineup` and used by [ContestSubmissionsTab.tsx:174](packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx:174) — wraps its items in `{ count: number, tracks: Array<{id, type}> }`. Iterating that object with `for-of` throws `TypeError: page is not iterable`, which crashes the drawer the moment the user opens it while a contest track is playing.

## Fix

Unwrap `page.tracks` when the page is an object instead of an array, in [QueueDrawer.tsx:251-256](packages/mobile/src/components/queue-drawer/QueueDrawer.tsx:251). All other lineup shapes continue to work unchanged.

The same bug exists in the equivalent web hook ([useNextFromSource.ts:40-50](packages/web/src/components/queue-popover/useNextFromSource.ts:40)); leaving that for a separate fix since the report was mobile-only.

## Test plan
- [ ] Mobile: play a track from the Contest screen Submissions tab, open the play queue drawer — drawer renders without crashing, "Up Next" populates with upcoming submission tracks not yet in the queue.
- [ ] Mobile: regression — play from feed / trending / profile, open the queue drawer — "Up Next" still populates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)