### PR TITLE
chore(analytics): remove second batch of dead Amplitude events

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -40,10 +40,6 @@ export enum Name {
   CREATE_ACCOUNT_OPEN = 'Create Account: Open',
   // When the user continues past the email page
   CREATE_ACCOUNT_COMPLETE_EMAIL = 'Create Account: Complete Email',
-  // When the user continues past the password page
-  CREATE_ACCOUNT_COMPLETE_PASSWORD = 'Create Account: Complete Password',
-  // When the user continues past the "profile info page"
-  CREATE_ACCOUNT_COMPLETE_PROFILE = 'Create Account: Complete Profile',
   // When the user uploads a profile photo in signup
   CREATE_ACCOUNT_UPLOAD_PROFILE_PHOTO = 'Create Account: Upload Profile Photo',
   // When the user has an error uploading their profile photo
@@ -58,16 +54,12 @@ export enum Name {
   CREATE_ACCOUNT_FOLLOW_ARTIST = 'Create Account: Follow Artist',
   // When the user clicks to preview a song from an artist on the follow artists page
   CREATE_ACCOUNT_ARTIST_PREVIEWED = 'Create Account: Artist Previewed',
-  // When the user continues past the follow page
-  CREATE_ACCOUNT_COMPLETE_FOLLOW = 'Create Account: Complete Follow',
   // When the user continues past the loading page
   CREATE_ACCOUNT_COMPLETE_CREATING = 'Create Account: Complete Creating',
   // When the user creates a guest account
   CREATE_ACCOUNT_COMPLETE_GUEST_CREATING = 'Create Account: Complete Guest Creating',
   // When the user completes a guest profile for a full user
   CREATE_ACCOUNT_COMPLETE_GUEST_PROFILE = 'Create Account: Complete Guest Profile',
-  // When the user continues past the entire signup modal
-  CREATE_ACCOUNT_FINISH = 'Create Account: Finish',
   // When the user gets rate limited during signup auth
   CREATE_ACCOUNT_RATE_LIMIT = 'Create Account: Rate Limit',
   // When the user gets blocked by AAO during the signup path
@@ -84,22 +76,9 @@ export enum Name {
 
   // Settings
   SETTINGS_CHANGE_THEME = 'Settings: Change Theme',
-  SETTINGS_START_TWITTER_OAUTH = 'Settings: Start Twitter OAuth',
-  SETTINGS_COMPLETE_TWITTER_OAUTH = 'Settings: Complete Twitter OAuth',
-  SETTINGS_START_INSTAGRAM_OAUTH = 'Settings: Start Instagram OAuth',
-  SETTINGS_COMPLETE_INSTAGRAM_OAUTH = 'Settings: Complete Instagram OAuth',
-  SETTINGS_START_TIKTOK_OAUTH = 'Settings: Start TikTok OAuth',
-  SETTINGS_COMPLETE_TIKTOK_OAUTH = 'Settings: Complete TikTok OAuth',
   SETTINGS_RESEND_ACCOUNT_RECOVERY = 'Settings: Resend Account Recovery',
-  SETTINGS_START_CHANGE_PASSWORD = 'Settings: Start Change Password',
   SETTINGS_COMPLETE_CHANGE_PASSWORD = 'Settings: Complete Change Password',
   SETTINGS_LOG_OUT = 'Settings: Log Out',
-
-  // TikTok
-  // TODO: deprecate the following 3 metrics in favor of the duped CREATE_ACCOUNT ones
-  TIKTOK_START_OAUTH = 'TikTok: Start TikTok OAuth',
-  TIKTOK_COMPLETE_OAUTH = 'TikTok: Complete TikTok OAuth',
-  TIKTOK_OAUTH_ERROR = 'TikTok: TikTok OAuth Error',
 
   // Audius OAuth Login Page
   AUDIUS_OAUTH_START = 'Audius Oauth: Open Login (authenticate)',
@@ -130,7 +109,6 @@ export enum Name {
   ACCOUNT_HEALTH_UPLOAD_COVER_PHOTO = 'Account Health: Upload Cover Photo',
   ACCOUNT_HEALTH_UPLOAD_PROFILE_PICTURE = 'Account Health: Upload Profile Picture',
   ACCOUNT_HEALTH_DOWNLOAD_DESKTOP = 'Account Health: Download Desktop',
-  ACCOUNT_HEALTH_CLICK_APP_CTA_BANNER = 'Account Health: App CTA Banner',
 
   // TOS
   BANNER_TOS_CLICKED = 'Banner TOS Clicked',
@@ -157,9 +135,6 @@ export enum Name {
   DELETE = 'Delete',
 
   // Folders
-  FOLDER_OPEN_CREATE = 'Folder: Open Create Playlist Folder',
-  FOLDER_SUBMIT_CREATE = 'Folder: Submit Create Playlist Folder',
-  FOLDER_CANCEL_CREATE = 'Folder: Cancel Create Playlist Folder',
   FOLDER_OPEN_EDIT = 'Folder: Open Edit Playlist Folder',
   FOLDER_SUBMIT_EDIT = 'Folder: Submit Edit Playlist Folder',
   FOLDER_DELETE = 'Folder: Delete Playlist Folder',
@@ -176,26 +151,21 @@ export enum Name {
   // Note that upload is considered complete if it is explicitly rejected
   // by the node receiving the file (HTTP 403).
   TRACK_UPLOAD_COMPLETE_UPLOAD = 'Track Upload: Complete Upload',
-  TRACK_UPLOAD_COPY_LINK = 'Track Upload: Copy Link',
-  TRACK_UPLOAD_SHARE_WITH_FANS = 'Track Upload: Share with your fans',
   TRACK_UPLOAD_VIEW_TRACK_PAGE = 'Track Upload: View Track page',
   TWEET_FIRST_UPLOAD = 'Tweet First Upload',
 
   // Upload success tracking
   TRACK_UPLOAD_SUCCESS = 'Track Upload: Success',
   TRACK_UPLOAD_FAILURE = 'Track Upload: Failure',
-  TRACK_UPLOAD_REJECTED = 'Track Upload: Rejected',
 
   // Gated Track Uploads
   TRACK_UPLOAD_FOLLOW_GATED = 'Track Upload: Follow Gated',
   TRACK_UPLOAD_USDC_GATED = 'Track Upload: USDC Gated',
   TRACK_UPLOAD_TOKEN_GATED = 'Track Upload: Token Gated',
-  TRACK_UPLOAD_CLICK_USDC_WAITLIST_LINK = 'Track Upload: Clicked USDC Waitlist Link',
   // Download-Only Gated Track Uploads
   TRACK_UPLOAD_FOLLOW_GATED_DOWNLOAD = 'Track Upload: Follow Gated Download',
   TRACK_UPLOAD_USDC_GATED_DOWNLOAD = 'Track Upload: USDC Gated Download',
   TRACK_UPLOAD_TOKEN_GATED_DOWNLOAD = 'Track Upload: Token Gated Download',
-  TRACK_UPLOAD_CLICK_USDC_DOWNLOAD_WAITLIST_LINK = 'Track Upload: Clicked USDC Download Waitlist Link',
 
   // Track Downloads
   TRACK_DOWNLOAD_CLICKED_DOWNLOAD_ALL = 'Track Download: Clicked Download All',
@@ -257,7 +227,6 @@ export enum Name {
   PROFILE_PAGE_SHOWN_ARTIST_RECOMMENDATIONS = 'ProfilePage: Shown Artist Recommendations',
 
   // Track page
-  TRACK_PAGE_DOWNLOAD = 'Track Page: Download',
   TRACK_PAGE_PLAY_MORE = 'Track Page: Play More By This Artist',
 
   // Playback
@@ -278,8 +247,6 @@ export enum Name {
 
   // Navigation
   PAGE_VIEW = 'Page View',
-  ON_FIRST_PAGE = 'nav-on-first-page',
-  NOT_ON_FIRST_PAGE = 'nav-not-on-first-page',
   LINK_CLICKING = 'Link Click',
   TAG_CLICKING = 'Tag Click',
 
@@ -290,7 +257,6 @@ export enum Name {
   // Search
   SEARCH_SEARCH = 'Search: Search',
   SEARCH_TAG_SEARCH = 'Search: Tag Search',
-  SEARCH_MORE_RESULTS = 'Search: More Results',
   SEARCH_RESULT_SELECT = 'Search: Result Select',
 
   // Explore
@@ -301,10 +267,6 @@ export enum Name {
   ERROR_PAGE = 'Error Page',
   NOT_FOUND_PAGE = 'Not Found Page',
 
-  // System
-  WEB_VITALS = 'Web Vitals',
-  PERFORMANCE = 'Performance',
-
   // Remixes
   STEM_COMPLETE_UPLOAD = 'Stem: Complete Upload',
   STEM_DELETE = 'Stem: Delete',
@@ -314,24 +276,14 @@ export enum Name {
   REMIX_HIDE = 'Remix: Hide',
 
   // $AUDIO
-  SEND_AUDIO_REQUEST = 'Send $AUDIO: Request',
   SEND_AUDIO_SUCCESS = 'Send $AUDIO: Success',
   SEND_AUDIO_FAILURE = 'Send $AUDIO: Failure',
-
-  // AUDIO Manager
-  TRANSFER_AUDIO_TO_WAUDIO_REQUEST = 'TRANSFER_AUDIO_TO_WAUDIO_REQUEST',
-  TRANSFER_AUDIO_TO_WAUDIO_SUCCESS = 'TRANSFER_AUDIO_TO_WAUDIO_SUCCESS',
-  TRANSFER_AUDIO_TO_WAUDIO_FAILURE = 'TRANSFER_AUDIO_TO_WAUDIO_FAILURE',
 
   // Playlist library
   PLAYLIST_LIBRARY_REORDER = 'Playlist Library: Reorder',
   PLAYLIST_LIBRARY_MOVE_PLAYLIST_INTO_FOLDER = 'Playlist Library: Move Playlist Into Folder',
   PLAYLIST_LIBRARY_ADD_PLAYLIST_TO_FOLDER = 'Playlist Library: Add Playlist To Folder',
   PLAYLIST_LIBRARY_MOVE_PLAYLIST_OUT_OF_FOLDER = 'Playlist Library: Move Playlist Out of Folder',
-  PLAYLIST_LIBRARY_EXPAND_FOLDER = 'Playlist Library: Expand Folder',
-  PLAYLIST_LIBRARY_COLLAPSE_FOLDER = 'Playlist Library: Collapse Folder',
-  // When a user clicks on a playlist in the library
-  PLAYLIST_LIBRARY_CLICKED = 'Playlist Library: Clicked',
 
   // Deactivate Account
   DEACTIVATE_ACCOUNT_PAGE_VIEW = 'Deactivate Account: Page View',
@@ -340,7 +292,6 @@ export enum Name {
   DEACTIVATE_ACCOUNT_FAILURE = 'Deactivate Account: Failure',
 
   // Create User Bank
-  CREATE_USER_BANK_REQUEST = 'Create User Bank: Request',
   CREATE_USER_BANK_SUCCESS = 'Create User Bank: Success',
   CREATE_USER_BANK_FAILURE = 'Create User Bank: Failure',
 
@@ -353,11 +304,6 @@ export enum Name {
   REWARDS_CLAIM_REQUEST = 'Rewards Claim: Request',
   REWARDS_CLAIM_SUCCESS = 'Rewards Claim: Success',
   REWARDS_CLAIM_BLOCKED = 'Rewards Claim: Blocked',
-
-  // Social Proof
-  SOCIAL_PROOF_OPEN = 'Social Proof: Open',
-  SOCIAL_PROOF_SUCCESS = 'Social Proof: Success',
-  SOCIAL_PROOF_ERROR = 'Social Proof: Error',
 
   // Buy USDC
   BUY_USDC_ON_RAMP_OPENED = 'Buy USDC: On Ramp Opened',
@@ -393,7 +339,6 @@ export enum Name {
   WITHDRAW_USDC_FORM_ERROR = 'Withdraw USDC: Form Error',
   WITHDRAW_USDC_SUCCESS = 'Withdraw USDC: Success',
   WITHDRAW_USDC_FAILURE = 'Withdraw USDC: Failure',
-  WITHDRAW_USDC_HELP_LINK_CLICKED = 'Withdraw USDC: Help Link Clicked',
   WITHDRAW_USDC_TRANSACTION_LINK_CLICKED = 'Withdraw USDC: Transaction Link Clicked',
 
   // Stripe Tracking
@@ -425,9 +370,7 @@ export enum Name {
   CONNECT_WALLET_NEW_WALLET_START = 'Connect Wallet: New Wallet Start',
   CONNECT_WALLET_NEW_WALLET_CONNECTING = 'Connect Wallet: New Wallet Connecting',
   CONNECT_WALLET_NEW_WALLET_CONNECTED = 'Connect Wallet: New Wallet Connected',
-  CONNECT_WALLET_DISCONNECTED = 'Connect Wallet: Disconnected',
   CONNECT_WALLET_ALREADY_ASSOCIATED = 'Connect Wallet: Already Associated',
-  CONNECT_WALLET_ASSOCIATION_ERROR = 'Connect Wallet: Association Error',
   CONNECT_WALLET_ERROR = 'Connect Wallet: Error',
 
   // Chat
@@ -453,10 +396,6 @@ export enum Name {
   CHAT_ENTRY_POINT = 'Chat Entry Point',
   CHAT_WEBSOCKET_ERROR = 'Chat Websocket Error',
 
-  // Jupiter
-  JUPITER_QUOTE_REQUEST = 'Jupiter: Quote Request',
-  JUPITER_QUOTE_RESPONSE = 'Jupiter: Quote Response',
-
   // Export Private Key
   EXPORT_PRIVATE_KEY_LINK_CLICKED = 'Export Private Key: Settings Link Clicked',
   EXPORT_PRIVATE_KEY_PAGE_VIEWED = 'Export Private Key: Page Viewed',
@@ -466,7 +405,6 @@ export enum Name {
 
   // Manager Mode
   MANAGER_MODE_SWITCH_ACCOUNT = 'Manager Mode: Switch Account',
-  MANAGER_MODE_INVITE_MANAGER = 'Manager Mode: Invite Manager',
   MANAGER_MODE_ACCEPT_INVITE = 'Manager Mode: Accept Invite',
   MANAGER_MODE_CANCEL_INVITE = 'Manager Mode: Cancel Invite',
   MANAGER_MODE_REJECT_INVITE = 'Manager Mode: Reject Invite',
@@ -495,7 +433,6 @@ export enum Name {
   COMMENTS_LOAD_MORE_COMMENTS = 'Comments: Load More Comments',
   COMMENTS_LOAD_NEW_COMMENTS = 'Comments: Load New Comments',
   COMMENTS_SHOW_REPLIES = 'Comments: Show Replies',
-  COMMENTS_LOAD_MORE_REPLIES = 'Comments: Load More Replies',
   COMMENTS_HIDE_REPLIES = 'Comments: Hide Replies',
   COMMENTS_APPLY_SORT = 'Comments: Apply Sort',
   COMMENTS_CLICK_COMMENT_STAT = 'Comments: Click Comment Stat',
@@ -531,11 +468,6 @@ export enum Name {
   REMIX_CONTEST_ENTER = 'Remix Contest: Enter',
   REMIX_CONTEST_VIEW_SUBMISSIONS = 'Remix Contest: View Submissions',
 
-  // Android App Lifecycle
-  ANDROID_APP_RESTART_HEARTBEAT = 'Android App: Restart Due to Heartbeat',
-  ANDROID_APP_RESTART_STALE = 'Android App: Restart Due to Stale Time',
-  ANDROID_APP_RESTART_FORCE_QUIT = 'Android App: Restart Due to Force Quit',
-
   // Fan Clubs
   BANNER_FAN_CLUBS_LAUNCH_CLICKED = 'Banner Artist Coins Launch Clicked',
   BANNER_TRADING_VOLUME_LAUNCH_CLICKED = 'Banner Trading Volume Launch Clicked',
@@ -555,9 +487,6 @@ export enum Name {
   LAUNCHPAD_COIN_CREATION_STARTED = 'Launchpad: Coin Creation Started',
   LAUNCHPAD_COIN_CREATION_SUCCESS = 'Launchpad: Coin Creation Success',
   LAUNCHPAD_COIN_CREATION_FAILURE = 'Launchpad: Coin Creation Failure',
-  LAUNCHPAD_FIRST_BUY_STARTED = 'Launchpad: First Buy Started',
-  LAUNCHPAD_FIRST_BUY_SUCCESS = 'Launchpad: First Buy Success',
-  LAUNCHPAD_FIRST_BUY_FAILURE = 'Launchpad: First Buy Failure',
   LAUNCHPAD_FIRST_BUY_RETRY = 'Launchpad: First Buy Retry',
   LAUNCHPAD_FIRST_BUY_MAX_BUTTON = 'Launchpad: First Buy Max Button Clicked',
   LAUNCHPAD_FIRST_BUY_QUOTE_RECEIVED = 'Launchpad: First Buy Quote Received',
@@ -611,10 +540,6 @@ type CreateAccountCompleteEmail = {
   eventName: Name.CREATE_ACCOUNT_COMPLETE_EMAIL
   emailAddress: string
 }
-type CreateAccountCompletePassword = {
-  eventName: Name.CREATE_ACCOUNT_COMPLETE_PASSWORD
-  emailAddress: string
-}
 type CreateAccountUploadProfilePhoto = {
   eventName: Name.CREATE_ACCOUNT_UPLOAD_PROFILE_PHOTO
   emailAddress?: string
@@ -632,11 +557,6 @@ type CreateAccountUploadProfileCover = {
 type CreateAccountUploadProfileCoverError = {
   eventName: Name.CREATE_ACCOUNT_UPLOAD_COVER_PHOTO_ERROR
   error: string
-}
-type CreateAccountCompleteProfile = {
-  eventName: Name.CREATE_ACCOUNT_COMPLETE_PROFILE
-  emailAddress: string
-  handle: string
 }
 type CreateAccountSelectGenre = {
   eventName: Name.CREATE_ACCOUNT_SELECT_GENRE
@@ -659,13 +579,6 @@ type CreateAccountPreviewArtist = {
   artistName: string
 }
 
-type CreateAccountCompleteFollow = {
-  eventName: Name.CREATE_ACCOUNT_COMPLETE_FOLLOW
-  emailAddress: string
-  handle: string
-  users: string
-  count: number
-}
 type CreateAccountCompleteCreating = {
   eventName: Name.CREATE_ACCOUNT_COMPLETE_CREATING
   emailAddress: string
@@ -681,12 +594,6 @@ type CreateAccountWelcomeModalUploadTrack = {
   emailAddress: string
   handle: string
 }
-type CreateAccountOpenFinish = {
-  eventName: Name.CREATE_ACCOUNT_FINISH
-  emailAddress: string
-  handle: string
-}
-
 // Sign In
 type SignInStart = {
   eventName: Name.SIGN_IN_START
@@ -706,41 +613,8 @@ type SettingsChangeTheme = {
   eventName: Name.SETTINGS_CHANGE_THEME
   mode: 'dark' | 'light' | 'matrix' | 'auto'
 }
-type SettingsStartTwitterOauth = {
-  eventName: Name.SETTINGS_START_TWITTER_OAUTH
-  handle?: string
-}
-type SettingsCompleteTwitterOauth = {
-  eventName: Name.SETTINGS_COMPLETE_TWITTER_OAUTH
-  handle?: string
-  screen_name: string
-  is_verified: boolean
-}
-type SettingsStartInstagramOauth = {
-  eventName: Name.SETTINGS_START_INSTAGRAM_OAUTH
-  handle?: string
-}
-type SettingsCompleteInstagramOauth = {
-  eventName: Name.SETTINGS_COMPLETE_INSTAGRAM_OAUTH
-  handle?: string
-  username: string
-  is_verified: boolean
-}
-type SettingsStartTikTokOauth = {
-  eventName: Name.SETTINGS_START_TIKTOK_OAUTH
-  handle?: string
-}
-type SettingsCompleteTikTokOauth = {
-  eventName: Name.SETTINGS_COMPLETE_TIKTOK_OAUTH
-  handle?: string
-  username: string
-  is_verified: boolean
-}
 type SettingsResetAccountRecovery = {
   eventName: Name.SETTINGS_RESEND_ACCOUNT_RECOVERY
-}
-type SettingsStartChangePassword = {
-  eventName: Name.SETTINGS_START_CHANGE_PASSWORD
 }
 type SettingsCompleteChangePassword = {
   eventName: Name.SETTINGS_COMPLETE_CHANGE_PASSWORD
@@ -748,20 +622,6 @@ type SettingsCompleteChangePassword = {
 }
 type SettingsLogOut = {
   eventName: Name.SETTINGS_LOG_OUT
-}
-
-// TikTok
-type TikTokStartOAuth = {
-  eventName: Name.TIKTOK_START_OAUTH
-}
-
-type TikTokCompleteOAuth = {
-  eventName: Name.TIKTOK_COMPLETE_OAUTH
-}
-
-type TikTokOAuthError = {
-  eventName: Name.TIKTOK_OAUTH_ERROR
-  error: string
 }
 
 // Error
@@ -797,10 +657,6 @@ type AccountHealthUploadProfilePhoto = {
 type AccountHealthDownloadDesktop = {
   eventName: Name.ACCOUNT_HEALTH_DOWNLOAD_DESKTOP
   source: 'banner' | 'settings'
-}
-
-type AccountHealthCTABanner = {
-  eventName: Name.ACCOUNT_HEALTH_CLICK_APP_CTA_BANNER
 }
 
 // Social
@@ -960,18 +816,6 @@ type Delete = {
 
 // Folder
 
-type FolderOpenCreate = {
-  eventName: Name.FOLDER_OPEN_CREATE
-}
-
-type FolderSubmitCreate = {
-  eventName: Name.FOLDER_SUBMIT_CREATE
-}
-
-type FolderCancelCreate = {
-  eventName: Name.FOLDER_CANCEL_CREATE
-}
-
 type FolderOpenEdit = {
   eventName: Name.FOLDER_OPEN_EDIT
 }
@@ -1039,22 +883,6 @@ type TrackUploadFailure = {
   error?: string
 }
 
-type TrackUploadRejected = {
-  eventName: Name.TRACK_UPLOAD_REJECTED
-  kind: 'single_track' | 'multi_track' | 'album' | 'playlist'
-  error?: string
-}
-
-type TrackUploadCopyLink = {
-  eventName: Name.TRACK_UPLOAD_COPY_LINK
-  uploadType: string
-  url: string
-}
-type TrackUploadShareWithFans = {
-  eventName: Name.TRACK_UPLOAD_SHARE_WITH_FANS
-  uploadType: string
-  text: string
-}
 type TrackUploadViewTrackPage = {
   eventName: Name.TRACK_UPLOAD_VIEW_TRACK_PAGE
   uploadType: string
@@ -1082,10 +910,6 @@ type TrackUploadTokenGated = {
   lossless: boolean
 }
 
-type TrackUploadClickUSDCWaitListLink = {
-  eventName: Name.TRACK_UPLOAD_CLICK_USDC_WAITLIST_LINK
-}
-
 type TrackUploadFollowGatedDownload = {
   eventName: Name.TRACK_UPLOAD_FOLLOW_GATED_DOWNLOAD
   kind: 'tracks'
@@ -1106,10 +930,6 @@ type TrackUploadUSDCGatedDownload = {
   kind: 'tracks'
   downloadable: boolean
   lossless: boolean
-}
-
-type TrackUploadClickUSDCDownloadWaitListLink = {
-  eventName: Name.TRACK_UPLOAD_CLICK_USDC_DOWNLOAD_WAITLIST_LINK
 }
 
 // Track Downloads
@@ -1322,12 +1142,6 @@ type ProfilePageShownArtistRecommendations = {
 }
 
 // Track Page
-type TrackPageDownload = {
-  eventName: Name.TRACK_PAGE_DOWNLOAD
-  id: ID
-  category?: string
-  parent_track_id?: ID
-}
 type TrackPagePlayMore = {
   eventName: Name.TRACK_PAGE_PLAY_MORE
   id: ID
@@ -1483,12 +1297,6 @@ type SearchTag = {
   source: SearchSource
 }
 
-type SearchMoreResults = {
-  eventName: Name.SEARCH_MORE_RESULTS
-  term: string
-  source: SearchSource
-}
-
 type SearchResultSelect = {
   eventName: Name.SEARCH_RESULT_SELECT
   term: string
@@ -1536,30 +1344,10 @@ type ExploreSectionClick = {
   link?: string
 }
 
-type OnFirstPage = {
-  eventName: Name.ON_FIRST_PAGE
-}
-
-type NotOnFirstPage = {
-  eventName: Name.NOT_ON_FIRST_PAGE
-}
-
 type BrowserNotificationSetting = {
   eventName: Name.BROWSER_NOTIFICATION_SETTINGS
   provider: 'safari' | 'gcm'
   enabled: boolean
-}
-
-type WebVitals = {
-  eventName: Name.WEB_VITALS
-  metric: string
-  value: number
-  route: string
-}
-type Performance = {
-  eventName: Name.PERFORMANCE
-  metric: string
-  value: number
 }
 
 type StemCompleteUpload = {
@@ -1615,18 +1403,6 @@ export type SendAudioSource =
   | 'oauth_pay_page'
   | 'send_tokens_drawer'
 
-type SendAudioRequest = {
-  eventName: Name.SEND_AUDIO_REQUEST
-  from: WalletAddress
-  recipient: WalletAddress
-  amount?: string
-  source?: SendAudioSource | string
-  senderHandle?: string
-  senderWallet?: WalletAddress
-  recipientHandle?: string
-  recipientWallet?: WalletAddress
-}
-
 type SendAudioSuccess = {
   eventName: Name.SEND_AUDIO_SUCCESS
   from: WalletAddress
@@ -1652,34 +1428,11 @@ type SendAudioFailure = {
   recipientWallet?: WalletAddress
 }
 
-type TransferAudioToWAudioRequest = {
-  eventName: Name.TRANSFER_AUDIO_TO_WAUDIO_REQUEST
-  from: WalletAddress
-}
-
-type TransferAudioToWAudioSuccess = {
-  eventName: Name.TRANSFER_AUDIO_TO_WAUDIO_SUCCESS
-  from: WalletAddress
-  txSignature: string
-  logs: string
-}
-
-type TransferAudioToWAudioFailure = {
-  eventName: Name.TRANSFER_AUDIO_TO_WAUDIO_FAILURE
-  from: WalletAddress
-}
-
 type PlaylistLibraryReorder = {
   eventName: Name.PLAYLIST_LIBRARY_REORDER
   // Whether or not the reorder contains newly created temp playlists
   containsTemporaryPlaylists: boolean
   kind: PlaylistLibraryKind
-}
-
-type PlaylistLibraryClicked = {
-  eventName: Name.PLAYLIST_LIBRARY_CLICKED
-  playlistId: ID
-  hasUpdate: boolean
 }
 
 type PlaylistLibraryMovePlaylistIntoFolder = {
@@ -1694,14 +1447,6 @@ type PlaylistLibraryMovePlaylistOutOfFolder = {
   eventName: Name.PLAYLIST_LIBRARY_MOVE_PLAYLIST_OUT_OF_FOLDER
 }
 
-type PlaylistLibraryExpandFolder = {
-  eventName: Name.PLAYLIST_LIBRARY_EXPAND_FOLDER
-}
-
-type PlaylistLibraryCollapseFolder = {
-  eventName: Name.PLAYLIST_LIBRARY_COLLAPSE_FOLDER
-}
-
 type DeactivateAccountPageView = {
   eventName: Name.DEACTIVATE_ACCOUNT_PAGE_VIEW
 }
@@ -1713,11 +1458,6 @@ type DeactivateAccountSuccess = {
 }
 type DeactivateAccountFailure = {
   eventName: Name.DEACTIVATE_ACCOUNT_FAILURE
-}
-
-type CreateUserBankRequest = {
-  eventName: Name.CREATE_USER_BANK_REQUEST
-  userId: ID
 }
 
 type CreateUserBankSuccess = {
@@ -1777,26 +1517,6 @@ type RewardsClaimAllBlocked = {
   eventName: Name.REWARDS_CLAIM_ALL_BLOCKED
   count: number
   code: number
-}
-
-type SocialProofOpen = {
-  eventName: Name.SOCIAL_PROOF_OPEN
-  kind: 'instagram' | 'twitter' | 'tiktok'
-  handle?: string
-}
-
-type SocialProofSuccess = {
-  eventName: Name.SOCIAL_PROOF_SUCCESS
-  kind: 'instagram' | 'twitter' | 'tiktok'
-  handle?: string
-  screenName: string
-}
-
-type SocialProofError = {
-  eventName: Name.SOCIAL_PROOF_ERROR
-  kind: 'instagram' | 'twitter' | 'tiktok'
-  handle?: string
-  error: string
 }
 
 type AudiusOauthStart = {
@@ -2071,10 +1791,6 @@ export type WithdrawUSDCCoinflowSendTransactionFailed = {
   errorCode?: string | number
 }
 
-export type WithdrawUSDCHelpLinkClicked = WithdrawUSDCEventFields & {
-  eventName: Name.WITHDRAW_USDC_HELP_LINK_CLICKED
-}
-
 export type WithdrawUSDCTxLinkClicked = WithdrawUSDCTransferEventFields & {
   eventName: Name.WITHDRAW_USDC_TRANSACTION_LINK_CLICKED
   signature: string
@@ -2208,18 +1924,8 @@ type ConnectWalletNewWalletConnected = {
   walletAddress: WalletAddress
 }
 
-type ConnectWalletDisconnected = {
-  eventName: Name.CONNECT_WALLET_DISCONNECTED
-}
-
 type ConnectWalletAlreadyAssociated = {
   eventName: Name.CONNECT_WALLET_ALREADY_ASSOCIATED
-  chain: Chain
-  walletAddress: WalletAddress
-}
-
-type ConnectWalletAssociationError = {
-  eventName: Name.CONNECT_WALLET_ASSOCIATION_ERROR
   chain: Chain
   walletAddress: WalletAddress
 }
@@ -2335,27 +2041,6 @@ type ChatWebsocketError = {
   code?: string
 }
 
-// Jupiter
-type JupiterQuoteRequest = {
-  eventName: Name.JUPITER_QUOTE_REQUEST
-  inputMint: string
-  outputMint: string
-  swapMode?: string
-  slippageBps?: number
-  amount: number
-}
-
-type JupiterQuoteResponse = {
-  eventName: Name.JUPITER_QUOTE_RESPONSE
-  inputMint: string
-  outputMint: string
-  swapMode: string
-  slippageBps: number
-  otherAmountThreshold: number
-  inAmount: number
-  outAmount: number
-}
-
 // Export Private Key
 type ExportPrivateKeyLinkClicked = {
   eventName: Name.EXPORT_PRIVATE_KEY_LINK_CLICKED
@@ -2391,11 +2076,6 @@ type ExportPrivateKeyPrivateKeyCopied = {
 type ManagerModeSwitchAccount = {
   eventName: Name.MANAGER_MODE_SWITCH_ACCOUNT
   managedUserId: ID
-}
-
-type ManagerModeInviteManager = {
-  eventName: Name.MANAGER_MODE_INVITE_MANAGER
-  managerId: ID
 }
 
 type ManagerModeAcceptInvite = {
@@ -2539,12 +2219,6 @@ export type CommentsLoadNewComments = {
 
 export type CommentsShowReplies = {
   eventName: Name.COMMENTS_SHOW_REPLIES
-  commentId: ID
-  trackId: ID
-}
-
-export type CommentsLoadMoreReplies = {
-  eventName: Name.COMMENTS_LOAD_MORE_REPLIES
   commentId: ID
   trackId: ID
 }
@@ -2702,20 +2376,6 @@ export type RemixContestViewSubmissions = {
   trackId: ID
 }
 
-export type AndroidAppRestartHeartbeat = {
-  eventName: Name.ANDROID_APP_RESTART_HEARTBEAT
-  timeSinceLastHeartbeat: number
-}
-
-export type AndroidAppRestartStale = {
-  eventName: Name.ANDROID_APP_RESTART_STALE
-  backgroundDuration: number
-}
-
-export type AndroidAppRestartForceQuit = {
-  eventName: Name.ANDROID_APP_RESTART_FORCE_QUIT
-}
-
 // Fan Club Launchpad
 export type LaunchpadSplashGetStarted = {
   eventName: Name.LAUNCHPAD_SPLASH_GET_STARTED
@@ -2785,30 +2445,6 @@ export type LaunchpadCoinCreationFailure = {
     | 'firstBuyFailed'
     | 'unknownError'
   launchCoinResponse: LaunchCoinResponse
-}
-
-export type LaunchpadFirstBuyStarted = {
-  eventName: Name.LAUNCHPAD_FIRST_BUY_STARTED
-  coinSymbol: string
-  mintAddress: string
-  payAmount: string
-  receiveAmount: string
-}
-
-export type LaunchpadFirstBuySuccess = {
-  eventName: Name.LAUNCHPAD_FIRST_BUY_SUCCESS
-  coinSymbol: string
-  mintAddress: string
-  payAmount: string
-  receiveAmount: string
-}
-
-export type LaunchpadFirstBuyFailure = {
-  eventName: Name.LAUNCHPAD_FIRST_BUY_FAILURE
-  coinSymbol: string
-  mintAddress: string
-  payAmount: string
-  error: string
 }
 
 export type LaunchpadFirstBuyRetry = {
@@ -2973,11 +2609,7 @@ export type AllTrackingEvents =
   | AppError
   | CreateAccountOpen
   | CreateAccountCompleteEmail
-  | CreateAccountCompletePassword
-  | CreateAccountCompleteProfile
-  | CreateAccountCompleteFollow
   | CreateAccountCompleteCreating
-  | CreateAccountOpenFinish
   | CreateAccountUploadProfilePhoto
   | CreateAccountUploadProfilePhotoError
   | CreateAccountUploadProfileCover
@@ -2991,26 +2623,15 @@ export type AllTrackingEvents =
   | SignInFinish
   | SignInWithIncompleteAccount
   | SettingsChangeTheme
-  | SettingsStartTwitterOauth
-  | SettingsCompleteTwitterOauth
-  | SettingsStartInstagramOauth
-  | SettingsCompleteInstagramOauth
-  | SettingsStartTikTokOauth
-  | SettingsCompleteTikTokOauth
   | SettingsResetAccountRecovery
-  | SettingsStartChangePassword
   | SettingsCompleteChangePassword
   | SettingsLogOut
-  | TikTokStartOAuth
-  | TikTokCompleteOAuth
-  | TikTokOAuthError
   | VisualizerOpen
   | VisualizerClose
   | AccountHealthMeterFull
   | AccountHealthUploadCoverPhoto
   | AccountHealthUploadProfilePhoto
   | AccountHealthDownloadDesktop
-  | AccountHealthCTABanner
   | Share
   | ShareToTwitter
   | Repost
@@ -3034,11 +2655,9 @@ export type AllTrackingEvents =
   | TrackUploadFollowGated
   | TrackUploadUSDCGated
   | TrackUploadTokenGated
-  | TrackUploadClickUSDCWaitListLink
   | TrackUploadFollowGatedDownload
   | TrackUploadUSDCGatedDownload
   | TrackUploadTokenGatedDownload
-  | TrackUploadClickUSDCDownloadWaitListLink
   | TrackDownloadClickedDownloadAll
   | TrackDownloadSuccessfulDownloadAll
   | TrackDownloadFailedDownloadAll
@@ -3052,9 +2671,6 @@ export type AllTrackingEvents =
   | CollectionEdit
   | TrackUploadSuccess
   | TrackUploadFailure
-  | TrackUploadRejected
-  | TrackUploadCopyLink
-  | TrackUploadShareWithFans
   | TrackUploadViewTrackPage
   | USDCGatedTrackUnlocked
   | FollowGatedTrackUnlocked
@@ -3084,7 +2700,6 @@ export type AllTrackingEvents =
   | ProfilePageClickTikTok
   | ProfilePageClickWebsite
   | ProfilePageShownArtistRecommendations
-  | TrackPageDownload
   | TrackPagePlayMore
   | PlaybackPlay
   | PlaybackPause
@@ -3105,43 +2720,30 @@ export type AllTrackingEvents =
   | ModalClosed
   | SearchTerm
   | SearchTag
-  | SearchMoreResults
   | SearchResultSelect
   | ExploreSectionView
   | ExploreSectionClick
   | ErrorPage
   | NotFoundPage
   | PageView
-  | OnFirstPage
-  | NotOnFirstPage
   | BrowserNotificationSetting
   | TweetFirstUpload
-  | WebVitals
-  | Performance
   | StemCompleteUpload
   | StemDelete
   | RemixNewRemix
   | RemixCosign
   | RemixCosignIndicator
   | RemixHide
-  | SendAudioRequest
   | SendAudioSuccess
   | SendAudioFailure
   | PlaylistLibraryReorder
-  | PlaylistLibraryClicked
   | PlaylistLibraryMovePlaylistIntoFolder
   | PlaylistLibraryAddPlaylistToFolder
   | PlaylistLibraryMovePlaylistOutOfFolder
-  | PlaylistLibraryExpandFolder
-  | PlaylistLibraryCollapseFolder
-  | TransferAudioToWAudioRequest
-  | TransferAudioToWAudioSuccess
-  | TransferAudioToWAudioFailure
   | DeactivateAccountPageView
   | DeactivateAccountRequest
   | DeactivateAccountSuccess
   | DeactivateAccountFailure
-  | CreateUserBankRequest
   | CreateUserBankSuccess
   | CreateUserBankFailure
   | RewardsClaimDetailsOpened
@@ -3152,12 +2754,6 @@ export type AllTrackingEvents =
   | RewardsClaimAllSuccess
   | RewardsClaimAllFailure
   | RewardsClaimAllBlocked
-  | SocialProofOpen
-  | SocialProofSuccess
-  | SocialProofError
-  | FolderOpenCreate
-  | FolderSubmitCreate
-  | FolderCancelCreate
   | FolderOpenEdit
   | FolderSubmitEdit
   | FolderDelete
@@ -3195,7 +2791,6 @@ export type AllTrackingEvents =
   | WithdrawUSDCCoinflowWithdrawalReady
   | WithdrawUSDCCoinflowSendTransaction
   | WithdrawUSDCCoinflowSendTransactionFailed
-  | WithdrawUSDCHelpLinkClicked
   | WithdrawUSDCTxLinkClicked
   | StripeSessionCreationError
   | StripeSessionCreated
@@ -3221,9 +2816,7 @@ export type AllTrackingEvents =
   | ConnectWalletNewWalletStart
   | ConnectWalletNewWalletConnecting
   | ConnectWalletNewWalletConnected
-  | ConnectWalletDisconnected
   | ConnectWalletAlreadyAssociated
-  | ConnectWalletAssociationError
   | ConnectWalletError
   | ChatBlastCTAClicked
   | ChatBlastMessageSent
@@ -3256,15 +2849,12 @@ export type AllTrackingEvents =
   | AuthorizedAppRemoveError
   | ChatEntryPoint
   | ChatWebsocketError
-  | JupiterQuoteResponse
-  | JupiterQuoteRequest
   | ExportPrivateKeyLinkClicked
   | ExportPrivateKeyPageOpened
   | ExportPrivateKeyModalOpened
   | ExportPrivateKeyPublicAddressCopied
   | ExportPrivateKeyPrivateKeyCopied
   | ManagerModeSwitchAccount
-  | ManagerModeInviteManager
   | ManagerModeAcceptInvite
   | ManagerModeCancelInvite
   | ManagerModeRejectInvite
@@ -3291,7 +2881,6 @@ export type AllTrackingEvents =
   | CommentsLoadMoreComments
   | CommentsLoadNewComments
   | CommentsShowReplies
-  | CommentsLoadMoreReplies
   | CommentsHideReplies
   | CommentsApplySort
   | CommentsClickCommentStat
@@ -3320,9 +2909,6 @@ export type AllTrackingEvents =
   | RemixContestView
   | RemixContestEnter
   | RemixContestViewSubmissions
-  | AndroidAppRestartHeartbeat
-  | AndroidAppRestartStale
-  | AndroidAppRestartForceQuit
   | LaunchpadSplashGetStarted
   | LaunchpadHasExistingFanClub
   | LaunchpadSplashLearnMoreClicked
@@ -3333,9 +2919,6 @@ export type AllTrackingEvents =
   | LaunchpadCoinCreationStarted
   | LaunchpadCoinCreationSuccess
   | LaunchpadCoinCreationFailure
-  | LaunchpadFirstBuyStarted
-  | LaunchpadFirstBuySuccess
-  | LaunchpadFirstBuyFailure
   | LaunchpadFirstBuyRetry
   | LaunchpadFormInputChange
   | LaunchpadFormBack

--- a/packages/mobile/src/store/sign-up/sagas/watchSignUpSucceededSaga.ts
+++ b/packages/mobile/src/store/sign-up/sagas/watchSignUpSucceededSaga.ts
@@ -16,18 +16,8 @@ function* handleSignUpSucceeded() {
   const emailField = yield* select(getEmailField)
   const handleField = yield* select(getHandleField)
 
-  // Record both CREATE_ACCOUNT_COMPLETE_CREATING and
-  // CREATE_ACCOUNT_FINISH events
-
   yield put(
     make(EventNames.CREATE_ACCOUNT_COMPLETE_CREATING, {
-      emailAddress: emailField.value,
-      handle: handleField.value
-    })
-  )
-
-  yield put(
-    make(EventNames.CREATE_ACCOUNT_FINISH, {
       emailAddress: emailField.value,
       handle: handleField.value
     })


### PR DESCRIPTION
Removes ~45 zero-callsite event definitions: legacy OAuth flows, dead create-account stubs, wAUDIO transfer events, abandoned Social Proof feature, playlist library UI events, performance instrumentation that never shipped, and more. Follows up on #14304.