### PR TITLE
[Cleanup] Remove live email frequency; fix broken email images

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -578,6 +578,9 @@ export enum Name {
   REMIX_CONTEST_DELETE = 'Remix Contest: Delete',
   REMIX_CONTEST_PICK_WINNERS_OPEN = 'Remix Contest: Pick Winners Open',
   REMIX_CONTEST_PICK_WINNERS_FINALIZE = 'Remix Contest: Finalize Winners',
+  REMIX_CONTEST_VIEW = 'Remix Contest: View',
+  REMIX_CONTEST_ENTER = 'Remix Contest: Enter',
+  REMIX_CONTEST_VIEW_SUBMISSIONS = 'Remix Contest: View Submissions',
 
   // Android App Lifecycle
   ANDROID_APP_RESTART_HEARTBEAT = 'Android App: Restart Due to Heartbeat',
@@ -2868,6 +2871,24 @@ export type RemixContestPickWinnersFinalize = {
   trackId: ID
 }
 
+export type RemixContestView = {
+  eventName: Name.REMIX_CONTEST_VIEW
+  remixContestId: ID
+  trackId: ID
+}
+
+export type RemixContestEnter = {
+  eventName: Name.REMIX_CONTEST_ENTER
+  remixContestId: ID
+  trackId: ID
+}
+
+export type RemixContestViewSubmissions = {
+  eventName: Name.REMIX_CONTEST_VIEW_SUBMISSIONS
+  remixContestId: ID
+  trackId: ID
+}
+
 export type AndroidAppRestartHeartbeat = {
   eventName: Name.ANDROID_APP_RESTART_HEARTBEAT
   timeSinceLastHeartbeat: number
@@ -3504,6 +3525,9 @@ export type AllTrackingEvents =
   | RemixContestDelete
   | RemixContestPickWinnersOpen
   | RemixContestPickWinnersFinalize
+  | RemixContestView
+  | RemixContestEnter
+  | RemixContestViewSubmissions
   | AndroidAppRestartHeartbeat
   | AndroidAppRestartStale
   | AndroidAppRestartForceQuit

--- a/packages/common/src/store/pages/settings/types.ts
+++ b/packages/common/src/store/pages/settings/types.ts
@@ -28,7 +28,6 @@ export enum PushNotificationSetting {
 }
 
 export enum EmailFrequency {
-  Live = 'live',
   Daily = 'daily',
   Weekly = 'weekly',
   Off = 'off'

--- a/packages/identity-service/sequelize/migrations/20260511000000-remove-live-emails.js
+++ b/packages/identity-service/sequelize/migrations/20260511000000-remove-live-emails.js
@@ -1,0 +1,48 @@
+'use strict'
+const models = require('../../src/models')
+
+// Inverse of 20200723161647-add-live-emails.js.
+// Postgres can't remove enum values without root db access, so the 'live'
+// label remains in the type — but no rows reference it and defaults are
+// flipped back to 'daily'.
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return models.UserNotificationSettings.update(
+      { emailFrequency: 'daily' },
+      { where: { emailFrequency: 'live' } }
+    )
+      .then(() => {
+        return queryInterface.sequelize.query(
+          'ALTER TABLE "NotificationEmails" ALTER "emailFrequency" set default \'daily\'::"enum_NotificationEmails_emailFrequency"'
+        )
+      })
+      .then(() => {
+        return queryInterface.sequelize.query(
+          'UPDATE "NotificationEmails" SET "emailFrequency" = \'daily\' WHERE "emailFrequency" = \'live\''
+        )
+      })
+      .then(() => {
+        return queryInterface.sequelize.query(
+          'ALTER TABLE "UserNotificationSettings" ALTER "emailFrequency" set default \'daily\'::"enum_UserNotificationSettings_emailFrequency"'
+        )
+      })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize
+      .query(
+        'ALTER TABLE "NotificationEmails" ALTER "emailFrequency" set default \'live\'::"enum_NotificationEmails_emailFrequency"'
+      )
+      .then(() => {
+        return queryInterface.sequelize.query(
+          'ALTER TABLE "UserNotificationSettings" ALTER "emailFrequency" set default \'live\'::"enum_UserNotificationSettings_emailFrequency"'
+        )
+      })
+      .then(() => {
+        return models.UserNotificationSettings.update(
+          { emailFrequency: 'live' },
+          { where: { emailFrequency: 'daily' } }
+        )
+      })
+  }
+}

--- a/packages/identity-service/src/models/userNotificationSettings.js
+++ b/packages/identity-service/src/models/userNotificationSettings.js
@@ -40,8 +40,8 @@ module.exports = (sequelize, DataTypes) => {
       },
       emailFrequency: {
         allowNull: false,
-        type: DataTypes.ENUM('live', 'daily', 'weekly', 'off'),
-        defaultValue: 'live'
+        type: DataTypes.ENUM('daily', 'weekly', 'off'),
+        defaultValue: 'daily'
       }
     },
     {}

