### PR TITLE
fix(playlist): allow removing the last track from a playlist

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -677,7 +677,10 @@ def populate_playlist_record_metadata(
         # Update the playlist_record when the corresponding field exists
         # in playlist_metadata
         if key == "playlist_contents":
-            if not playlist_metadata.get(key):
+            # Use `is None` rather than a truthiness check so that an explicit
+            # empty list (the user removing the last track) is applied instead
+            # of being silently treated as "field omitted".
+            if playlist_metadata.get(key) is None:
                 continue
             playlist_record.playlist_contents = process_playlist_contents(
                 playlist_record,

--- a/packages/web/src/components/edit-collection/EditCollectionForm.tsx
+++ b/packages/web/src/components/edit-collection/EditCollectionForm.tsx
@@ -195,7 +195,7 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
             </Flex>
           ) : null}
         </Tile>
-        <CollectionTrackFieldArray />
+        <CollectionTrackFieldArray isUpload={isUpload} />
         {isUpload ? <AnchoredSubmitRow /> : <AnchoredSubmitRowEdit />}
         {playlist_id ? (
           <>

--- a/packages/web/src/components/edit/fields/CollectionTrackFieldArray.tsx
+++ b/packages/web/src/components/edit/fields/CollectionTrackFieldArray.tsx
@@ -66,7 +66,13 @@ const makeTrackKey = (track: TrackForUpload | TrackForEdit, index: number) => {
   return `${track.metadata.track_id}${suffix}`
 }
 
-export const CollectionTrackFieldArray = () => {
+type CollectionTrackFieldArrayProps = {
+  isUpload?: boolean
+}
+
+export const CollectionTrackFieldArray = ({
+  isUpload = false
+}: CollectionTrackFieldArrayProps = {}) => {
   const [{ value: tracks }] =
     useField<(TrackForUpload | TrackForEdit)[]>('tracks')
 
@@ -104,7 +110,7 @@ export const CollectionTrackFieldArray = () => {
                           <CollectionTrackField
                             index={index}
                             remove={remove}
-                            disableDelete={tracks.length === 1}
+                            disableDelete={isUpload && tracks.length === 1}
                           />
                         </div>
                       )}


### PR DESCRIPTION
## Summary

- **UI:** The trash icon in `CollectionTrackFieldArray` was disabled whenever only one track remained. That guard fits the upload flow (which reuses the same form) but blocked edits to existing playlists from ever emptying out. `isUpload` now flows through from `EditCollectionForm`, so the guard only applies during upload.
- **Backend:** Removing the final track via the kebab menu's "Remove from playlist" appeared to succeed (optimistic update + toast) but the track reappeared on reload. In `populate_playlist_record_metadata`, a Python truthiness check on `playlist_metadata["playlist_contents"]` treated the SDK's empty-array payload (`[]`) as if the field were omitted and silently skipped the update. Switched to `is None` so an explicit empty list is applied. Downstream `update_playlist_tracks` already handles an empty `track_ids` correctly (marks all existing rows removed).

## Repro

1. Visit a playlist with one track.
2. Track kebab → "Remove from playlist".
3. Confirmer succeeds, toast shows, track disappears from view.
4. Reload — track is still there.

Also: open the same playlist via "Edit Playlist" — the trash icon on the only row was disabled.

## Test plan

- [ ] Edit-playlist form: remove the final track and save → playlist is empty on reload.
- [ ] Track kebab → "Remove from playlist" on a one-track playlist → playlist is empty on reload.
- [ ] Regression: removing one of several tracks still works in both paths.
- [ ] Regression: upload flow still prevents bottoming out at zero tracks.
- [ ] Backend regression: `playlist_contents: {"track_ids": []}` (legacy dict form, used in existing tests) continues to update correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)