### PR TITLE
[Mobile] Fix offline album track downloads after v1 SDK migration

### DIFF
--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -139,41 +139,70 @@ function* downloadTrackAsync(
       call(writeTrackMetadata, track)
     ])
   } catch (e) {
+    console.warn(
+      `[offline] track ${trackId} download failed:`,
+      e instanceof Error ? e.message : e
+    )
     return OfflineDownloadStatus.ERROR
   }
 
   return OfflineDownloadStatus.SUCCESS
 }
 
+function buildMirrorUris(primary: string, mirrors: string[] | undefined) {
+  const uris = [primary]
+  for (const mirror of mirrors ?? []) {
+    try {
+      const url = new URL(primary)
+      url.hostname = new URL(mirror).hostname
+      uris.push(url.toString())
+    } catch {
+      // skip malformed mirror
+    }
+  }
+  return uris
+}
+
 function* downloadTrackAudio(track: UserTrackMetadata, userId: ID) {
-  const { track_id } = track
+  const { track_id, stream } = track
 
   const trackFilePath = getLocalAudioPath(track_id)
 
-  const audiusSdk = yield* getContext('audiusSdk')
-  const sdk = yield* call(audiusSdk)
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const nftAccessSignatureMap = yield* select(getNftAccessSignatureMap)
-  const nftAccessSignature = nftAccessSignatureMap[track_id]?.mp3 ?? null
-  const { data, signature } = yield* call(
-    audiusBackendInstance.signGatedContentRequest,
-    { sdk }
-  )
-  const trackAudioUri = yield* call(
-    [sdk.tracks, sdk.tracks.getTrackStreamUrl],
-    {
-      trackId: Id.parse(track_id),
-      userId: OptionalId.parse(userId),
-      userSignature: signature,
-      userData: data,
-      nftAccessSignature: nftAccessSignature
-        ? JSON.stringify(nftAccessSignature)
-        : undefined
-    }
-  )
-  const response = yield* call(downloadFile, trackAudioUri, trackFilePath)
-  const { status } = response.info()
-  if (status === 200) return
+  // Prefer the v1 pre-signed stream URL (with mirrors), matching the
+  // AudioPlayer's online-streaming logic. Only fall back to building a
+  // URL manually when the v1 response omits stream.url.
+  let candidateUris: string[]
+  if (stream?.url) {
+    candidateUris = buildMirrorUris(stream.url, stream.mirrors)
+  } else {
+    const sdk = yield* getSDK()
+    const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+    const nftAccessSignatureMap = yield* select(getNftAccessSignatureMap)
+    const nftAccessSignature = nftAccessSignatureMap[track_id]?.mp3 ?? null
+    const { data, signature } = yield* call(
+      audiusBackendInstance.signGatedContentRequest,
+      { sdk }
+    )
+    const fallbackUri = yield* call(
+      [sdk.tracks, sdk.tracks.getTrackStreamUrl],
+      {
+        trackId: Id.parse(track_id),
+        userId: OptionalId.parse(userId),
+        userSignature: signature,
+        userData: data,
+        nftAccessSignature: nftAccessSignature
+          ? JSON.stringify(nftAccessSignature)
+          : undefined
+      }
+    )
+    candidateUris = [fallbackUri]
+  }
+
+  for (const uri of candidateUris) {
+    const response = yield* call(downloadFile, uri, trackFilePath)
+    const { status } = response.info()
+    if (status === 200) return
+  }
 
   throw new Error('Unable to download track audio')
 }
