### PR TITLE
fix(mobile): stop comments swipe-to-dismiss from closing now-playing drawer

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -23,6 +23,7 @@ import TrackPlayer from 'react-native-track-player'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { BOTTOM_BAR_HEIGHT } from 'app/components/bottom-tab-bar'
+import { useCommentDrawer } from 'app/components/comments/CommentDrawerContext'
 import Drawer, {
   DrawerAnimationStyle,
   FULL_DRAWER_HEIGHT
@@ -109,6 +110,9 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   const styles = useStyles()
 
   const { isOpen, onOpen, onClose } = useDrawer('NowPlaying')
+  // Defer to the comments bottom-sheet while it's presented: its swipe-to-dismiss
+  // gesture would otherwise leak through and also close this drawer underneath.
+  const { isOpen: isCommentDrawerOpen } = useCommentDrawer()
   const playCounter = useSelector(getCounter)
   const currentTrackId = useSelector(getTrackId)
   const isPlaying = useSelector(getPlaying)
@@ -294,6 +298,7 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
       onPanResponderMove={onPanResponderMove}
       onPanResponderRelease={onPanResponderRelease}
       isGestureSupported={isGestureEnabled}
+      gesturesDisabled={isCommentDrawerOpen}
       translationAnim={translationAnim}
       // Disable safe area view edges because they are handled manually
       disableSafeAreaView


### PR DESCRIPTION
## Summary

- When the now-playing drawer is open and a user opens the comments bottom-sheet on top, swiping down to dismiss the comments was also dismissing the now-playing drawer underneath.
- Root cause: the two drawers use different gesture systems. Comments uses `@gorhom/bottom-sheet` (via `react-native-gesture-handler`); the now-playing drawer uses the legacy `PanResponder`. RNGH won't reject a native pan responder, so the swipe propagates through.
- Fix: subscribe `NowPlayingDrawer` to `CommentDrawerContext.isOpen` and pass it through as `gesturesDisabled` on the underlying `Drawer`. The pan responder already mirrors that flag into a ref (see `Drawer.tsx`), so `onMoveShouldSetPanResponder` returns false while comments are presented and re-enables itself as soon as comments dismiss.

## Test plan

- [ ] Play a track to open the playbar
- [ ] Expand the now-playing drawer (swipe up or tap the playbar)
- [ ] Tap Comments to present the comments bottom-sheet on top
- [ ] Swipe down on the comments sheet to dismiss it
- [ ] **Expected:** comments dismiss, now-playing drawer stays open
- [ ] After comments close, confirm swipe-down on the now-playing drawer still dismisses it back to the playbar
- [ ] Repeat on iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)