### PR TITLE
fix(contest): mobile comments disappear after pressing send

### DIFF
--- a/packages/common/src/api/tan-query/comments/usePostEventComment.ts
+++ b/packages/common/src/api/tan-query/comments/usePostEventComment.ts
@@ -144,12 +144,14 @@ export const usePostEventComment = () => {
 
       return { newId }
     },
-    onSuccess: (_data, args) => {
-      // Invalidate every sort variant — the user might be on Top or Newest.
-      queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.eventComments, args.eventId]
-      })
-    },
+    // No onSuccess invalidate: the optimistic comment was just primed with
+    // the same id the SDK reserved, so the next natural refetch (focus /
+    // remount / staleTime expiry) will replace it seamlessly once the
+    // indexer has caught up. Invalidating immediately races the indexer —
+    // the refetch returns the pre-comment list before the new row lands,
+    // wiping the optimistic comment from the cache and giving the user the
+    // "I pressed send and it disappeared" experience. Mirrors how the
+    // track-comment hook (usePostComment) handles success.
     onError: (error: Error, args) => {
       reportToSentry({
         error,


### PR DESCRIPTION
## Summary

- Drop the `onSuccess` invalidate from `usePostEventComment` so the optimistic comment isn't wiped by an indexer race
- Optimistic row was being primed with the SDK-reserved id, then immediately erased when the post-success refetch returned the pre-comment list (indexer hadn't processed yet)
- Matches how the track-comment hook (`usePostComment`) handles success — natural refetch on focus/remount/staleTime picks up the indexed comment seamlessly

## Why this fixed the bug

User on mobile: types a comment on a contest, taps send, input clears, comment flashes in, then vanishes — never showing up in the list. The post itself succeeds on chain; the UI just races itself.

Sequence before the fix:
1. `onMutate` primes the optimistic comment in the cache (id = SDK-reserved newId)
2. `mutationFn` posts to entity manager — returns ~immediately
3. `onSuccess` invalidates the `eventComments` query
4. Refetch fires — discovery indexer hasn't yet indexed the new comment (typically 5-10s)
5. Refetch returns the pre-comment list, replacing the cache
6. Optimistic comment is gone from the visible list

Sequence after the fix:
1-2. Same
3. `onSuccess` is a no-op
4. Optimistic comment stays visible until the next natural refetch
5. On focus/remount/etc., the refetch returns the indexed comment with the same id — seamless replace

The `onError` invalidate is preserved: if the post truly fails, the optimistic row needs to be cleared.

## Test plan

- [ ] Mobile: open a contest, post a top-level comment as a non-host viewer — comment stays visible after send
- [ ] Mobile: post a reply to a comment — reply stays nested under parent after send
- [ ] Mobile: navigate away and back — comment is still there once the indexer catches up
- [ ] Mobile: simulate a failed post (e.g. airplane mode) — toast appears and optimistic comment disappears
- [ ] Web: regression check — contest comments page behaves the same (web wasn't broken because users rarely catch the flash, but the same hook backs it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)