@@ -184,15 +213,7 @@ function* downloadTrackCoverArt(track: TrackMetadata) {
   const primaryImage = artwork[SquareSizes.SIZE_1000_BY_1000]
   if (!primaryImage) return
 
-  const coverArtUris = [
-    primaryImage,
-    ...(artwork.mirrors ?? []).map((mirror) => {
-      const url = new URL(primaryImage)
-      url.hostname = new URL(mirror).hostname
-      return url.toString()
-    })
-  ]
-
+  const coverArtUris = buildMirrorUris(primaryImage, artwork.mirrors)
   const covertArtFilePath = getLocalTrackCoverArtDestination(track_id)
 
   for (const coverArtUri of coverArtUris) {
@@ -201,7 +222,9 @@ function* downloadTrackCoverArt(track: TrackMetadata) {
     if (status === 200) return
   }
 
-  throw new Error('Unable to download track cover art')
+  // Best-effort: don't fail the whole track download if cover art is
+  // unavailable — the audio file is the essential payload, and the
+  // collection cover art download follows the same non-fatal pattern.
 }
 
 async function writeTrackMetadata(track: UserTrackMetadata) {


### PR DESCRIPTION
## Summary

Track downloads were failing in offline mode — the user-visible symptom is *"clicks download, sees a track attempt, then a failure icon."* This affects **both individual track downloads** (favoriting a track with auto-download on, or any other path that queues a single track) **and tracks inside an album/collection download**, because every track-job entry point lands in the same queue and is processed by the same worker.

Two compounding issues in `downloadTrackWorker.ts`, both effectively introduced by the v1 SDK migration (#13728):

1. **`downloadTrackAudio` skipped the v1 pre-signed stream URL.** It built the URL via `sdk.tracks.getTrackStreamUrl()`, ignoring `track.stream.url`. The v1 API returns a pre-signed stream URL (with mirrors) on the track itself; `AudioPlayer` prefers it for online streaming and only falls back to manual URL construction when `stream.url` is missing. The offline worker skipped that working path entirely, so it relied on the fallback for every track.

2. **`downloadTrackCoverArt` was fatal.** It threw when no artwork URI returned 200, and because cover art runs in `all([cover, audio, json])`, a single flaky artwork host failed the entire track download — even though audio is the only essential payload. The collection cover art download follows the opposite (best-effort) pattern; this PR brings the track version in line.

Plus `downloadTrackAsync`'s `catch` block silently swallowed the error — no logs, no Sentry breadcrumb. That's why this had been hard to diagnose.

### Why this fixes both individual tracks and collections

Every track-job source — `requestDownloadCollectionSaga`, `requestDownloadFavoritedCollectionSaga`, `requestDownloadAllFavoritesSaga`, `watchSaveTrackSaga` (standalone track favorite), `watchAddTrackToPlaylistSaga`, `syncCollectionWorker` — dispatches `addOfflineEntries({ items: [..., { type: 'track' }, ...] })`. The queue processor routes every `type === 'track'` job to a single `downloadTrackWorker`, which calls the two functions patched here. So both flows share the same broken code path.

## Changes

- `downloadTrackAudio`: prefer `track.stream.url` (with mirror substitution), keep `getTrackStreamUrl()` + manual signing as a last-resort fallback. Mirrors `AudioPlayer.tsx` logic.
- `downloadTrackCoverArt`: best-effort — return silently if all URIs fail rather than throwing.
- Extract shared `buildMirrorUris(primary, mirrors)` helper used by both audio and cover art.
- Add a `console.warn` in the catch block of `downloadTrackAsync` so future failures are diagnosable instead of silent.

## Test plan

- [ ] Offline mode → favorite a single track with "download all favorites" enabled. Track reaches SUCCESS, plays from local file.
- [ ] Offline mode → download an album you don't own (where you've favorited it). All tracks reach SUCCESS, audio plays from local file.
- [ ] Offline mode → download an album where the artwork host is degraded. Audio still downloads successfully; cover art is best-effort.
- [ ] Offline mode → download a single track via the track menu. Still works (no regression).
- [ ] Offline mode → toggle "Download all favorites." Track downloads succeed.
- [ ] Offline mode → play a downloaded track while offline. File-system playback still works.
- [ ] Gated content (USDC / NFT) → confirm the manual-URL fallback path still signs correctly when `stream.url` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)