### PR TITLE
discovery: filter shadow-banned hosts from event listings

### DIFF
--- a/packages/discovery-provider/src/queries/get_events.py
+++ b/packages/discovery-provider/src/queries/get_events.py
@@ -1,9 +1,11 @@
 import logging
 from typing import List, Optional, TypedDict
 
-from sqlalchemy import desc, or_
+from sqlalchemy import desc, func, or_
 
+from src.models.comments.comment_report import COMMENT_KARMA_THRESHOLD
 from src.models.events.event import Event, EventEntityType, EventType
+from src.models.moderation.muted_user import MutedUser
 from src.models.users.aggregate_user import AggregateUser
 from src.queries.query_helpers import add_query_pagination, get_pagination_vars
 from src.utils import helpers
@@ -91,15 +93,33 @@ def _get_events(session, args):
     if args.get("filter_deleted", True):
         base_query = base_query.filter(Event.is_deleted == False)
 
-    # Hide events whose host has been shadow-banned. Mirrors the
-    # `score < 0` check used in the SQL feed handlers (handle_save,
-    # handle_follow, handle_repost). Uses an OUTER JOIN so users
-    # without an aggregate_user row (e.g. brand-new accounts that
-    # haven't been rolled up yet) aren't excluded — only users with a
-    # confirmed negative score get filtered out.
+    # Hide events whose host is shadow-banned. The discovery-provider
+    # has two parallel shadow-ban signals; we apply both so the filter
+    # catches the full population:
+    #
+    # 1. `aggregate_user.score < 0` — composite account-quality signal
+    #    (impersonators, low engagement, chat-blocks). Same check used
+    #    by the SQL feed handlers handle_save, handle_follow,
+    #    handle_repost. OUTER JOIN with a NULL-pass so brand-new users
+    #    without an aggregate_user row aren't excluded.
+    # 2. `muted_by_karma` — host has been comment-muted by users whose
+    #    combined follower counts cross COMMENT_KARMA_THRESHOLD. Same
+    #    subquery shape used in `get_track_comment_count.py` for
+    #    per-user comment hiding.
+    muted_by_karma = (
+        session.query(MutedUser.muted_user_id)
+        .join(AggregateUser, MutedUser.user_id == AggregateUser.user_id)
+        .filter(MutedUser.is_delete == False)
+        .group_by(MutedUser.muted_user_id)
+        .having(func.sum(AggregateUser.follower_count) >= COMMENT_KARMA_THRESHOLD)
+        .subquery()
+    )
     base_query = base_query.outerjoin(
         AggregateUser, AggregateUser.user_id == Event.user_id
-    ).filter(or_(AggregateUser.score >= 0, AggregateUser.score.is_(None)))
+    ).filter(
+        or_(AggregateUser.score >= 0, AggregateUser.score.is_(None)),
+        ~Event.user_id.in_(muted_by_karma),
+    )
 
     # Order by created_at desc by default
     base_query = base_query.order_by(desc(Event.created_at))

--- a/packages/discovery-provider/src/queries/get_events.py
+++ b/packages/discovery-provider/src/queries/get_events.py
@@ -1,9 +1,10 @@
 import logging
 from typing import List, Optional, TypedDict
 
-from sqlalchemy import desc
+from sqlalchemy import desc, or_
 
 from src.models.events.event import Event, EventEntityType, EventType
+from src.models.users.aggregate_user import AggregateUser
 from src.queries.query_helpers import add_query_pagination, get_pagination_vars
 from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
@@ -89,6 +90,16 @@ def _get_events(session, args):
     # Allow filtering of deletes
     if args.get("filter_deleted", True):
         base_query = base_query.filter(Event.is_deleted == False)
+
+    # Hide events whose host has been shadow-banned. Mirrors the
+    # `score < 0` check used in the SQL feed handlers (handle_save,
+    # handle_follow, handle_repost). Uses an OUTER JOIN so users
+    # without an aggregate_user row (e.g. brand-new accounts that
+    # haven't been rolled up yet) aren't excluded — only users with a
+    # confirmed negative score get filtered out.
+    base_query = base_query.outerjoin(
+        AggregateUser, AggregateUser.user_id == Event.user_id
+    ).filter(or_(AggregateUser.score >= 0, AggregateUser.score.is_(None)))
 
     # Order by created_at desc by default
     base_query = base_query.order_by(desc(Event.created_at))


### PR DESCRIPTION
## Summary

