### PR TITLE
fix: oauth popup profile picture renders as a perfect circle

### DIFF
--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
@@ -104,6 +104,7 @@
 
 .profileImg {
   height: 48px;
+  width: 48px;
 }
 
 .userInfoDisplayName {


### PR DESCRIPTION
## Summary
- The harmony `Image` migration in #14196 swapped `ProfileInfo`'s plain `<img>` for `<Image>`, which wraps the avatar in a `Box` that respects `h`/`w` props (78px).
- The OAuth login page's `.profileImg` only overrode `height: 48px`, leaving the wrapper at 78px wide and rendering a 78×48 pill shape instead of a circle.
- Fix: also constrain `width: 48px` so the wrapper is square and the existing `border-radius` produces a perfect circle.

## Test plan
- [ ] Open the OAuth consent popup (e.g. via a third-party Connect Audius flow) — the signed-in user's avatar should render as a perfect circle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)