### PR TITLE
[Mobile] Use skeleton placeholders on notifications screen

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/NotificationList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationList.tsx
@@ -1,37 +1,31 @@
-import { useCallback, useContext, useState } from 'react'
+import { useCallback, useContext, useMemo, useState } from 'react'
 
 import { useNotifications } from '@audius/common/api'
 import type { Notification } from '@audius/common/store'
 import { useIsFocused } from '@react-navigation/native'
 import { FlashList } from '@shopify/flash-list'
 import type { ViewToken } from 'react-native'
-import { View } from 'react-native'
 
-import LoadingSpinner from 'app/components/loading-spinner'
 import { makeStyles } from 'app/styles'
 
 import { AppDrawerContext } from '../app-drawer-screen'
 
 import { EmptyNotifications } from './EmptyNotifications'
 import { NotificationListItem } from './NotificationListItem'
+import { NotificationListItemSkeleton } from './NotificationListItemSkeleton'
 
-const useStyles = makeStyles(({ spacing, palette }) => ({
+const INITIAL_SKELETON_COUNT = 5
+const PAGINATION_SKELETON_COUNT = 3
+
+type LoadingItem = { _loading: true }
+type RenderItem = Notification | LoadingItem
+
+const isLoadingItem = (item: RenderItem): item is LoadingItem =>
+  '_loading' in item
+
+const useStyles = makeStyles(({ spacing }) => ({
   container: {
     paddingBottom: spacing(30)
-  },
-  itemContainer: {
-    marginTop: spacing(2),
-    paddingHorizontal: spacing(2)
-  },
-  footer: {
-    marginTop: spacing(5),
-    width: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: spacing(12)
-  },
-  spinner: {
-    color: palette.neutralLight4
   }
 }))
 
@@ -113,10 +107,44 @@ export const NotificationList = () => {
 
   const [isVisible, visibilityCallback] = useIsViewable()
 
+  const data = useMemo<RenderItem[]>(() => {
+    if (isError) return notifications
+    if (isPending && notifications.length === 0 && !isRefreshing) {
+      return Array.from(
+        { length: INITIAL_SKELETON_COUNT },
+        () => ({ _loading: true }) as LoadingItem
+      )
+    }
+    if (isFetchingNextPage) {
+      return [
+        ...notifications,
+        ...Array.from(
+          { length: PAGINATION_SKELETON_COUNT },
+          () => ({ _loading: true }) as LoadingItem
+        )
+      ]
+    }
+    return notifications
+  }, [notifications, isPending, isFetchingNextPage, isError, isRefreshing])
+
+  const keyExtractor = useCallback(
+    (item: RenderItem, index: number) =>
+      isLoadingItem(item) ? `skeleton-${index}` : item.id,
+    []
+  )
+
   const renderItem = useCallback(
-    ({ item, index }) => (
-      <NotificationListItem notification={item} isVisible={isVisible(index)} />
-    ),
+    ({ item, index }: { item: RenderItem; index: number }) => {
+      if (isLoadingItem(item)) {
+        return <NotificationListItemSkeleton />
+      }
+      return (
+        <NotificationListItem
+          notification={item}
+          isVisible={isVisible(index)}
+        />
+      )
+    },
     [isVisible]
   )
 
@@ -129,16 +157,9 @@ export const NotificationList = () => {
       contentContainerStyle={styles.container}
       refreshing={isRefreshing}
       onRefresh={handleRefresh}
-      data={notifications}
-      keyExtractor={(item: Notification) => item.id}
+      data={data}
+      keyExtractor={keyExtractor}
       renderItem={renderItem}
-      ListFooterComponent={
-        isPending && !isRefreshing ? (
-          <View style={styles.footer}>
-            <LoadingSpinner fill={styles.spinner.color} />
-          </View>
-        ) : undefined
-      }
       onEndReached={handleLoadMore}
       scrollEnabled={!gesturesDisabled}
       onViewableItemsChanged={visibilityCallback}

--- a/packages/mobile/src/screens/notifications-screen/NotificationListItemSkeleton.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationListItemSkeleton.tsx
@@ -1,0 +1,74 @@
+import { Flex } from '@audius/harmony-native'
+import { Tile } from 'app/components/core'
+import Skeleton from 'app/components/skeleton'
+import { makeStyles } from 'app/styles'
+
+const useStyles = makeStyles(({ spacing }) => ({
+  root: {
+    marginTop: spacing(2),
+    paddingHorizontal: spacing(2)
+  },
+  content: {
+    padding: spacing(4)
+  },
+  profilePicture: {
+    borderRadius: 19,
+    marginRight: spacing(-2)
+  }
+}))
+
+type NotificationListItemSkeletonProps = {
+  noShimmer?: boolean
+}
+
+export const NotificationListItemSkeleton = ({
+  noShimmer
+}: NotificationListItemSkeletonProps) => {
+  const styles = useStyles()
+  return (
+    <Tile styles={{ root: styles.root, content: styles.content }}>
+      <Flex
+        row
+        alignItems='center'
+        borderBottom='default'
+        pb='l'
+        mb='l'
+        gap='m'
+      >
+        <Skeleton
+          width={30}
+          height={30}
+          style={{ borderRadius: 15 }}
+          noShimmer={noShimmer}
+        />
+        <Flex row>
+          <Skeleton
+            width={38}
+            height={38}
+            style={styles.profilePicture}
+            noShimmer={noShimmer}
+          />
+          <Skeleton
+            width={38}
+            height={38}
+            style={styles.profilePicture}
+            noShimmer={noShimmer}
+          />
+          <Skeleton
+            width={38}
+            height={38}
+            style={styles.profilePicture}
+            noShimmer={noShimmer}
+          />
+        </Flex>
+      </Flex>
+      <Flex gap='s'>
+        <Skeleton width='90%' height={20} noShimmer={noShimmer} />
+        <Skeleton width='60%' height={20} noShimmer={noShimmer} />
+      </Flex>
+      <Flex row alignItems='center' mt='l'>
+        <Skeleton width={64} height={12} noShimmer={noShimmer} />
+      </Flex>
+    </Tile>
+  )
+}


### PR DESCRIPTION
## Summary
- Replaces the footer spinner on the mobile notifications screen with skeleton notification rows that mirror the shape of real notifications.
- Matches the loading pattern recently introduced for lineups (`LineupTileSkeleton` in `TrackLineup`): skeletons render during initial fetch and during pagination, mixed into the same `FlashList` data array.
- Empty (`EmptyNotifications`) and error states are preserved — skeletons are suppressed when `isError` is true, and the empty-state branch is unchanged.

### Files
- `packages/mobile/src/screens/notifications-screen/NotificationListItemSkeleton.tsx` — new skeleton row mirroring the `NotificationTile` layout (icon + profile picture row + 2 text lines + timestamp placeholder).
- `packages/mobile/src/screens/notifications-screen/NotificationList.tsx` — interleaves `LoadingItem` placeholders into the FlashList data; drops the footer spinner.

## Test plan
- [ ] Open the notifications screen with a slow network — skeleton rows render on initial load instead of a spinner.
- [ ] Scroll to fetch the next page — pagination skeletons appear at the bottom while loading.
- [ ] Empty state still renders `EmptyNotifications` when there are no notifications.
- [ ] Pull-to-refresh still works without showing initial-load skeletons.
- [ ] Error state does not get stuck showing skeletons forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)