### PR TITLE
fix: mobile contest followers list shows blank

### DIFF
--- a/packages/common/src/api/tan-query/events/useEventFollowers.ts
+++ b/packages/common/src/api/tan-query/events/useEventFollowers.ts
@@ -40,7 +40,6 @@ export const useEventFollowers = (
 
   const queryRes = useQuery({
     queryKey: getEventFollowersQueryKey({ eventId, limit }),
-    enabled: options?.enabled !== false && !!eventId,
     queryFn: async (): Promise<ID[]> => {
       if (!eventId) return []
       try {
@@ -63,7 +62,8 @@ export const useEventFollowers = (
         return []
       }
     },
-    ...options
+    ...options,
+    enabled: !!eventId && (options?.enabled ?? true)
   })
 
   const { data: users } = useUsers(queryRes.data)


### PR DESCRIPTION
## Summary

- The `enabled` option in `useEventFollowers` was placed BEFORE the `...options` spread, so any caller passing an explicit `enabled` (e.g. `ContestFollowersModal` with `{ enabled: isOpen }`) silently overrode the `!!eventId` guard.
- Moved the `enabled` line AFTER the spread and combined the eventId guard with the caller's value: `enabled: !!eventId && (options?.enabled ?? true)`. The eventId check now always wins, so the query can never run with a null event id.

## Test plan

- [ ] Open a remix contest page on mobile
- [ ] Tap the "Followers (N)" card to push the dedicated followers screen
- [ ] Confirm the followers list renders (avatars + handles) instead of staying blank
- [ ] Confirm the avatar pile on the contest details tab still renders
- [ ] On web, open the contest followers modal and confirm it still loads correctly (caller passes `{ enabled: isOpen }`)
- [ ] Follow / unfollow an event and confirm the avatar pile updates (existing invalidation path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)