### PR TITLE
fix(profile): keep edit-name pencil static white for dark mode

### DIFF
--- a/packages/web/src/components/profile-picture/ProfilePicture.jsx
+++ b/packages/web/src/components/profile-picture/ProfilePicture.jsx
@@ -116,7 +116,7 @@ const ProfilePicture = ({
         </Image>
         {editMode || showEdit ? (
           <ImageSelectionButton
-            className={styles.imageSelectionButtonWrapper}
+            wrapperClassName={styles.imageSelectionButtonWrapper}
             buttonClassName={styles.imageSelectionButton}
             onSelect={onSelect}
             onClick={onClick}

--- a/packages/web/src/pages/profile-page/components/EditableName.tsx
+++ b/packages/web/src/pages/profile-page/components/EditableName.tsx
@@ -54,7 +54,7 @@ export const EditableName = (props: EditableNameProps) => {
               css={{ marginBottom: spacing.s }}
               aria-label={messages.editLabel}
               icon={IconPencil}
-              color='white'
+              color='staticWhite'
               onClick={() => setEditing(true)}
               shadow='drop'
             />

--- a/packages/web/src/pages/profile-page/components/EditableName.tsx
+++ b/packages/web/src/pages/profile-page/components/EditableName.tsx
@@ -51,7 +51,7 @@ export const EditableName = (props: EditableNameProps) => {
           <div className={styles.editNameContainer}>
             <span className={styles.editingName}>{name}</span>
             <IconButton
-              css={{ marginBottom: spacing.s }}
+              css={{ marginBottom: spacing.s, marginLeft: spacing.s }}
               aria-label={messages.editLabel}
               icon={IconPencil}
               color='staticWhite'


### PR DESCRIPTION
## Summary
- The edit-name pencil on the profile page used Harmony's `white` icon color, which is theme-aware and flips to near-black in dark mode — making the icon hard to see against the cover photo.
- Switch to `staticWhite` so the pencil stays white in both themes.

## Test plan
- [ ] In light mode, the pencil icon next to your display name still renders correctly over the cover photo.
- [ ] In dark mode, the pencil icon is now clearly visible (white instead of near-black).

🤖 Generated with [Claude Code](https://claude.com/claude-code)