### PR TITLE
Add Amplitude analytics to contest UI

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -578,6 +578,9 @@ export enum Name {
   REMIX_CONTEST_DELETE = 'Remix Contest: Delete',
   REMIX_CONTEST_PICK_WINNERS_OPEN = 'Remix Contest: Pick Winners Open',
   REMIX_CONTEST_PICK_WINNERS_FINALIZE = 'Remix Contest: Finalize Winners',
+  REMIX_CONTEST_VIEW = 'Remix Contest: View',
+  REMIX_CONTEST_ENTER = 'Remix Contest: Enter',
+  REMIX_CONTEST_VIEW_SUBMISSIONS = 'Remix Contest: View Submissions',
 
   // Android App Lifecycle
   ANDROID_APP_RESTART_HEARTBEAT = 'Android App: Restart Due to Heartbeat',
@@ -2868,6 +2871,24 @@ export type RemixContestPickWinnersFinalize = {
   trackId: ID
 }
 
+export type RemixContestView = {
+  eventName: Name.REMIX_CONTEST_VIEW
+  remixContestId: ID
+  trackId: ID
+}
+
+export type RemixContestEnter = {
+  eventName: Name.REMIX_CONTEST_ENTER
+  remixContestId: ID
+  trackId: ID
+}
+
+export type RemixContestViewSubmissions = {
+  eventName: Name.REMIX_CONTEST_VIEW_SUBMISSIONS
+  remixContestId: ID
+  trackId: ID
+}
+
 export type AndroidAppRestartHeartbeat = {
   eventName: Name.ANDROID_APP_RESTART_HEARTBEAT
   timeSinceLastHeartbeat: number
@@ -3504,6 +3525,9 @@ export type AllTrackingEvents =
   | RemixContestDelete
   | RemixContestPickWinnersOpen
   | RemixContestPickWinnersFinalize
+  | RemixContestView
+  | RemixContestEnter
+  | RemixContestViewSubmissions
   | AndroidAppRestartHeartbeat
   | AndroidAppRestartStale
   | AndroidAppRestartForceQuit

--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState
 } from 'react'
 
@@ -21,7 +22,7 @@ import {
   useUser
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
-import { ShareSource } from '@audius/common/models'
+import { Name, ShareSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import { shareModalUIActions } from '@audius/common/store'
 import { dayjs, getLocalTimezone } from '@audius/common/utils'
@@ -36,6 +37,7 @@ import { useDispatch } from 'react-redux'
 import { Button, Divider, Flex, Text } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
 import { ProfilePicture } from 'app/components/core/ProfilePicture'
+import { make, track as trackEvent } from 'app/services/analytics'
 import {
   CollapsibleTabNavigator,
   collapsibleTabScreen
@@ -295,7 +297,38 @@ export const ContestScreen = () => {
     dispatch(setVisibility({ drawer: 'PickWinners', visible: true }))
   }, [trackId, dispatch])
 
-  const handleEnterContest = useEnterContest(trackId)
+  const enterContest = useEnterContest(trackId)
+  const handleEnterContest = useCallback(async () => {
+    if (trackId != null && eventId != null) {
+      trackEvent(
+        make({
+          eventName: Name.REMIX_CONTEST_ENTER,
+          remixContestId: eventId,
+          trackId
+        })
+      )
+    }
+    await enterContest()
+  }, [enterContest, trackId, eventId])
+
+  // Fire a Remix Contest: View event the first time the screen resolves
+  // both a trackId and an eventId. The screen is mounted once per
+  // navigation push, so a ref guard makes the event idempotent across
+  // unrelated re-renders (followers count update, scroll-y reaction,
+  // etc.) while still firing on each fresh push.
+  const hasFiredViewRef = useRef(false)
+  useEffect(() => {
+    if (hasFiredViewRef.current) return
+    if (trackId == null || eventId == null) return
+    hasFiredViewRef.current = true
+    trackEvent(
+      make({
+        eventName: Name.REMIX_CONTEST_VIEW,
+        remixContestId: eventId,
+        trackId
+      })
+    )
+  }, [trackId, eventId])
 
   // Hide the stack navigator header — the in-hero back button is the
   // only back affordance in the Figma (2888-131647). Leaving the

--- a/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   getRemixesQueryKey,
@@ -6,10 +6,13 @@ import {
   useRemixesCount,
   useRemixesLineup
 } from '@audius/common/api'
+import { Name } from '@audius/common/models'
 import type { ID } from '@audius/common/models'
+import { useFocusedTab } from 'react-native-collapsible-tab-view'
 
 import { Divider, FilterButton, Flex, Text } from '@audius/harmony-native'
 import { TrackLineup } from 'app/components/lineup/TrackLineup'
+import { make, track as trackEvent } from 'app/services/analytics'
 
 import { useContestPage } from '../ContestPageContext'
 
@@ -56,9 +59,32 @@ const SORT_OPTIONS = [
  * gap by hydrating Redux from the tan-query cache immediately.
  */
 export const ContestSubmissionsTab = () => {
-  const { trackId } = useContestPage()
+  const { trackId, eventId } = useContestPage()
   const { data: contest } = useRemixContest(trackId)
   const winnerCount = contest?.eventData?.winners?.length ?? 0
+
+  // Fire a Remix Contest: View Submissions event the first time the
+  // user actually focuses this tab. Tabs are mounted eagerly
+  // (`lazy: false` in `CollapsibleTabNavigator`), so a plain mount
+  // effect would fire even for users who only ever look at the Details
+  // tab. `useFocusedTab` from react-native-collapsible-tab-view is the
+  // primitive the tab navigator already uses — it returns the
+  // currently-focused tab name and re-runs effects when that changes.
+  const focusedTab = useFocusedTab()
+  const hasFiredSubmissionsViewRef = useRef(false)
+  useEffect(() => {
+    if (hasFiredSubmissionsViewRef.current) return
+    if (focusedTab !== 'Submissions') return
+    if (trackId == null || eventId == null) return
+    hasFiredSubmissionsViewRef.current = true
+    trackEvent(
+      make({
+        eventName: Name.REMIX_CONTEST_VIEW_SUBMISSIONS,
+        remixContestId: eventId,
+        trackId
+      })
+    )
+  }, [focusedTab, trackId, eventId])
 
   const [sortMethod, setSortMethod] = useState<'recent' | 'plays' | 'likes'>(
     'recent'

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   getRemixesQueryKey,
@@ -16,7 +16,7 @@ import {
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
-import { SquareSizes, ShareSource } from '@audius/common/models'
+import { Name, SquareSizes, ShareSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
   remixesPageActions,
@@ -53,6 +53,7 @@ import { UserGeneratedText } from 'components/user-generated-text'
 import { VideoEmbed } from 'components/video-embed/VideoEmbed'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
+import { make, track as trackEvent } from 'services/analytics'
 import { useRemixPageParams } from 'pages/remixes-page/hooks'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
 import {
@@ -318,6 +319,24 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     }
   }, [dispatch])
 
+  // Fire a Remix Contest: View event the first time the page resolves a
+  // trackId + eventId for the contest. Guard with a ref so navigating
+  // between contest tabs (which doesn't unmount the page) doesn't
+  // re-fire the event.
+  const hasFiredViewRef = useRef(false)
+  useEffect(() => {
+    if (hasFiredViewRef.current) return
+    if (trackId == null || eventId == null) return
+    hasFiredViewRef.current = true
+    trackEvent(
+      make({
+        eventName: Name.REMIX_CONTEST_VIEW,
+        remixContestId: eventId,
+        trackId
+      })
+    )
+  }, [trackId, eventId])
+
   const isEnded = useMemo(() => {
     if (!contest?.endDate) return true
     return dayjs(contest.endDate).isBefore(dayjs())
@@ -368,7 +387,19 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
   // shape; reused across the desktop + mobile contest pages and the
   // mobile track-page contest details tab so submitters get the same
   // pre-filled form regardless of entry point.
-  const handleEnterContest = useEnterContest(trackId)
+  const enterContest = useEnterContest(trackId)
+  const handleEnterContest = useCallback(async () => {
+    if (trackId != null && eventId != null) {
+      trackEvent(
+        make({
+          eventName: Name.REMIX_CONTEST_ENTER,
+          remixContestId: eventId,
+          trackId
+        })
+      )
+    }
+    await enterContest()
+  }, [enterContest, trackId, eventId])
 
   const handleShareContest = useCallback(() => {
     if (!trackId) return
@@ -711,7 +742,18 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
                 size='large'
                 isSelected={activeTab === 'submissions'}
                 label={messages.submissionsTab(submissionsCount)}
-                onClick={() => setActiveTab('submissions')}
+                onClick={() => {
+                  if (activeTab !== 'submissions' && trackId && eventId) {
+                    trackEvent(
+                      make({
+                        eventName: Name.REMIX_CONTEST_VIEW_SUBMISSIONS,
+                        remixContestId: eventId,
+                        trackId
+                      })
+                    )
+                  }
+                  setActiveTab('submissions')
+                }}
               />
             </Flex>
           ) : null}


### PR DESCRIPTION
## Summary

Adds Amplitude tracking for three key contest interactions, following the existing `Remix Contest:` event prefix and `{ remixContestId, trackId }` property shape used by the host / pick-winners events.

| Event | Fires when |
| --- | --- |
| `REMIX_CONTEST_VIEW` (`Remix Contest: View`) | Contest page/screen first resolves both `trackId` and `eventId`. Ref-guarded so re-renders (followers count, scroll-y reactions) don't re-fire. |
| `REMIX_CONTEST_ENTER` (`Remix Contest: Enter`) | User taps the Enter Contest / Upload Remix button. Wraps the existing `useEnterContest` callback so the upload flow itself is unchanged. |
| `REMIX_CONTEST_VIEW_SUBMISSIONS` (`Remix Contest: View Submissions`) | User opens the submissions tab. |

### Files

- `packages/common/src/models/Analytics.ts` — three new `Name` enum entries, three matching event-property types, and three union additions.
- `packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx` — view effect, wrapped enter handler, submissions-pill `onClick` event.
- `packages/mobile/src/screens/contest-screen/ContestScreen.tsx` — view effect + wrapped enter handler.
- `packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx` — submissions-tab focus event.

### Notes

- Mobile submissions firing uses `useFocusedTab` from `react-native-collapsible-tab-view`. The contest tab navigator runs with `lazy: false`, so a plain mount effect would fire even for users who only ever look at the Details tab.
- The `ENTER` event fires on click intent — i.e. before `useRequiresAccountCallback` redirects unauthenticated users to sign-in. This matches typical click-tracking semantics; switch to firing inside the gate if we want completion-only.

## Test plan

- [ ] `npm run typecheck` passes (verified locally on `@audius/common`, `@audius/web`, `@audius/mobile`)
- [ ] Web: open a contest page → check Amplitude debug logs for one `Remix Contest: View`. Click Enter Contest → one `Remix Contest: Enter`. Click Submissions tab → one `Remix Contest: View Submissions` (and only one when toggling back and forth).
- [ ] Mobile: navigate to a contest screen → one `Remix Contest: View`. Tap Enter Contest → one `Remix Contest: Enter`. Swipe/tap to Submissions → one `Remix Contest: View Submissions`; swipe back and forth shouldn't re-fire.
- [ ] Confirm `remixContestId` + `trackId` payloads land in Amplitude alongside the existing remix-contest events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)