### PR TITLE
chore: update terminology to Open Audio Validator Node

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Terminology
+
+Audius runs on the **Open Audio Protocol**, which uses a single canonical node type: the **Open Audio Validator Node**. The earlier split between *Discovery Nodes* and *Content Nodes* is deprecated — both roles are now served by validator nodes. When writing docs, comments, commit messages, or user-facing strings, use "Open Audio Validator Node" (or just "validator node"). Do not introduce new references to "Discovery Node", "Content Node", "Creator Node", or "Discovery Provider". Directory names like `packages/discovery-provider` and `mediorum` are retained for compatibility but no longer reflect the architecture.
+
 ## Project Overview
 
 Audius is a decentralized, community-owned music-sharing protocol. This is a monorepo containing:
 
 - Web and desktop applications (React + Vite)
 - Mobile applications (React Native)
-- Backend services (Discovery Provider, Content Node)
+- Backend services that together make up the Open Audio Validator Node software (indexer + media storage; see `packages/discovery-provider` and `mediorum` directories — names retained from earlier architecture)
 - Blockchain smart contracts (Ethereum and Solana)
 - SDK and common libraries
 
@@ -76,7 +80,7 @@ audius-cmd stream
 - **packages/sdk**: JavaScript SDK for interacting with Audius protocol
 - **packages/harmony**: Design system components and tokens
 - **packages/discovery-provider**: Python backend that indexes blockchain data
-- **mediorum**: Content node for storing/serving audio files
+- **mediorum**: Media storage component of the Open Audio Validator Node — stores and serves audio files (directory name retained from earlier "content node" architecture)
 
 ### State Management
 
@@ -130,7 +134,7 @@ audius-cmd stream
 - Protocol must be running for local development
 - Mobile requires proper native environment setup
 - Some features require blockchain interaction
-- Audio processing happens on content nodes
+- Audio processing happens on Open Audio Validator Nodes (the role formerly called "content node" — deprecated terminology)
 
 ## Code Style and Best Practices
 

--- a/packages/eth/README.md
+++ b/packages/eth/README.md
@@ -108,7 +108,7 @@ const signature = await walletClient.signTypedData({
 | `EthRewardsManager`      | Transfers AUDIO rewards from Ethereum to Solana via Wormhole.                       |
 | `Governance`             | On-chain governance: proposals, stake-weighted voting, execution.                   |
 | `Registry`               | Central directory mapping contract names to addresses.                              |
-| `ServiceProviderFactory` | Registration and staking for discovery nodes and content nodes.                     |
+| `ServiceProviderFactory` | Registration and staking for Open Audio Validator Nodes (the unified node type that replaces the legacy *discovery node* / *content node* split — contract and service-type names are retained from the earlier architecture). |
 | `ServiceTypeManager`     | Registry of valid service types and their versions.                                 |
 | `Staking`                | Core staking contract holding all staked AUDIO with checkpointing.                  |
 | `TrustedNotifierManager` | Registry of trusted notifier entities.                                              |

--- a/packages/protocol-dashboard/README.md
+++ b/packages/protocol-dashboard/README.md
@@ -1,8 +1,8 @@
 # Audius Service Provider Dashboard
 
 ## Summary
-Audius Service Provider Dashboard allows users to register content nodes and discovery providers, 
-view their registered services & which ones are out date, and explore all audius services.
+Audius Service Provider Dashboard allows operators to register Open Audio Validator Nodes (the unified node type that replaces the deprecated *content node* / *discovery provider* split),
+view their registered services and which ones are out of date, and explore all Audius services.
 
 ## Running the Application
 The application requires ethereum contracts.


### PR DESCRIPTION
## Summary
- Adds a **Terminology** section near the top of \`CLAUDE.md\` instructing AI assistants to use **Open Audio Validator Node** and treat *Discovery Node* / *Content Node* / *Creator Node* / *Discovery Provider* as deprecated.
- Updates the in-body references in \`CLAUDE.md\` (Project Overview, Monorepo Structure, Common Pitfalls) to canonical terminology while noting that the \`packages/discovery-provider\` and \`mediorum\` directory names are retained for compatibility.
- Updates \`packages/protocol-dashboard/README.md\` and \`packages/eth/README.md\` (ServiceProviderFactory row) so the user-facing descriptions match.

## Motivation
\`CLAUDE.md\` is a literal AI instruction file — keeping deprecated terminology in it shapes what every Claude session in this repo writes next. The two README updates are small but cover the most public surfaces (dashboard + \`@audius/eth\` consumers).

No code, ABI, contract address, or behavior changes — documentation only.

## Test plan
- [ ] No build impact; docs-only change