### PR TITLE
fix(contests): show skeletons only until feature flag resolves

### DIFF
--- a/packages/web/src/pages/contests-page/ContestsPage.tsx
+++ b/packages/web/src/pages/contests-page/ContestsPage.tsx
@@ -53,7 +53,7 @@ export const ContestsPage = () => {
     isFetchingNextPage
   } = useAllRemixContests(
     { pageSize: PAGE_SIZE },
-    { enabled: isContestsPageEnabled }
+    { enabled: !isFlagLoaded || isContestsPageEnabled }
   )
 
   const getScrollParent = useCallback(


### PR DESCRIPTION
## Summary
- Contests page disabled its `useAllRemixContests` query while `useFeatureFlag(CONTESTS).isEnabled` was still `undefined` during Optimizely's ~14s cold-load. Disabled queries report `isPending: true`, so the skeleton state stayed on screen indefinitely on first paint.
- Fix: start the query optimistically before the flag resolves by gating `enabled` on `!isFlagLoaded || isContestsPageEnabled`. The existing `<Navigate to='/' />` continues to redirect once the flag loads as `false`, so users without access still can't see contest data.

## Test plan
- [ ] Cold-load `/contests` with Optimizely throttled — verify contest cards render as soon as the API responds rather than waiting on the flag.
- [ ] Toggle the `CONTESTS` flag off — verify the page still redirects to `/` after the flag resolves.
- [ ] Flag on, no contests in response — verify empty state still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)