--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState
 } from 'react'
 
@@ -21,7 +22,7 @@ import {
   useUser
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
-import { ShareSource } from '@audius/common/models'
+import { Name, ShareSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import { shareModalUIActions } from '@audius/common/store'
 import { dayjs, getLocalTimezone } from '@audius/common/utils'
@@ -36,6 +37,7 @@ import { useDispatch } from 'react-redux'
 import { Button, Divider, Flex, Text } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
 import { ProfilePicture } from 'app/components/core/ProfilePicture'
+import { make, track as trackEvent } from 'app/services/analytics'
 import {
   CollapsibleTabNavigator,
   collapsibleTabScreen
@@ -295,7 +297,38 @@ export const ContestScreen = () => {
     dispatch(setVisibility({ drawer: 'PickWinners', visible: true }))
   }, [trackId, dispatch])
 
-  const handleEnterContest = useEnterContest(trackId)
+  const enterContest = useEnterContest(trackId)
+  const handleEnterContest = useCallback(async () => {
+    if (trackId != null && eventId != null) {
+      trackEvent(
+        make({
+          eventName: Name.REMIX_CONTEST_ENTER,
+          remixContestId: eventId,
+          trackId
+        })
+      )
+    }
+    await enterContest()
+  }, [enterContest, trackId, eventId])
+
+  // Fire a Remix Contest: View event the first time the screen resolves
+  // both a trackId and an eventId. The screen is mounted once per
+  // navigation push, so a ref guard makes the event idempotent across
+  // unrelated re-renders (followers count update, scroll-y reaction,
+  // etc.) while still firing on each fresh push.
+  const hasFiredViewRef = useRef(false)
+  useEffect(() => {
+    if (hasFiredViewRef.current) return
+    if (trackId == null || eventId == null) return
+    hasFiredViewRef.current = true
+    trackEvent(
+      make({
+        eventName: Name.REMIX_CONTEST_VIEW,
+        remixContestId: eventId,
+        trackId
+      })
+    )
+  }, [trackId, eventId])
 
   // Hide the stack navigator header — the in-hero back button is the
   // only back affordance in the Figma (2888-131647). Leaving the

--- a/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/contest-screen/tabs/ContestSubmissionsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   getRemixesQueryKey,
@@ -6,10 +6,13 @@ import {
   useRemixesCount,
   useRemixesLineup
 } from '@audius/common/api'
+import { Name } from '@audius/common/models'
 import type { ID } from '@audius/common/models'
+import { useFocusedTab } from 'react-native-collapsible-tab-view'
 
 import { Divider, FilterButton, Flex, Text } from '@audius/harmony-native'
 import { TrackLineup } from 'app/components/lineup/TrackLineup'
+import { make, track as trackEvent } from 'app/services/analytics'
 
 import { useContestPage } from '../ContestPageContext'
 
@@ -56,9 +59,32 @@ const SORT_OPTIONS = [
  * gap by hydrating Redux from the tan-query cache immediately.
  */
 export const ContestSubmissionsTab = () => {
-  const { trackId } = useContestPage()
+  const { trackId, eventId } = useContestPage()
   const { data: contest } = useRemixContest(trackId)
   const winnerCount = contest?.eventData?.winners?.length ?? 0
+
+  // Fire a Remix Contest: View Submissions event the first time the
+  // user actually focuses this tab. Tabs are mounted eagerly
+  // (`lazy: false` in `CollapsibleTabNavigator`), so a plain mount
+  // effect would fire even for users who only ever look at the Details
+  // tab. `useFocusedTab` from react-native-collapsible-tab-view is the
+  // primitive the tab navigator already uses — it returns the
+  // currently-focused tab name and re-runs effects when that changes.
+  const focusedTab = useFocusedTab()
+  const hasFiredSubmissionsViewRef = useRef(false)
+  useEffect(() => {
+    if (hasFiredSubmissionsViewRef.current) return
+    if (focusedTab !== 'Submissions') return
+    if (trackId == null || eventId == null) return
+    hasFiredSubmissionsViewRef.current = true
+    trackEvent(
+      make({
+        eventName: Name.REMIX_CONTEST_VIEW_SUBMISSIONS,
+        remixContestId: eventId,
+        trackId
+      })
+    )
+  }, [focusedTab, trackId, eventId])
 
   const [sortMethod, setSortMethod] = useState<'recent' | 'plays' | 'likes'>(
     'recent'

--- a/packages/mobile/src/screens/settings-screen/EmailFrequencyControlRow.tsx
+++ b/packages/mobile/src/screens/settings-screen/EmailFrequencyControlRow.tsx
@@ -17,14 +17,12 @@ const { updateEmailFrequency } = settingsPageActions
 
 const messages = {
   emailFrequency: "'What You Missed' Email Frequency",
-  live: 'Live',
   daily: 'Daily',
   weekly: 'Weekly',
   off: 'Off'
 }
 
 const emailFrequencyOptions = [
-  { key: EmailFrequency.Live, text: messages.live },
   { key: EmailFrequency.Daily, text: messages.daily },
   { key: EmailFrequency.Weekly, text: messages.weekly },
   { key: EmailFrequency.Off, text: messages.off }

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   getRemixesQueryKey,
@@ -16,7 +16,7 @@ import {
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
-import { SquareSizes, ShareSource } from '@audius/common/models'
+import { Name, SquareSizes, ShareSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
   remixesPageActions,
@@ -53,6 +53,7 @@ import { UserGeneratedText } from 'components/user-generated-text'
 import { VideoEmbed } from 'components/video-embed/VideoEmbed'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
+import { make, track as trackEvent } from 'services/analytics'
 import { useRemixPageParams } from 'pages/remixes-page/hooks'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
 import {
@@ -318,6 +319,24 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     }
   }, [dispatch])
 
+  // Fire a Remix Contest: View event the first time the page resolves a
+  // trackId + eventId for the contest. Guard with a ref so navigating
+  // between contest tabs (which doesn't unmount the page) doesn't
+  // re-fire the event.
+  const hasFiredViewRef = useRef(false)
+  useEffect(() => {
+    if (hasFiredViewRef.current) return
+    if (trackId == null || eventId == null) return
+    hasFiredViewRef.current = true
+    trackEvent(
+      make({
+        eventName: Name.REMIX_CONTEST_VIEW,
+        remixContestId: eventId,
+        trackId
+      })
+    )
+  }, [trackId, eventId])
+
   const isEnded = useMemo(() => {
     if (!contest?.endDate) return true
     return dayjs(contest.endDate).isBefore(dayjs())
@@ -368,7 +387,19 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
   // shape; reused across the desktop + mobile contest pages and the
   // mobile track-page contest details tab so submitters get the same
   // pre-filled form regardless of entry point.
-  const handleEnterContest = useEnterContest(trackId)
+  const enterContest = useEnterContest(trackId)
+  const handleEnterContest = useCallback(async () => {
+    if (trackId != null && eventId != null) {
+      trackEvent(
+        make({
+          eventName: Name.REMIX_CONTEST_ENTER,
+          remixContestId: eventId,
+          trackId
+        })
+      )
+    }
+    await enterContest()
+  }, [enterContest, trackId, eventId])
 
   const handleShareContest = useCallback(() => {
     if (!trackId) return
@@ -711,7 +742,18 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
                 size='large'
                 isSelected={activeTab === 'submissions'}
                 label={messages.submissionsTab(submissionsCount)}
-                onClick={() => setActiveTab('submissions')}
+                onClick={() => {
+                  if (activeTab !== 'submissions' && trackId && eventId) {
+                    trackEvent(
+                      make({
+                        eventName: Name.REMIX_CONTEST_VIEW_SUBMISSIONS,
+                        remixContestId: eventId,
+                        trackId
+                      })
+                    )
+                  }
+                  setActiveTab('submissions')
+                }}
               />
             </Flex>
           ) : null}

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -53,9 +53,9 @@ import { UserGeneratedText } from 'components/user-generated-text'
 import { VideoEmbed } from 'components/video-embed/VideoEmbed'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
-import { make, track as trackEvent } from 'services/analytics'
 import { useRemixPageParams } from 'pages/remixes-page/hooks'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
+import { make, track as trackEvent } from 'services/analytics'
 import {
   fullContestPage,
   hostRemixContestPage,

--- a/packages/web/src/pages/settings-page/components/desktop/NotificationSettingsModal.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/NotificationSettingsModal.tsx
@@ -144,7 +144,6 @@ const NotificationSettingsModal = (props: NotificationSettingsModalProps) => {
   ]
 
   const emailOptions = [
-    { key: EmailFrequency.Live, text: 'Live' },
     { key: EmailFrequency.Daily, text: 'Daily' },
     { key: EmailFrequency.Weekly, text: 'Weekly' },
     { key: EmailFrequency.Off, text: 'Off' }

--- a/packages/web/src/pages/settings-page/components/mobile/NotificationsSettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/mobile/NotificationsSettingsPage.tsx
@@ -31,7 +31,6 @@ const messages = {
 }
 
 const emailOptions = [
-  { key: EmailFrequency.Live, text: 'Live' },
   { key: EmailFrequency.Daily, text: 'Daily' },
   { key: EmailFrequency.Weekly, text: 'Weekly' },
   { key: EmailFrequency.Off, text: 'Off' }


### PR DESCRIPTION
## Summary

**Note:** This PR is one of two. The companion changes live in the [`pedalboard`](https://github.com/AudiusProject/pedalboard) repo (broadcastEmailAnnouncements rewrite, per-event live-email cleanup across all mappers, the broken-logo + missing-cover-art image fixes). They must merge together.

### PART 1 — Remove the \"live\" email frequency option

- Drop \`EmailFrequency.Live\` from \`packages/common\`
- Remove the \"Live\" segmented-control option from the desktop notif modal, mobile settings page, and React Native EmailFrequencyControlRow
- Identity-service \`UserNotificationSettings\` model: remove \`'live'\` from the enum, change \`defaultValue\` from \`'live'\` to \`'daily'\`
- Add Sequelize migration \`20260511000000-remove-live-emails.js\` (inverse of \`20200723161647-add-live-emails.js\`): \`UPDATE\` existing \`live\` rows to \`daily\` on both \`UserNotificationSettings\` and \`NotificationEmails\`, flip PG column defaults back to \`'daily'\`. The PG enum value \`'live'\` is left orphaned (Postgres can't drop enum labels without root access; matches what the original migration did).

### PART 2

In the pedalboard PR.

## Test plan
- [ ] Apply migration on staging and verify \`UserNotificationSettings\`/\`NotificationEmails\` defaults are \`'daily'\` and no row has \`'live'\` frequency
- [ ] Web/Mobile/RN settings pages show only Daily / Weekly / Off; a user previously on \`live\` sees \`Daily\` selected after migration
- [ ] Verify pedalboard companion PR is queued to merge alongside this one (otherwise announcement emails will fail to target the now-empty \`live\` audience)

🤖 Generated with [Claude Code](https://claude.com/claude-code)