`get_events` ([packages/discovery-provider/src/queries/get_events.py](packages/discovery-provider/src/queries/get_events.py)) backs the contests discovery list (and any other event-list consumer). It previously surfaced contests whose host had been shadow-banned, because the existing filter chain only excluded `Event.is_deleted == True`.

This PR adds a host-shadow-ban filter that combines the **two parallel shadow-ban signals** the discovery-provider already uses elsewhere — applying both so the filter catches the full shadow-banned population.

## The two signals (and why both)

| Signal | Source | Catches | Used by today |
|---|---|---|---|
| `aggregate_user.score < 0` | composite account-quality score from [compute_user_score.sql](packages/discovery-provider/ddl/functions/compute_user_score.sql) | Audius-impersonators, low-engagement / bot-like accounts, chat-blocked users | [handle_save.sql:129](packages/discovery-provider/ddl/functions/handle_save.sql#L129), [handle_follow.sql:29](packages/discovery-provider/ddl/functions/handle_follow.sql#L29), [handle_repost.sql:94](packages/discovery-provider/ddl/functions/handle_repost.sql#L94) — feed-action notification suppression |
| `muted_by_karma` subquery (sum of muters' follower_count ≥ `COMMENT_KARMA_THRESHOLD`) | community-driven karma muting via the `muted_users` table | Users high-follower accounts have specifically reported / muted | [get_track_comment_count.py:31-38](packages/discovery-provider/src/queries/get_track_comment_count.py#L31) — per-user comment hiding |

The two catch different (but overlapping) populations. Score-based catches bots and impersonators who may never have been actively reported; karma-mute catches users that influential accounts have explicitly flagged. Applying both means contest discovery hides anyone who falls into either bucket.

## Implementation

Inside `_get_events`, after the existing `filter_deleted` step:

```python
muted_by_karma = (
    session.query(MutedUser.muted_user_id)
    .join(AggregateUser, MutedUser.user_id == AggregateUser.user_id)
    .filter(MutedUser.is_delete == False)
    .group_by(MutedUser.muted_user_id)
    .having(func.sum(AggregateUser.follower_count) >= COMMENT_KARMA_THRESHOLD)
    .subquery()
)
base_query = base_query.outerjoin(
    AggregateUser, AggregateUser.user_id == Event.user_id
).filter(
    or_(AggregateUser.score >= 0, AggregateUser.score.is_(None)),
    ~Event.user_id.in_(muted_by_karma),
)
```

- **OUTER JOIN** on `aggregate_user` so users without an aggregate row yet (brand-new accounts) aren't accidentally filtered — the `or_(... is_(None))` lets them through; only **confirmed** negative scores are excluded.
- `muted_by_karma` is lifted from `get_track_comment_count.py` verbatim (same shape, same `COMMENT_KARMA_THRESHOLD` constant), so the contest discovery filter applies the exact same per-user check the comment system uses.
- No row duplication: `aggregate_user.user_id` is a primary key, so the outer join is 1:1 per Event. The `IN`-subquery doesn't join, so it can't duplicate either.
- `add_query_pagination` is plain `LIMIT/OFFSET` with optional `include_count`; both work correctly with the dual filter.
- **`get_events_by_ids` (the by-ID lookup) is unchanged on purpose.** Deep-link lookups for known events shouldn't be silently broken by a discovery-time filter — comment/action surfaces on those pages have their own enforcement paths.

## Risk / blast radius

`get_events` is the single entry point for event-list queries (confirmed via grep — no other callers in `src/`). Any consumer that wanted to see shadow-banned hosts' events explicitly would need a new flag like `include_shadowbanned: bool` — I didn't add one because no caller asks for it today; happy to extend if there's a known admin/internal need.

## Test plan

- [ ] Create two contest events; mark one host's `aggregate_user.score = -1`. Call `get_events(...)` → only the non-shadow-banned event is returned.
- [ ] Create a contest by a host who has been muted by a set of users whose combined follower counts ≥ `COMMENT_KARMA_THRESHOLD` (but whose own `score >= 0`). Confirm that event is also excluded.
- [ ] Create a contest by a brand-new user with no `aggregate_user` row. Confirm their event still appears (the outer join's NULL is allowed through; they're not in `muted_by_karma` because no one has muted them yet).
- [ ] Confirm `get_events_by_ids(id=[shadowbanned_event_id])` still returns the event (filter not applied on that path).
- [ ] Smoke the contests discovery list in mobile + web after deploy — shadow-banned users' contests should disappear from the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)