### PR TITLE
fix(feed): add bottom padding to chronological feed filter pills

### DIFF
--- a/packages/web/src/pages/feed-page/components/FeedFilters.tsx
+++ b/packages/web/src/pages/feed-page/components/FeedFilters.tsx
@@ -38,7 +38,7 @@ export const FeedFilters = ({
   )
 
   return (
-    <Flex gap='s' role='radiogroup' onChange={handleChange}>
+    <Flex gap='s' role='radiogroup' onChange={handleChange} pb='l'>
       {filters.map((filter) => (
         <SelectablePill
           name='feed-filter'


### PR DESCRIPTION
## Summary
- The web `FeedFilters` component renders into the Header's `bottomBar` slot with no padding-bottom, leaving the All Posts / Original Posts / Reposts pills flush against the header's bottom border.
- Add `pb='l'` to give the pills breathing room before the page content begins, matching the pattern already used by the trending page's bottomBar and mirroring the existing `paddingBottom: spacing.s` on the mobile `FeedFilters` component.

## Test plan
- [ ] Open the web app, sign in, navigate to Your Feed.
- [ ] With the Chronological tab selected, verify there is a clear gap between the filter pills (All Posts / Original Posts / Reposts) and the first track tile below — pills no longer sit flush against the header border.
- [ ] Switch to the For You tab and confirm the layout is unchanged (no bottomBar there).
- [ ] Toggle between filter pills and confirm the spacing remains consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)