### PR TITLE
refactor(for-you): back feed's For You tab with /recommended-tracks

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
@@ -1,4 +1,4 @@
-import { Id } from '@audius/sdk'
+import { Id, GetUserRecommendedTracksTimeRangeEnum } from '@audius/sdk'
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
@@ -24,9 +24,11 @@ export const getForYouFeedQueryKey = (userId: ID | null | undefined) => {
 }
 
 /**
- * "For You" personalized feed. Calls the server-ranked
- * `GET /v1/users/{id}/feed/for-you` endpoint and exposes the result as
- * a paginated lineup of track ids.
+ * "For You" feed for the Feed page. Backed by the same recommended-tracks
+ * endpoint that powers the Explore page's For You section
+ * (`GET /v1/users/{id}/recommended-tracks`). The dedicated
+ * `/feed/for-you` endpoint has been retired in favor of consolidating on
+ * the recommended-tracks source — see the API repo for the deletion.
  */
 export const useForYouFeed = (
   {
@@ -55,11 +57,12 @@ export const useForYouFeed = (
       const isFirstPage = pageParam === 0
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       const sdk = await audiusSdk()
-      const { data = [] } = await sdk.users.getUserForYouFeed({
+      const { data = [] } = await sdk.users.getUserRecommendedTracks({
         id: Id.parse(currentUserId),
         userId: Id.parse(currentUserId),
         limit: currentPageSize,
-        offset: pageParam
+        offset: pageParam,
+        timeRange: GetUserRecommendedTracksTimeRangeEnum.Week
       })
 
       const tracks = primeTrackData({


### PR DESCRIPTION
## Summary

The Feed page's **For You** tab hit a dedicated `/v1/users/{id}/feed/for-you` endpoint with its own custom server-side ranker. That endpoint had:
- An auth gate that broke the web RC (fixed in api#804)
- A 60+s SQL plan for power users (partially mitigated in api#805/#806, but `similar_artists` self-join still timed out — see [EXPLAIN ANALYZE writeup])

Meanwhile, the **Explore page's For You section** already exists, works fine, and is powered by `/v1/users/{id}/recommended-tracks` (via `useRecommendedTracks` → `sdk.users.getUserRecommendedTracks`). Same shape: ranked track list for the signed-in user.

This PR consolidates: rewrite `useForYouFeed`'s queryFn to call the same SDK method the Explore section uses. The custom `/feed/for-you` endpoint is being deleted from the API in a companion PR.

## What changed

- `packages/common/src/api/tan-query/lineups/useForYouFeed.ts`
  - `sdk.users.getUserForYouFeed(...)` → `sdk.users.getUserRecommendedTracks(... timeRange: Week)`
  - Updated docstring to point at the new endpoint

## What stayed the same (intentionally — so consumers don't touch)

- Exported symbols: `useForYouFeed`, `FOR_YOU_INITIAL_PAGE_SIZE`, `FOR_YOU_LOAD_MORE_PAGE_SIZE`, `getForYouFeedQueryKey`
- Return shape (`trackIds`, `isPending`, `isLoading`, `isFetching`, `isSuccess`, `isError`, `isInitialLoading`, `hasNextPage`, `fetchNextPage`, `loadNextPage`, `refetch`, `queryKey`)
- Page sizes (10/10)
- The `isDisabled` empty-state behavior added in #14290/#14291

Verified consumers — none needed changes:
- `packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx`
- `packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx`
- `packages/mobile/src/screens/feed-screen/FeedScreen.tsx`

## Test plan

- ✅ Typecheck clean (`tsc --noEmit -p packages/common`)
- ✅ Lint clean
- After deploy on the web RC (`release-candidate.audius.co`):
  - Signed in, open Feed → For You tab → should show recommended tracks (same content as Explore's For You section)
  - Network: `/v1/users/{id}/recommended-tracks?time_range=week&limit=10&offset=0&user_id={id}` → 200 with track data
  - No more calls to `/v1/users/{id}/feed/for-you`
  - Following tab still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)