### PR TITLE
feat(feed): replace chronological filter pills with filter button

### DIFF
--- a/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
+++ b/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
@@ -115,24 +115,14 @@ export const ArtistRecommendations = forwardRef<
   // Follow/Unfollow listeners
   const handleFollowAll = useCallback(() => {
     suggestedArtists.forEach((a) => {
-      dispatch(
-        socialActions.followUser(
-          a.user_id,
-          FollowSource.USER_LIST
-        )
-      )
+      dispatch(socialActions.followUser(a.user_id, FollowSource.USER_LIST))
     })
     setHasFollowedAll(true)
   }, [dispatch, suggestedArtists])
 
   const handleUnfollowAll = useCallback(() => {
     suggestedArtists.forEach((a) => {
-      dispatch(
-        socialActions.unfollowUser(
-          a.user_id,
-          FollowSource.USER_LIST
-        )
-      )
+      dispatch(socialActions.unfollowUser(a.user_id, FollowSource.USER_LIST))
     })
     setHasFollowedAll(false)
   }, [dispatch, suggestedArtists])

--- a/packages/web/src/pages/feed-page/components/FeedFilters.tsx
+++ b/packages/web/src/pages/feed-page/components/FeedFilters.tsx
@@ -1,7 +1,7 @@
-import { ChangeEvent, useCallback } from 'react'
+import { useCallback } from 'react'
 
 import { FeedFilter } from '@audius/common/models'
-import { Flex, SelectablePill } from '@audius/harmony'
+import { FilterButton } from '@audius/harmony'
 
 type FeedFiltersProps = {
   currentFilter: FeedFilter
@@ -14,16 +14,10 @@ const messages = {
   reposts: 'Reposts'
 }
 
-const filterToLabel: Record<FeedFilter, string> = {
-  [FeedFilter.ALL]: messages.allPosts,
-  [FeedFilter.ORIGINAL]: messages.originalPosts,
-  [FeedFilter.REPOST]: messages.reposts
-}
-
-const filters: FeedFilter[] = [
-  FeedFilter.ALL,
-  FeedFilter.ORIGINAL,
-  FeedFilter.REPOST
+const filterOptions = [
+  { label: messages.allPosts, value: FeedFilter.ALL },
+  { label: messages.originalPosts, value: FeedFilter.ORIGINAL },
+  { label: messages.reposts, value: FeedFilter.REPOST }
 ]
 
 export const FeedFilters = ({
@@ -31,25 +25,19 @@ export const FeedFilters = ({
   onSelectFilter
 }: FeedFiltersProps) => {
   const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      onSelectFilter(e.target.value as FeedFilter)
+    (value: string) => {
+      onSelectFilter(value as FeedFilter)
     },
     [onSelectFilter]
   )
 
   return (
-    <Flex gap='s' role='radiogroup' onChange={handleChange} pb='l'>
-      {filters.map((filter) => (
-        <SelectablePill
-          name='feed-filter'
-          key={filter}
-          type='radio'
-          value={filter}
-          label={filterToLabel[filter]}
-          isSelected={currentFilter === filter}
-          size='small'
-        />
-      ))}
-    </Flex>
+    <FilterButton
+      label={messages.allPosts}
+      value={currentFilter}
+      variant='replaceLabel'
+      onChange={handleChange}
+      options={filterOptions}
+    />
   )
 }

--- a/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
@@ -114,15 +114,15 @@ const FeedPageContent = ({ containerRef }: FeedPageContentProps) => {
       icon={IconFeed}
       primary={messages.feedHeaderTitle}
       rightDecorator={
-        <FeedTabs currentTab={feedTab} onSelectTab={onSelectTab} />
-      }
-      bottomBar={
-        isForYou ? null : (
-          <FeedFilters
-            currentFilter={feedFilter}
-            onSelectFilter={onSelectFilter}
-          />
-        )
+        <Flex gap='s' alignItems='center'>
+          <FeedTabs currentTab={feedTab} onSelectTab={onSelectTab} />
+          {isForYou ? null : (
+            <FeedFilters
+              currentFilter={feedFilter}
+              onSelectFilter={onSelectFilter}
+            />
+          )}
+        </Flex>
       }
     />
   )

--- a/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
@@ -113,7 +113,7 @@ const FeedPageMobileContent = ({
   useEffect(() => {
     setHeader(
       <Header title={messages.title} className={styles.header}>
-        <Flex direction='column' gap='s' alignItems='center'>
+        <Flex gap='s' alignItems='center' justifyContent='center'>
           <FeedTabs currentTab={feedTab} onSelectTab={handleSelectTab} />
           {isForYou ? null : (
             <FeedFilters


### PR DESCRIPTION
## Summary
- Replace the row of sub-pills (`All Posts` / `Original Posts` / `Reposts`) below the Chronological feed tab with a single dropdown filter button rendered to the right of the For You / Chronological tabs — matching the pattern used on the trending page.
- The filter button is hidden when the For You tab is active.
- Applies to both desktop and mobile-web feed headers.

## Test plan
- [ ] On desktop, open the feed page → confirm the filter pills no longer appear below the tab bar.
- [ ] On desktop, with the Chronological tab selected → confirm a filter dropdown appears next to the tabs with `All Posts`, `Original Posts`, `Reposts` options and changes the lineup as expected.
- [ ] On desktop, switch to the For You tab → confirm the filter button is hidden.
- [ ] On mobile-web, repeat the same checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)