### PR TITLE
[Mobile] Smooth out lineup infinite-scroll on Trending and Feed

### DIFF
--- a/.changeset/improve-mobile-lineup-scroll.md
+++ b/.changeset/improve-mobile-lineup-scroll.md
@@ -1,0 +1,5 @@
+---
+'@audius/mobile': patch
+---
+
+Smooth out the infinite-scroll feel on Trending and Feed lineups. The mobile `TrackLineup` previously waited a 100ms debounce before dispatching `loadNextPage`, then waited again for the parent's `isFetching` to round-trip back through tanquery before any skeleton rows appeared — so users would scroll to the bottom, see nothing happen, then see late skeletons, then tracks. The threshold is now bumped from 0.5 to a full viewport ahead, the debounce and the duplicate `onScroll` handler are removed, and a synchronous local "load triggered" flag flips skeletons on in the same tick the scroll handler fires.

--- a/packages/mobile/src/components/lineup/TrackLineup.tsx
+++ b/packages/mobile/src/components/lineup/TrackLineup.tsx
@@ -1,6 +1,13 @@
-import { memo, useCallback, useMemo, useRef, type ReactElement } from 'react'
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement
+} from 'react'
 
-import { useDebouncedCallback } from '@audius/common/hooks'
 import {
   Kind,
   type ID,
@@ -27,9 +34,11 @@ const { makeGetCurrent } = playbackSelectors
 const { getPlaying } = playbackSelectors
 const { getCurrentTrackId: getPlaybackCurrentTrackId } = playbackSelectors
 
-// Threshold (as a fraction of visible list height) for how close to the end
-// of the list the user must scroll before we fetch the next page.
-const LOAD_MORE_THRESHOLD = 0.5
+// Threshold for `onEndReachedThreshold` (fraction of viewport length).
+// 1.0 means "fetch when one full viewport of content remains below" so the
+// next page request is in flight well before the user actually hits the
+// bottom of the list.
+const LOAD_MORE_THRESHOLD = 1
 
 const styles = StyleSheet.create({
   root: { flex: 1 },
@@ -204,12 +213,30 @@ export const TrackLineup = ({
     [visibleTrackIds, uidFor]
   )
 
+  // Synchronous "load more was triggered" flag — set the moment the scroll
+  // handler fires so skeletons render on the next frame, without waiting for
+  // the parent's tanquery `isFetching` to propagate. Cleared once the parent
+  // either delivers more entries or finishes fetching.
+  const [isLoadMoreTriggered, setIsLoadMoreTriggered] = useState(false)
+  const prevEntriesLengthRef = useRef(entries.length)
+  useEffect(() => {
+    if (entries.length !== prevEntriesLengthRef.current) {
+      prevEntriesLengthRef.current = entries.length
+      setIsLoadMoreTriggered(false)
+    }
+  }, [entries.length])
+  useEffect(() => {
+    if (!isFetching) setIsLoadMoreTriggered(false)
+  }, [isFetching])
+
   const sections: Section[] = useMemo(() => {
     const getSkeletonCount = () => {
       if (entries.length === 0 && isPending) {
         return Math.min(maxEntries, initialPageSize ?? pageSize)
       }
-      if (isFetching) return Math.min(maxEntries, pageSize)
+      if (isFetching || isLoadMoreTriggered) {
+        return Math.min(maxEntries, pageSize)
+      }
       return 0
     }
     const skeletons = range(getSkeletonCount()).map(
@@ -218,7 +245,15 @@ export const TrackLineup = ({
     const data: RenderItem[] = [...entries, ...skeletons]
     if (data.length === 0) return []
     return [{ data }]
-  }, [entries, isPending, isFetching, initialPageSize, pageSize, maxEntries])
+  }, [
+    entries,
+    isPending,
+    isFetching,
+    isLoadMoreTriggered,
+    initialPageSize,
+    pageSize,
+    maxEntries
+  ])
 
   const renderItem = useCallback(
     ({ item, index }: { item: RenderItem; index: number }) => {
@@ -254,26 +289,16 @@ export const TrackLineup = ({
     ]
   )
 
-  const debouncedLoadNextPage = useDebouncedCallback(
-    () => {
-      loadNextPage?.()
-    },
-    [loadNextPage],
-    100
-  )
-
-  const handleScroll = useCallback(
-    ({ nativeEvent }: any) => {
-      const { layoutMeasurement, contentOffset, contentSize } = nativeEvent
-      if (
-        layoutMeasurement.height + contentOffset.y >=
-        contentSize.height - LOAD_MORE_THRESHOLD * layoutMeasurement.height
-      ) {
-        if (!isFetching && hasNextPage) debouncedLoadNextPage()
-      }
-    },
-    [debouncedLoadNextPage, isFetching, hasNextPage]
-  )
+  // Single, synchronous load-more entry point. Flipping the local flag in the
+  // same tick as dispatching the parent's `loadNextPage` makes the skeletons
+  // render on the very next frame, instead of after a debounce window plus
+  // the round-trip through tanquery's `isFetching`.
+  const handleLoadMore = useCallback(() => {
+    if (!hasNextPage || isFetching || isLoadMoreTriggered) return
+    if (!loadNextPage) return
+    setIsLoadMoreTriggered(true)
+    loadNextPage()
+  }, [hasNextPage, isFetching, isLoadMoreTriggered, loadNextPage])
 
   const scrollToTop = useCallback(() => {
     if (entries.length === 0) return
@@ -296,12 +321,11 @@ export const TrackLineup = ({
       <SectionList
         {...pullToRefreshProps}
         ref={ref}
-        onScroll={handleScroll}
         ListHeaderComponent={hideHeaderOnEmpty && isEmpty ? undefined : header}
         ListFooterComponent={hasNextPage ? null : ListFooterComponent}
         hidePlayBarChin={true}
         ListEmptyComponent={LineupEmptyComponent}
-        onEndReached={debouncedLoadNextPage}
+        onEndReached={handleLoadMore}
         onEndReachedThreshold={LOAD_MORE_THRESHOLD}
         sections={isEmpty ? [] : sections}
         stickySectionHeadersEnabled={false}


### PR DESCRIPTION
## Summary

The mobile `TrackLineup` infinite-scroll on Trending and Feed felt rough: scrolling to the bottom looked frozen for a beat, then late skeletons appeared, then tracks loaded. Three things were stacked on top of each other:

- **100ms debounce** on `loadNextPage` (`useDebouncedCallback(..., 100)`) — every load trigger waited a full debounce window before dispatching.
- **Skeletons gated on the parent's `isFetching`** — they only rendered after `loadNextPage()` ran, RTK Query started the request, and `isFetching` propagated back through the parent. That's a multi-tick round-trip after the user already hit the bottom.
- **Duplicate scroll handlers** — both a custom `onScroll` and `onEndReached` called the same debounced load.

This PR makes the scroll feedback synchronous:

- Bump `onEndReachedThreshold` from `0.5` to `1` so the next page request fires when one full viewport of content remains below.
- Drop the debounce and the duplicate `onScroll` handler — `onEndReached` already fires at the same threshold.
- Add a local `isLoadMoreTriggered` flag set the same tick the scroll handler fires, so skeletons render on the very next frame instead of waiting for the parent's tanquery `isFetching` to flip. Cleared once new entries arrive or the parent finishes fetching.

Single load-more entry point now:

```ts
const handleLoadMore = useCallback(() => {
  if (!hasNextPage || isFetching || isLoadMoreTriggered) return
  if (!loadNextPage) return
  setIsLoadMoreTriggered(true)
  loadNextPage()
}, [hasNextPage, isFetching, isLoadMoreTriggered, loadNextPage])
```

Skeleton count consults both the parent state and the local trigger:

```ts
if (isFetching || isLoadMoreTriggered) {
  return Math.min(maxEntries, pageSize)
}
```

## Test plan

- [ ] Open Trending (Week / Month / All-Time) on iOS, scroll quickly — skeletons appear before reaching the bottom and the next page loads in.
- [ ] Same on Android.
- [ ] Open Feed, scroll fast through several pages — no perceptible "frozen at bottom" pause.
- [ ] Verify pull-to-refresh still works on Trending / Feed.
- [ ] Verify other `TrackLineup` consumers still paginate correctly (Profile Tracks/Reposts, Search Tracks, Track remixes, Listening History, Contest Submissions).
- [ ] Verify the empty state still renders when a tab has no tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)