### PR TITLE
fix: sign For You feed request to fix 403 from discovery

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
@@ -55,12 +55,33 @@ export const useForYouFeed = (
       const isFirstPage = pageParam === 0
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       const sdk = await audiusSdk()
-      const { data = [] } = await sdk.users.getUserForYouFeed({
-        id: Id.parse(currentUserId),
-        userId: Id.parse(currentUserId),
-        limit: currentPageSize,
-        offset: pageParam
+      // The OpenAPI spec for /v1/users/{id}/feed/for-you omits the
+      // Encoded-Data-Message / Encoded-Data-Signature header parameters
+      // that the analogous /v1/users/{id}/feed endpoint declares, so the
+      // generated SDK method has no auth-header handling. Without those
+      // headers the discovery node rejects the request with 403
+      // (`authedWallet=` empty). Sign here and pass the headers via
+      // initOverrides — the request-signature middleware sees them
+      // already present and skips its own injection.
+      const message = `signature:${Date.now()}`
+      const signature = await sdk.services.audiusWalletClient.signMessage({
+        message
       })
+      const { data = [] } = await sdk.users.getUserForYouFeed(
+        {
+          id: Id.parse(currentUserId),
+          userId: Id.parse(currentUserId),
+          limit: currentPageSize,
+          offset: pageParam
+        },
+        async ({ init }) => ({
+          headers: {
+            ...(init.headers as Record<string, string>),
+            'Encoded-Data-Message': message,
+            'Encoded-Data-Signature': signature
+          }
+        })
+      )
 
       const tracks = primeTrackData({
         tracks: transformAndCleanList(data, userTrackMetadataFromSDK),


### PR DESCRIPTION
## Summary

The For You feed on web RC was returning empty / blank because the discovery-node request was reaching the server **unsigned**, getting back `403 "You are not authorized to make this request authedWallet= myId=<N>"`.

## Root cause

The OpenAPI swagger spec for `/v1/users/{id}/feed/for-you` is missing the `Encoded-Data-Message` and `Encoded-Data-Signature` header parameters that the analogous `/v1/users/{id}/feed` endpoint declares. Compare the generated SDK methods:

- `getUserFeedRaw` reads `params.encodedDataMessage` / `params.encodedDataSignature` into `headerParameters` before calling `this.request(...)` — these match what the addRequestSignatureMiddleware would inject, so the headers are always present.
- `getUserForYouFeedRaw` has **no auth-header handling at all** — relies entirely on middleware-injected headers.

The signing middleware (`addRequestSignatureMiddleware`) is supposed to populate those headers at request time, and *should* apply to both endpoints since both call `this.request()`. In practice the For You call is going out without them — symptom verified by the 403 response with empty `authedWallet=`.

Rather than chase the middleware behavior, this PR signs explicitly at the call site so the headers are guaranteed present.

## What changed

- `packages/common/src/api/tan-query/lineups/useForYouFeed.ts`: sign with `sdk.services.audiusWalletClient.signMessage` and pass `Encoded-Data-Message` / `Encoded-Data-Signature` via the SDK method's `initOverrides`. The request-signature middleware sees the headers already present and skips its injection — no double-signing.

## Test plan

- [ ] On `release-candidate.audius.co` (signed in), open For You tab and verify it loads tracks instead of showing empty / skeleton state.
- [ ] DevTools Network: inspect the `GET /v1/users/{id}/feed/for-you` request — confirm `Encoded-Data-Message` and `Encoded-Data-Signature` headers are present, and response is 200 with track data.
- [ ] Following tab still works (regression check — same shared hook pattern).
- [ ] Mobile RC: For You feed loads after OTA picks up the bundle.

## Follow-ups (not in this PR)

- The swagger spec for `/feed/for-you` should declare the `Encoded-Data-*` header parameters so the next SDK regenerate brings the generated method in line with `getUserFeedRaw`. Once that lands, this hook-level patch can be reverted.
- `staging.audius.co` is serving a Dec 2025 build because the staging deploy pipeline was retired (#13540) but DNS still points at the orphaned worker. Worth tombstoning or redirecting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)