### PR TITLE
fix(solana-relay): share a single Knex pool across all routes

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/db.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/db.ts
@@ -1,0 +1,12 @@
+import { initializeDiscoveryDb } from '@pedalboard/basekit'
+
+import { config } from './config'
+
+/**
+ * Single shared Knex connection pool for the solana-relay service.
+ *
+ * Previously each route module called initializeDiscoveryDb() independently,
+ * creating up to 9 separate pools (each with a default max of 10 connections)
+ * and exhausting the Postgres connection limit under load.
+ */
+export const db = initializeDiscoveryDb(config.discoveryDbConnectionString)

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/signerRecovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/signerRecovery.ts
@@ -1,12 +1,9 @@
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import { Table, Users } from '@pedalboard/storage'
 import { recoverPersonalSignature } from 'eth-sig-util'
 import { NextFunction, Request, Response } from 'express'
 
-import { config } from '../config'
+import { db as discoveryDb } from '../db'
 import { getCachedDiscoveryNodes } from '../redis'
-
-const discoveryDb = initializeDiscoveryDb(config.discoveryDbConnectionString)
 
 export const userSignerRecoveryMiddleware = async (
   req: Request,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/claim_fees.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/claim_fees.ts
@@ -1,6 +1,5 @@
 import { CpAmm, getUnClaimReward } from '@meteora-ag/cp-amm-sdk'
 import { DynamicBondingCurveClient } from '@meteora-ag/dynamic-bonding-curve-sdk'
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import {
   TOKEN_PROGRAM_ID,
   createTransferInstruction,
@@ -9,13 +8,11 @@ import {
 import { Connection, PublicKey } from '@solana/web3.js'
 import { Request, Response } from 'express'
 
-import { config } from '../../config'
+import { db } from '../../db'
 import { logger } from '../../logger'
 import { getConnection } from '../../utils/connections'
 
 import { AUDIO_MINT } from './constants'
-
-const db = initializeDiscoveryDb(config.discoveryDbConnectionString)
 
 interface ClaimFeesRequestBody {
   tokenMint: string

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/claim_vested_coins.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/claim_vested_coins.ts
@@ -1,4 +1,3 @@
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import {
   createTransferCheckedInstruction,
   getAssociatedTokenAddressSync
@@ -8,11 +7,9 @@ import BN from 'bn.js'
 import { Request, Response } from 'express'
 
 import { LockClient } from '@meteora-ag/met-lock-sdk'
-import { config } from '../../config'
+import { db } from '../../db'
 import { logger } from '../../logger'
 import { getConnection } from '../../utils/connections'
-
-const db = initializeDiscoveryDb(config.discoveryDbConnectionString)
 
 interface ClaimVestedCoinsRequestBody {
   tokenMint: string

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/getKeypair.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/launchpad/getKeypair.ts
@@ -1,11 +1,8 @@
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import type { SolKeypairs } from '@pedalboard/storage'
 import { Keypair } from '@solana/web3.js'
 import { Logger } from 'pino'
 
-import { config } from '../../config'
-
-const db = initializeDiscoveryDb(config.discoveryDbConnectionString)
+import { db } from '../../db'
 
 export const getKeypair = async (logger: Logger): Promise<Keypair> => {
   const [deleted] = await db<SolKeypairs>('sol_keypairs')

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/meteora/swap_coin.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/meteora/swap_coin.ts
@@ -3,7 +3,6 @@ import {
   DynamicBondingCurveClient,
   SwapMode
 } from '@meteora-ag/dynamic-bonding-curve-sdk'
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import {
   SolMeteoraDammV2Pools,
   SolMeteoraDbcPools,
@@ -14,14 +13,12 @@ import { Connection, PublicKey, Transaction } from '@solana/web3.js'
 import BN from 'bn.js'
 import { Request, Response } from 'express'
 
-import { config } from '../../config'
+import { db } from '../../db'
 import { logger } from '../../logger'
 import { getConnection } from '../../utils/connections'
 import { AUDIO_MINT } from '../launchpad/constants'
 
 import { SWAP_SLIPPAGE_BPS } from './constants'
-
-const db = initializeDiscoveryDb(config.discoveryDbConnectionString)
 
 const SPL_TOKEN_PROGRAM_ID = new PublicKey(
   'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/meteora/swap_coin_quote.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/meteora/swap_coin_quote.ts
@@ -3,7 +3,6 @@ import {
   DynamicBondingCurveClient,
   SwapMode
 } from '@meteora-ag/dynamic-bonding-curve-sdk'
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import {
   SolMeteoraDammV2Pools,
   SolMeteoraDbcPools,
@@ -14,14 +13,12 @@ import { Connection, PublicKey } from '@solana/web3.js'
 import BN from 'bn.js'
 import { NextFunction, Request, Response } from 'express'
 
-import { config } from '../../config'
+import { db } from '../../db'
 import { logger } from '../../logger'
 import { getConnection } from '../../utils/connections'
 import { AUDIO_MINT } from '../launchpad/constants'
 
 import { SWAP_SLIPPAGE_BPS } from './constants'
-
-const db = initializeDiscoveryDb(config.discoveryDbConnectionString)
 
 const getDBCPoolQuote = async (
   dbcPool: SolMeteoraDbcPools,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/associateExternalWallet.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/associateExternalWallet.ts
@@ -1,11 +1,8 @@
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import { AssociatedWallets, Table, WalletChain } from '@pedalboard/storage'
 import { VersionedTransaction } from '@solana/web3.js'
 
-import { config } from '../../config'
+import { db } from '../../db'
 import { logger } from '../../logger'
-
-const db = initializeDiscoveryDb(config.discoveryDbConnectionString)
 
 export const associateExternalWallet = async (
   transaction: VersionedTransaction,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/getAllowedMints.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/getAllowedMints.ts
@@ -1,9 +1,7 @@
-import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import type { ArtistCoins } from '@pedalboard/storage'
 
 import { config } from '../../config'
-
-const db = initializeDiscoveryDb(config.discoveryDbConnectionString)
+import { db } from '../../db'
 
 export const getAllowedMints = async (): Promise<string[]> => {
   const rows = await db<ArtistCoins>('artist_coins').select('mint')


### PR DESCRIPTION
## Summary

- Each route module in `solana-relay` was calling `initializeDiscoveryDb()` at import time, creating up to 9 independent Knex pools (default `max=10` each) and exhausting the Postgres connection limit under load.
- Extract a single shared pool into a new `src/db.ts` module and import it from every route and middleware.

## Files changed

- `src/db.ts` (new) — single shared `initializeDiscoveryDb` instance.
- `src/routes/meteora/{swap_coin,swap_coin_quote}.ts`
- `src/routes/launchpad/{claim_fees,claim_vested_coins,getKeypair}.ts`
- `src/routes/relay/{getAllowedMints,associateExternalWallet}.ts`
- `src/middleware/signerRecovery.ts`

Net diff: 9 files, +20 / -31 — each touched file drops its local pool initialization in favor of `import { db } from '../../db'`.

## Test plan

- [ ] Type check `pedalboard/apps/solana-relay` builds clean
- [ ] Local solana-relay boots and serves a request through one DBC and one DAMM v2 route
- [ ] Postgres `pg_stat_activity` shows a single pool's worth of connections from solana-relay under load (not N×pool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)