### PR TITLE
[Mobile] Fix play queue crash on contest/remix pages by normalizing lineup shape

### DIFF
--- a/packages/common/src/api/tan-query/events/useAllRemixContests.ts
+++ b/packages/common/src/api/tan-query/events/useAllRemixContests.ts
@@ -7,17 +7,17 @@ import {
 } from '@audius/sdk'
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 
-import { eventMetadataFromSDK } from '~/adapters/event'
-import { getRemixesQueryKey } from '~/api/tan-query/remixes/useRemixes'
-import { useQueryContext } from '~/api/tan-query/utils'
-import { primeRelatedData } from '~/api/tan-query/utils/primeRelatedData'
-import { ID } from '~/models'
-import { removeNullable } from '~/utils'
-
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, QueryOptions } from '../types'
 
 import { getEventIdsByEntityIdQueryKey, getEventQueryKey } from './utils'
+
+import { eventMetadataFromSDK } from '~/adapters/event'
+import { getRemixesCountQueryKey } from '~/api/tan-query/remixes/useRemixes'
+import { useQueryContext } from '~/api/tan-query/utils'
+import { primeRelatedData } from '~/api/tan-query/utils/primeRelatedData'
+import { ID } from '~/models'
+import { removeNullable } from '~/utils'
 
 const DEFAULT_PAGE_SIZE = 25
 
