### PR TITLE
fix: render downloaded albums in offline library tab

### DIFF
--- a/packages/mobile/src/screens/library-screen/useLibraryCollections.ts
+++ b/packages/mobile/src/screens/library-screen/useLibraryCollections.ts
@@ -16,6 +16,7 @@ import { difference } from 'lodash'
 import { useSelector } from 'react-redux'
 
 import type { AppState } from 'app/store'
+import { DOWNLOAD_REASON_FAVORITES } from 'app/store/offline-downloads/constants'
 import {
   getIsDoneLoadingFromDisk,
   getOfflineCollectionsStatus
@@ -100,21 +101,39 @@ export const useLibraryCollections = ({
 
   const offlineCollectionIds = useSelector((state: AppState) => {
     const offlineCollectionsStatus = getOfflineCollectionsStatus(state)
-    return Object.keys(offlineCollectionsStatus).filter(
-      (k) => offlineCollectionsStatus[k] === OfflineDownloadStatus.SUCCESS
-    )
+    const ids: number[] = []
+    for (const key of Object.keys(offlineCollectionsStatus)) {
+      if (key === DOWNLOAD_REASON_FAVORITES) continue
+      if (offlineCollectionsStatus[key] !== OfflineDownloadStatus.SUCCESS)
+        continue
+      const numericId = Number(key)
+      if (Number.isFinite(numericId) && numericId > 0) ids.push(numericId)
+    }
+    return ids
   })
+
+  const { data: offlineCollections = [] } = useCollections(offlineCollectionIds)
+
+  const filteredOfflineCollectionIds = useMemo(() => {
+    const wantAlbums = collectionType === 'albums'
+    return filterCollections(
+      offlineCollections.filter(
+        (collection) => Boolean(collection.is_album) === wantAlbums
+      ),
+      { filterText: filterValue }
+    ).map((collection) => collection.playlist_id)
+  }, [offlineCollections, collectionType, filterValue])
 
   const collectionIds = useMemo(
     () =>
       isReachable
         ? [...filteredLocalCollectionIds, ...filteredFetchedCollectionIds]
-        : offlineCollectionIds,
+        : filteredOfflineCollectionIds,
     [
       isReachable,
       filteredLocalCollectionIds,
       filteredFetchedCollectionIds,
-      offlineCollectionIds
+      filteredOfflineCollectionIds
     ]
   )
 
@@ -141,12 +160,12 @@ export const useLibraryCollections = ({
 
   return {
     collectionIds,
-    hasNextPage,
+    hasNextPage: isReachable ? hasNextPage : false,
     loadNextPage,
     status,
-    isPending,
-    isLoading,
-    isFetchingNextPage,
+    isPending: isReachable ? isPending : !isDoneLoadingFromDisk,
+    isLoading: isReachable ? isLoading : !isDoneLoadingFromDisk,
+    isFetchingNextPage: isReachable ? isFetchingNextPage : false,
     localCollectionCount: localCollectionIds.length
   }
 }


### PR DESCRIPTION
## Summary
- Library → Albums tab in offline mode showed skeletons forever instead of the user's downloaded albums. The banner correctly read "Displaying Available Offline Content" but no cards ever resolved.
- `useLibraryCollections`'s offline branch returned `Object.keys(collectionStatus)` directly. Three problems compounded:
  1. The keys are **strings**, but `useCollection` (used inside each `CollectionCard`) keys its TanStack cache by **number** — every per-card lookup missed cache, fell to `if (!partialCollection) return <CollectionCardSkeleton />` ([CollectionCard.tsx:86](packages/mobile/src/components/collection-list/CollectionCard.tsx)), and rendered a skeleton forever.
  2. The literal `'favorites'` sentinel (`DOWNLOAD_REASON_FAVORITES`) lives in the same map and was being passed downstream as a "collection id."
  3. No filtering by `collectionType`, so the Albums tab also pulled in playlist IDs and vice versa.
- Additionally, the hook returned `isPending`/`isLoading` from the network query, which stays `true` indefinitely under TanStack's default `networkMode: 'online'` when offline. With an empty `collectionIds`, that drove the outer `CardList` skeleton too.

## Fix
- Build numeric `offlineCollectionIds` (drop the `'favorites'` sentinel, ignore non-numeric keys).
- Resolve the cached collections via the existing `useCollections` hook, then filter by `is_album` per `collectionType` and apply the existing text filter.
- Override `isPending`/`isLoading`/`hasNextPage`/`isFetchingNextPage` to offline-appropriate values (driven by `isDoneLoadingFromDisk`) when not reachable, so the outer skeleton no longer gates on the paused network query.

Single file changed: `packages/mobile/src/screens/library-screen/useLibraryCollections.ts`. Both the Albums and Playlists tabs share this hook, so both are fixed.

## Test plan
- [ ] Online: Library → Albums and Playlists tabs render the same set as before (network path unchanged).
- [ ] Online → download an album → toggle airplane mode → open Library → Albums tab. Banner shows; the downloaded album renders (no skeleton).
- [ ] Same flow, Playlists tab: only downloaded playlists render (no album leakage, no `'favorites'` ghost card).
- [ ] Offline with no downloads: empty state renders (skeleton no longer stuck because `isPending` resolves once disk rehydration completes).
- [ ] Filter input still narrows offline results by name.
- [ ] `npx tsc` and `npx eslint` clean for `useLibraryCollections.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)