@@ -83,28 +83,15 @@ export const useAllRemixContests = (
       // network round-trip instead of N+1.
       primeRelatedData({ related, queryClient })
 
-      // Prime useRemixes({ trackId, pageSize: 0, isContestEntry: true }) so
-      // ContestCard's entry-count badge doesn't fire a count-only request
-      // per card. The card reads `data.pages[0].count`, so we seed the
-      // InfiniteData shape directly.
+      // Prime the dedicated `useRemixesCount` cache so ContestCard's
+      // entry-count badge doesn't fire a count-only request per card.
       const entryCounts = related?.entryCounts ?? {}
       for (const [hashedTrackId, count] of Object.entries(entryCounts)) {
         const trackId = OptionalHashId.parse(hashedTrackId)
         if (!trackId) continue
-        // The useRemixes query key is typed as `InfiniteData<RemixesQueryData[]>`
-        // (pages-of-arrays) but the runtime cache shape is `InfiniteData<RemixesQueryData>`
-        // — see ContestCard's `remixesData?.pages?.[0]?.count` access. We
-        // seed the real runtime shape and cast to bypass the existing key type.
         queryClient.setQueryData(
-          getRemixesQueryKey({
-            trackId,
-            pageSize: 0,
-            isContestEntry: true
-          }),
-          {
-            pages: [{ count, tracks: [] }],
-            pageParams: [0]
-          } as unknown as never
+          getRemixesCountQueryKey({ trackId, isContestEntry: true }),
+          count
         )
       }
 

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -81,6 +81,7 @@ export const QUERY_KEYS = {
   usdcTransactions: 'usdcTransactions',
   libraryTracks: 'libraryTracks',
   remixes: 'remixes',
+  remixesCount: 'remixesCount',
   premiumTracks: 'premiumTracks',
   profileReposts: 'profileReposts',
   profileTracks: 'profileTracks',

--- a/packages/common/src/api/tan-query/remixes/useRemixes.ts
+++ b/packages/common/src/api/tan-query/remixes/useRemixes.ts
@@ -7,21 +7,21 @@ import {
 import {
   InfiniteData,
   useInfiniteQuery,
+  useQuery,
   useQueryClient
 } from '@tanstack/react-query'
 import { useDispatch } from 'react-redux'
 
-import { transformAndCleanList, userTrackMetadataFromSDK } from '~/adapters'
-import { useQueryContext } from '~/api/tan-query/utils'
-import { ID } from '~/models'
-import { remixesPageActions } from '~/store/pages'
-
 import { QUERY_KEYS } from '../queryKeys'
 import { getTrackQueryKey } from '../tracks/useTrack'
-import { QueryKey, QueryOptions } from '../types'
+import { LineupData, QueryKey, QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { getUserQueryKey } from '../users/useUser'
 import { primeTrackData } from '../utils/primeTrackData'
+
+import { transformAndCleanList, userTrackMetadataFromSDK } from '~/adapters'
+import { useQueryContext } from '~/api/tan-query/utils'
+import { remixesPageActions } from '~/store/pages'
 
 const DEFAULT_PAGE_SIZE = 10
 
@@ -35,9 +35,10 @@ export type UseRemixesArgs = {
   isContestEntry?: boolean
 }
 
-export type RemixesQueryData = {
-  count: number
-  tracks: { id: ID; type: EntityType }[]
+export type UseRemixesCountArgs = {
+  trackId: number | null | undefined
+  isCosign?: boolean
+  isContestEntry?: boolean
 }
 
 export const getRemixesQueryKey = ({
@@ -60,7 +61,18 @@ export const getRemixesQueryKey = ({
       isCosign,
       isContestEntry
     }
-  ] as unknown as QueryKey<InfiniteData<RemixesQueryData[]>>
+  ] as unknown as QueryKey<InfiniteData<LineupData[]>>
+
+export const getRemixesCountQueryKey = ({
+  trackId,
+  isCosign = false,
+  isContestEntry = false
+}: UseRemixesCountArgs) =>
+  [
+    QUERY_KEYS.remixesCount,
+    trackId,
+    { isCosign, isContestEntry }
+  ] as unknown as QueryKey<number>
 
 export const useRemixes = (
   {
@@ -90,16 +102,16 @@ export const useRemixes = (
       isContestEntry
     }),
     initialPageParam: 0,
-    getNextPageParam: (lastPage: RemixesQueryData, allPages) => {
-      const isSecondPage = allPages.length === 1
-      if (
-        lastPage?.tracks?.length < pageSize ||
-        (isSecondPage && includeOriginal && lastPage?.tracks?.length - 1 === 0)
-      ) {
-        return undefined
-      }
+    getNextPageParam: (lastPage: LineupData[], allPages) => {
+      // First page may have the original prepended; subtract it before
+      // comparing to pageSize so a full page of `pageSize` actual remixes
+      // doesn't false-stop pagination.
+      const isFirstPage = allPages.length === 1
+      const remixesOnLastPage =
+        lastPage.length - (isFirstPage && includeOriginal ? 1 : 0)
+      if (remixesOnLastPage < pageSize) return undefined
       return (
-        allPages.reduce((acc, page) => acc + page.tracks.length, 0) -
+        allPages.reduce((acc, page) => acc + page.length, 0) -
         (includeOriginal ? 1 : 0)
       )
     },
@@ -133,20 +145,60 @@ export const useRemixes = (
 
       primeTrackData({ tracks: processedTracks, queryClient })
 
-      // Update count in store
+      // Mirror the count into the dedicated count query so single-purpose
+      // count consumers don't need to fire their own request once the
+      // lineup is loaded.
+      queryClient.setQueryData(
+        getRemixesCountQueryKey({ trackId, isCosign, isContestEntry }),
+        data.count ?? 0
+      )
+
+      // Update count in legacy redux store
       dispatch(remixesPageActions.setCount({ count: data.count }))
 
-      return {
-        tracks: processedTracks.map((t) => ({
-          id: t.track_id,
-          type: EntityType.TRACK
-        })),
-        count: data.count
-      }
+      return processedTracks.map((t) => ({
+        id: t.track_id,
+        type: EntityType.TRACK
+      }))
     },
     enabled: options?.enabled !== false && !!trackId,
     ...options
   })
 
   return queryData
+}
+
+/**
+ * Count-only companion to `useRemixes`. Hits the same SDK endpoint with
+ * `limit=0` and stores just the total under a separate query key so the
+ * lineup query can keep its standard `LineupData[]` page shape (which is
+ * what `TrackLineup` / `playFrom`'s `querySource` requires).
+ */
+export const useRemixesCount = (
+  { trackId, isCosign = false, isContestEntry = false }: UseRemixesCountArgs,
+  options?: QueryOptions
+) => {
+  const { audiusSdk } = useQueryContext()
+  const { data: currentUserId } = useCurrentUserId()
+  const dispatch = useDispatch()
+
+  return useQuery({
+    queryKey: getRemixesCountQueryKey({ trackId, isCosign, isContestEntry }),
+    queryFn: async () => {
+      const sdk = await audiusSdk()
+      const remixesResponse = await sdk.tracks.getTrackRemixes({
+        trackId: Id.parse(trackId),
+        userId: OptionalId.parse(currentUserId),
+        limit: 0,
+        offset: 0,
+        onlyCosigns: isCosign,
+        onlyContestEntries: isContestEntry
+      })
+      const count = remixesResponse?.data?.count ?? 0
+      dispatch(remixesPageActions.setCount({ count }))
+      return count
+    },
+    enabled: options?.enabled !== false && !!trackId,
+    ...options
+  })
 }

--- a/packages/common/src/api/tan-query/remixes/useRemixesLineup.ts
+++ b/packages/common/src/api/tan-query/remixes/useRemixesLineup.ts
@@ -3,14 +3,19 @@ import { useEffect, useMemo } from 'react'
 import { EntityType } from '@audius/sdk'
 import { useDispatch } from 'react-redux'
 
-import { useRemixContestWinners } from '~/api/tan-query/events/useRemixContestWinners'
-import { ID } from '~/models'
-import { remixesPageActions } from '~/store/pages'
-
 import { LineupData, QueryOptions } from '../types'
 import { makeLoadNextPage } from '../utils/infiniteQueryLoadNextPage'
 
-import { UseRemixesArgs, useRemixes, getRemixesQueryKey } from './useRemixes'
+import {
+  UseRemixesArgs,
+  useRemixes,
+  useRemixesCount,
+  getRemixesQueryKey
+} from './useRemixes'
+
+import { useRemixContestWinners } from '~/api/tan-query/events/useRemixContestWinners'
+import { ID } from '~/models'
+import { remixesPageActions } from '~/store/pages'
 
 const DEFAULT_PAGE_SIZE = 10
 
@@ -60,10 +65,19 @@ export const useRemixesLineup = (
     }
   )
 
+  // Total submissions/remixes count comes from the dedicated count query.
+  // The lineup query's queryFn primes this cache entry, so once the lineup
+  // is loaded this hits the cache instead of making another round-trip.
+  const { data: count } = useRemixesCount(
+    { trackId, isCosign, isContestEntry },
+    {
+      enabled: options?.enabled !== false && !!trackId
+    }
+  )
+
   // Process and order the lineup data
   const processedLineupData: LineupData[] = useMemo(() => {
-    const remixTracks =
-      queryData.data?.pages.flatMap((page) => page.tracks) ?? []
+    const remixTracks = queryData.data?.pages.flat() ?? []
 
     const orderedTracks: LineupData[] = []
 
@@ -114,7 +128,7 @@ export const useRemixesLineup = (
 
   return {
     data: processedLineupData,
-    count: queryData.data?.pages[0]?.count,
+    count,
     trackIds,
     queryKey,
     pageSize,

--- a/packages/mobile/src/components/contest-card/ContestCard.tsx
+++ b/packages/mobile/src/components/contest-card/ContestCard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import {
   useRemixContest,
-  useRemixes,
+  useRemixesCount,
   useTrack,
   useUser
 } from '@audius/common/api'
@@ -262,12 +262,10 @@ export const ContestCard = (props: ContestCardProps) => {
     ? { uri: contestCoverPhotoUrl }
     : trackImageSource
 
-  // Count-only: API returns full total in `count` even when limit=0 (no track rows).
-  const { data: remixesData } = useRemixes(
-    { trackId, pageSize: 0, isContestEntry: true },
+  const { data: entriesCount = 0 } = useRemixesCount(
+    { trackId, isContestEntry: true },
     { enabled: !!trackId }
   )
-  const entriesCount = remixesData?.pages?.[0]?.count ?? 0
 
   const navigation = useNavigation<NavigationProp>()
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from 'react'
 import {
   getRemixesQueryKey,
   useRemixContest,
-  useRemixes,
+  useRemixesCount,
   useRemixesLineup
 } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
@@ -96,11 +96,10 @@ export const ContestSubmissionsTab = () => {
 
   // Submissions total comes from a count-only API query so it matches
   // the contest card total instead of growing as the user scrolls.
-  const { data: remixesCountData } = useRemixes(
-    { trackId, pageSize: 0, isContestEntry: true },
+  const { data: submissionsCount = 0 } = useRemixesCount(
+    { trackId, isContestEntry: true },
     { enabled: !!trackId, staleTime: 60_000 }
   )
-  const submissionsCount = remixesCountData?.pages?.[0]?.count ?? 0
 
   const winnersDelineator = useMemo(
     () => (

--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -4,7 +4,7 @@ import {
   getRemixesQueryKey,
   useCurrentUserId,
   useRemixContest,
-  useRemixes,
+  useRemixesCount,
   useRemixesLineup,
   useTrackByParams
 } from '@audius/common/api'
@@ -88,11 +88,10 @@ export const TrackRemixesScreen = () => {
   const isRemixContestEnded =
     isRemixContest && dayjs(contest.endDate).isBefore(dayjs())
   const isTrackOwner = currentUserId === track?.owner_id
-  const { data: remixes } = useRemixes({
+  const { data: remixCount = 0 } = useRemixesCount({
     trackId: track?.track_id,
     isContestEntry: true
   })
-  const remixCount = remixes?.pages[0]?.count ?? 0
   const showPickWinnersButton =
     isTrackOwner && isRemixContestEnded && remixCount > 0
   const winnerCount = contest?.eventData?.winners?.length ?? 0

--- a/packages/web/src/components/contest-card/ContestCard.tsx
+++ b/packages/web/src/components/contest-card/ContestCard.tsx
@@ -10,7 +10,7 @@ import {
 
 import {
   useRemixContest,
-  useRemixes,
+  useRemixesCount,
   useTrack,
   useUser
 } from '@audius/common/api'
@@ -248,17 +248,15 @@ export const ContestCard = forwardRef(
       ?.coverPhotoUrl as string | undefined
     const imageUrl = contestCoverPhotoUrl || trackImageUrl
 
-    // Count-only: API returns full total in `count` even when limit=0 (no track rows).
     // staleTime lets the discovery endpoint's primed cache (see
     // useAllRemixContests) satisfy this query without an extra count-only
     // round-trip per card. 60s is loose enough to skip redundant refetches
     // during a single visit, tight enough that a returning user sees
     // near-live counts.
-    const { data: remixesData } = useRemixes(
-      { trackId, pageSize: 0, isContestEntry: true },
+    const { data: entriesCount = 0 } = useRemixesCount(
+      { trackId, isContestEntry: true },
       { enabled: !!trackId, staleTime: 60_000 }
     )
-    const entriesCount = remixesData?.pages?.[0]?.count ?? 0
     // Line-height for heading/m + heading/l respectively, pulled from
     // Harmony typography. We pin the title row to exactly two lines so
     // cards in the grid line up regardless of title length (Figma

--- a/packages/web/src/components/notification/Notification/ArtistRemixContestEndedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestEndedNotification.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { useNotificationEntity, useRemixes } from '@audius/common/api'
+import { useNotificationEntity, useRemixesCount } from '@audius/common/api'
 import {
   ArtistRemixContestEndedNotification as ArtistRemixContestEndedNotificationType,
   TrackEntity
@@ -39,12 +39,10 @@ export const ArtistRemixContestEndedNotification = (
   const dispatch = useDispatch()
 
   const entity = useNotificationEntity(notification) as TrackEntity | null
-  const { data: remixes } = useRemixes({
+  const { data: remixCount = 0 } = useRemixesCount({
     trackId: entity?.track_id,
     isContestEntry: true
   })
-
-  const remixCount = remixes?.pages[0]?.count ?? 0
 
   const pickWinnersRoute = entity ? pickWinnersPage(entity?.permalink) : ''
 

--- a/packages/web/src/pages/contest-page/ContestPage.test.tsx
+++ b/packages/web/src/pages/contest-page/ContestPage.test.tsx
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
   useFollowEvent: vi.fn(),
   useUnfollowEvent: vi.fn(),
   useRemixesLineup: vi.fn(),
-  useRemixes: vi.fn(),
+  useRemixesCount: vi.fn(),
   useRemixersCount: vi.fn(),
   useComment: vi.fn(),
   useEventComments: vi.fn(),
@@ -44,7 +44,7 @@ vi.mock('@audius/common/api', async (importOriginal) => {
     useFollowEvent: mocks.useFollowEvent,
     useUnfollowEvent: mocks.useUnfollowEvent,
     useRemixesLineup: mocks.useRemixesLineup,
-    useRemixes: mocks.useRemixes,
+    useRemixesCount: mocks.useRemixesCount,
     useRemixersCount: mocks.useRemixersCount,
     useComment: mocks.useComment,
     useEventComments: mocks.useEventComments,
@@ -159,9 +159,7 @@ describe('ContestPage', () => {
       lineup: { entries: [], order: {} }
     })
     mocks.useRemixersCount.mockReturnValue({ data: 0 })
-    mocks.useRemixes.mockReturnValue({
-      data: { pages: [{ count: 0 }] }
-    })
+    mocks.useRemixesCount.mockReturnValue({ data: 0 })
     mocks.useEventComments.mockReturnValue({
       data: [],
       isPending: false,
@@ -220,9 +218,7 @@ describe('ContestPage', () => {
     // Submissions pill reads from the count-only API query, not the
     // lineup length — so the test needs a non-zero count for the pill
     // to render.
-    mocks.useRemixes.mockReturnValue({
-      data: { pages: [{ count: 1 }] }
-    })
+    mocks.useRemixesCount.mockReturnValue({ data: 1 })
     renderContestPage()
 
     // About + Prizes are now rendered as uppercase label-style section

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -6,7 +6,7 @@ import {
   useEventFollowState,
   useFollowEvent,
   useRemixContest,
-  useRemixes,
+  useRemixesCount,
   useRemixesLineup,
   useStems,
   useTrack,
@@ -341,12 +341,10 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
   // only reflects what infinite-scroll has loaded — the count crept
   // up as the user scrolled rather than reading as a stable total.
   const winnerCount = contest?.eventData?.winners?.length ?? 0
-  const { data: remixesCountData } = useRemixes(
-    { trackId: trackId ?? 0, pageSize: 0, isContestEntry: true },
+  const { data: submissionsCount } = useRemixesCount(
+    { trackId, isContestEntry: true },
     { enabled: !!trackId, staleTime: 60_000 }
   )
-  const submissionsCount: number | undefined =
-    remixesCountData?.pages?.[0]?.count
 
   const handleEditContest = useCallback(() => {
     if (track?.permalink) {

--- a/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
+++ b/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
@@ -5,6 +5,7 @@ import {
   useCurrentUserId,
   useRemixContest,
   useRemixes,
+  useRemixesCount,
   useTrackByPermalink,
   useUpdateEvent
 } from '@audius/common/api'
@@ -104,12 +105,14 @@ export const PickWinnersPage = () => {
   const remixesQuery = useRemixes(remixesArgs)
   const trackIds = useMemo(
     () =>
-      remixesQuery.data?.pages.flatMap((page) =>
-        page.tracks.map((t) => t.id)
-      ) ?? [],
+      remixesQuery.data?.pages.flatMap((page) => page.map((t) => t.id)) ?? [],
     [remixesQuery.data]
   )
-  const count = remixesQuery.data?.pages[0]?.count
+  const { data: count } = useRemixesCount({
+    trackId: originalTrack?.track_id,
+    isCosign,
+    isContestEntry: true
+  })
   const isFetching = remixesQuery.isFetching
   const isPending = remixesQuery.isPending
   const isError = remixesQuery.isError

--- a/packages/web/src/pages/remixes-page/components/desktop/RemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/RemixesPage.tsx
@@ -8,7 +8,7 @@ import {
   useRemixersCount,
   useRemixesLineup,
   useCurrentUserId,
-  useRemixes,
+  useRemixesCount,
   getRemixesQueryKey
 } from '@audius/common/api'
 import { remixMessages as messages } from '@audius/common/messages'
@@ -67,11 +67,10 @@ const RemixesPage = (_props: RemixesPageProps) => {
   const { data: currentUserId } = useCurrentUserId()
   const { data: contest } = useRemixContest(trackId)
   const winnerCount = contest?.eventData?.winners?.length ?? 0
-  const { data: remixes } = useRemixes({
+  const { data: remixCount = 0 } = useRemixesCount({
     trackId: trackId ?? undefined,
     isContestEntry: true
   })
-  const remixCount = remixes?.pages[0]?.count ?? 0
 
   const { sortMethod, isCosign, isContestEntry } = useRemixPageParams()
   const {


### PR DESCRIPTION
## Summary
- The mobile play queue drawer crashed (`TypeError: page is not iterable`) whenever a contest or remix page was the playback source.
- Root cause: `useRemixes` stored each tan-query page as `{ count, tracks: LineupItem[] }`, while every other lineup query (and the queue drawer / web 'Up Next' code that iterates `data.pages`) expects a flat `LineupItem[]` per page.
- Rather than special-case the queue drawer, this PR conforms the contest/remix queries to the standard lineup pattern.

## Changes
- `useRemixes` now returns flat `LineupData[]` per page — matching `useProfileTracks` and friends.
- New `useRemixesCount` (regular query, not infinite) carries the total count. The lineup queryFn primes the count cache so consumers reading both don't pay an extra round-trip.
- `useRemixesLineup` reads `count` via `useRemixesCount`; `useAllRemixContests` primes the new count key.
- Migrated all `pages?.[0]?.count` consumers to `useRemixesCount`:
  - web: `ContestPage`, `RemixesPage` (desktop), `PickWinnersPage`, `ContestCard`, `ArtistRemixContestEndedNotification`
  - mobile: `ContestCard`, `TrackRemixesScreen`, `ContestSubmissionsTab`
- Updated `ContestPage.test.tsx` mocks to match.

## Test plan
- [ ] Open a contest page, play any submission, then open the play queue drawer — drawer renders, "Up Next from <source>" populates without crashing.
- [ ] Open a track's remixes page, play a remix, then open the play queue drawer — same as above.
- [ ] Verify the submissions count badge on `ContestCard` (explore grid) and the submissions pill on the Contest page still show the correct totals (not zero, not "growing as you scroll").
- [ ] Verify "X Remixes" header on the mobile remixes page still reflects the API total.
- [ ] Pick Winners page: submission list still loads and paginates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)