### PR TITLE
feat(web): bulk track actions toolbar with select-all, copy URLs, remove, undo/redo

### DIFF
--- a/packages/web/src/components/collection/desktop/edit-mode/tracks/TrackBulkActionsBar.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/tracks/TrackBulkActionsBar.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useMemo } from 'react'
+
+import { useCollection, useTracks } from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { cacheCollectionsActions, toastActions } from '@audius/common/store'
+import {
+  Button,
+  Flex,
+  IconCopy,
+  IconTrash,
+  Text,
+  useTheme
+} from '@audius/harmony'
+import { useDispatch } from 'react-redux'
+
+import { usePlaylistEditMode } from '../PlaylistEditModeContext'
+
+import { useTrackHistoryContext } from './TrackHistoryContext'
+import { useTrackSelection } from './TrackSelectionContext'
+
+const { removeTrackFromPlaylist, addTrackToPlaylist } = cacheCollectionsActions
+const { toast } = toastActions
+
+const messages = {
+  selected: (n: number) => `${n} selected`,
+  copy: 'Copy URLs',
+  remove: 'Remove',
+  clear: 'Clear',
+  selectAll: 'Select all',
+  undo: 'Undo',
+  redo: 'Redo',
+  copiedOne: 'Copied 1 track URL to clipboard',
+  copiedMany: (n: number) => `Copied ${n} track URLs to clipboard`,
+  copyFailed: 'Could not copy URLs to clipboard',
+  removed: (n: number) => (n === 1 ? 'Removed 1 track' : `Removed ${n} tracks`)
+}
+
+type Props = {
+  collectionId: ID
+  orderedTrackIds: ID[]
+}
+
+export const TrackBulkActionsBar = (props: Props) => {
+  const { collectionId, orderedTrackIds } = props
+  const dispatch = useDispatch()
+  const { color } = useTheme()
+  const editMode = usePlaylistEditMode()
+  const selection = useTrackSelection()
+  const history = useTrackHistoryContext()
+
+  const { data: collection } = useCollection(collectionId)
+  const selectedIds = useMemo(
+    () => orderedTrackIds.filter((id) => selection.isSelected(id)),
+    [orderedTrackIds, selection]
+  )
+  const { data: selectedTracks } = useTracks(selectedIds)
+
+  const copyUrls = useCallback(async () => {
+    if (!selectedTracks?.length) return
+    const origin =
+      typeof window !== 'undefined'
+        ? window.location.origin
+        : 'https://audius.co'
+    const urls = selectedTracks
+      .map((t) => (t?.permalink ? `${origin}${t.permalink}` : null))
+      .filter((u): u is string => !!u)
+      .join('\n')
+    try {
+      await navigator.clipboard.writeText(urls)
+      dispatch(
+        toast({
+          content:
+            urls.split('\n').length === 1
+              ? messages.copiedOne
+              : messages.copiedMany(urls.split('\n').length)
+        })
+      )
+    } catch {
+      dispatch(toast({ content: messages.copyFailed }))
+    }
+  }, [dispatch, selectedTracks])
+
+  const removeSelected = useCallback(() => {
+    if (!collection) return
+    const trackIds = selectedIds
+    if (trackIds.length === 0) return
+    // Record each removal in history so it can be undone.
+    trackIds.forEach((trackId) => {
+      const entry = collection.playlist_contents.track_ids.find(
+        (t) => t.track === trackId
+      )
+      if (!entry) return
+      const index = collection.playlist_contents.track_ids.findIndex(
+        (t) => t.track === trackId && t.time === entry.time
+      )
+      const timestamp = entry.metadata_time ?? entry.time
+      history.push({ type: 'remove', trackId, index, timestamp })
+      dispatch(removeTrackFromPlaylist(trackId, collectionId, timestamp))
+    })
+    dispatch(toast({ content: messages.removed(trackIds.length) }))
+    selection.clear()
+  }, [collection, collectionId, dispatch, history, selectedIds, selection])
+
+  const handleUndo = useCallback(() => {
+    history.undo((inverse) => {
+      if (inverse.type === 'add') {
+        dispatch(
+          addTrackToPlaylist(inverse.trackId, collectionId, { silent: true })
+        )
+      }
+    })
+  }, [collectionId, dispatch, history])
+
+  const handleRedo = useCallback(() => {
+    history.redo()
+  }, [history])
+
+  // Keyboard shortcuts: only active while in edit mode
+  useEffect(() => {
+    if (!editMode.isEditMode || editMode.collectionId !== collectionId) return
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      const isInputFocused =
+        target &&
+        ['INPUT', 'TEXTAREA'].includes(target.tagName) &&
+        !target.dataset.bulkActions
+      if (isInputFocused) return
+      const mod = e.metaKey || e.ctrlKey
+      if (mod && e.key.toLowerCase() === 'a') {
+        e.preventDefault()
+        selection.selectAll(orderedTrackIds)
+        return
+      }
+      if (mod && e.key.toLowerCase() === 'z' && !e.shiftKey) {
+        e.preventDefault()
+        handleUndo()
+        return
+      }
+      if (
+        (mod && e.key.toLowerCase() === 'z' && e.shiftKey) ||
+        (mod && e.key.toLowerCase() === 'y')
+      ) {
+        e.preventDefault()
+        handleRedo()
+        return
+      }
+      if (e.key === 'Escape') {
+        if (selection.count > 0) {
+          e.preventDefault()
+          selection.clear()
+        }
+      }
+      if (
+        (e.key === 'Delete' || e.key === 'Backspace') &&
+        selection.count > 0
+      ) {
+        e.preventDefault()
+        removeSelected()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [
+    collectionId,
+    editMode.collectionId,
+    editMode.isEditMode,
+    handleRedo,
+    handleUndo,
+    orderedTrackIds,
+    removeSelected,
+    selection
+  ])
+
+  if (!editMode.isEditMode || editMode.collectionId !== collectionId) {
+    return null
+  }
+  if (selection.count === 0 && !history.canUndo && !history.canRedo) {
+    return null
+  }
+
+  return (
+    <Flex
+      data-bulk-actions
+      css={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 4,
+        backgroundColor: color.background.surface1,
+        borderBottom: `1px solid ${color.border.strong}`
+      }}
+      p='m'
+      gap='m'
+      alignItems='center'
+      justifyContent='space-between'
+    >
+      <Flex gap='m' alignItems='center'>
+        <Text variant='body' strength='strong'>
+          {messages.selected(selection.count)}
+        </Text>
+        {selection.count > 0 ? (
+          <Button variant='secondary' size='small' onClick={selection.clear}>
+            {messages.clear}
+          </Button>
+        ) : null}
+        <Button
+          variant='secondary'
+          size='small'
+          onClick={() => selection.selectAll(orderedTrackIds)}
+        >
+          {messages.selectAll}
+        </Button>
+      </Flex>
+      <Flex gap='m' alignItems='center'>
+        <Button
+          variant='secondary'
+          size='small'
+          iconLeft={IconCopy}
+          disabled={selection.count === 0}
+          onClick={copyUrls}
+        >
+          {messages.copy}
+        </Button>
+        <Button
+          variant='destructive'
+          size='small'
+          iconLeft={IconTrash}
+          disabled={selection.count === 0}
+          onClick={removeSelected}
+        >
+          {messages.remove}
+        </Button>
+        <Button
+          variant='secondary'
+          size='small'
+          disabled={!history.canUndo}
+          onClick={handleUndo}
+        >
+          {messages.undo}
+        </Button>
+        <Button
+          variant='secondary'
+          size='small'
+          disabled={!history.canRedo}
+          onClick={handleRedo}
+        >
+          {messages.redo}
+        </Button>
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/web/src/components/collection/desktop/edit-mode/tracks/TrackHistoryContext.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/tracks/TrackHistoryContext.tsx
@@ -1,0 +1,142 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+
+import { ID } from '@audius/common/models'
+import { cacheCollectionsActions, toastActions } from '@audius/common/store'
+import { useDispatch } from 'react-redux'
+
+const { addTrackToPlaylist, removeTrackFromPlaylist } = cacheCollectionsActions
+const { toast } = toastActions
+
+export type TrackHistoryEntry =
+  | {
+      type: 'remove'
+      trackId: ID
+      // best-effort original position; not used to re-insert into the same
+      // slot because the existing addTrackToPlaylist saga always appends.
+      index: number
+      // timestamp captured at the time of removal for the saga call.
+      timestamp: number
+    }
+  | {
+      type: 'add'
+      trackId: ID
+    }
+
+type TrackHistoryContextValue = {
+  canUndo: boolean
+  canRedo: boolean
+  push: (entry: TrackHistoryEntry) => void
+  undo: (applyInverse: (entry: TrackHistoryEntry) => void) => void
+  redo: () => void
+}
+
+const TrackHistoryContext = createContext<TrackHistoryContextValue | null>(null)
+
+type ProviderProps = {
+  collectionId?: ID
+  children: ReactNode
+}
+
+const messages = {
+  noMoreUndo: 'Nothing to undo',
+  noMoreRedo: 'Nothing to redo'
+}
+
+export const TrackHistoryProvider = ({
+  collectionId,
+  children
+}: ProviderProps) => {
+  const dispatch = useDispatch()
+  const undoStackRef = useRef<TrackHistoryEntry[]>([])
+  const redoStackRef = useRef<TrackHistoryEntry[]>([])
+  const [, force] = useState(0)
+  const bump = useCallback(() => force((v) => v + 1), [])
+
+  const push = useCallback(
+    (entry: TrackHistoryEntry) => {
+      undoStackRef.current.push(entry)
+      redoStackRef.current = []
+      bump()
+    },
+    [bump]
+  )
+
+  const undo = useCallback(
+    (applyInverse: (entry: TrackHistoryEntry) => void) => {
+      const entry = undoStackRef.current.pop()
+      if (!entry) {
+        dispatch(toast({ content: messages.noMoreUndo }))
+        return
+      }
+      redoStackRef.current.push(entry)
+      bump()
+      const inverse: TrackHistoryEntry =
+        entry.type === 'remove'
+          ? { type: 'add', trackId: entry.trackId }
+          : { type: 'remove', trackId: entry.trackId, index: -1, timestamp: 0 }
+      applyInverse(inverse)
+    },
+    [bump, dispatch]
+  )
+
+  const redo = useCallback(() => {
+    const entry = redoStackRef.current.pop()
+    if (!entry) {
+      dispatch(toast({ content: messages.noMoreRedo }))
+      return
+    }
+    undoStackRef.current.push(entry)
+    bump()
+    if (!collectionId) return
+    if (entry.type === 'remove') {
+      dispatch(
+        removeTrackFromPlaylist(entry.trackId, collectionId, entry.timestamp)
+      )
+    } else if (entry.type === 'add') {
+      dispatch(
+        addTrackToPlaylist(entry.trackId, collectionId, { silent: true })
+      )
+    }
+  }, [bump, collectionId, dispatch])
+
+  const value = useMemo<TrackHistoryContextValue>(
+    () => ({
+      canUndo: undoStackRef.current.length > 0,
+      canRedo: redoStackRef.current.length > 0,
+      push,
+      undo,
+      redo
+    }),
+    // Intentionally include bump tick via undoStackRef.current.length read
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [push, undo, redo, undoStackRef.current.length, redoStackRef.current.length]
+  )
+
+  return (
+    <TrackHistoryContext.Provider value={value}>
+      {children}
+    </TrackHistoryContext.Provider>
+  )
+}
+
+export const useTrackHistoryContext = (): TrackHistoryContextValue => {
+  const ctx = useContext(TrackHistoryContext)
+  if (!ctx) {
+    return {
+      canUndo: false,
+      canRedo: false,
+      push: () => {},
+      undo: () => {},
+      redo: () => {}
+    }
+  }
+  return ctx
+}

--- a/packages/web/src/components/collection/desktop/edit-mode/tracks/TrackSelectionContext.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/tracks/TrackSelectionContext.tsx
@@ -1,0 +1,109 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+
+import { ID } from '@audius/common/models'
+
+type SelectionContextValue = {
+  selected: Set<ID>
+  count: number
+  isSelected: (id: ID) => boolean
+  toggle: (id: ID, index: number, opts?: { shift?: boolean }) => void
+  selectAll: (ids: ID[]) => void
+  clear: () => void
+  setSelected: (next: Set<ID>) => void
+}
+
+const TrackSelectionContext = createContext<SelectionContextValue | null>(null)
+
+type ProviderProps = {
+  orderedIds: ID[]
+  children: ReactNode
+}
+
+export const TrackSelectionProvider = ({
+  orderedIds,
+  children
+}: ProviderProps) => {
+  const [selected, setSelectedState] = useState<Set<ID>>(new Set())
+  const lastIndexRef = useRef<number | null>(null)
+
+  const setSelected = useCallback((next: Set<ID>) => {
+    setSelectedState(new Set(next))
+  }, [])
+
+  const isSelected = useCallback((id: ID) => selected.has(id), [selected])
+
+  const toggle = useCallback<SelectionContextValue['toggle']>(
+    (id, index, opts) => {
+      setSelectedState((prev) => {
+        const next = new Set(prev)
+        if (opts?.shift && lastIndexRef.current !== null) {
+          const [a, b] = [lastIndexRef.current, index].sort((x, y) => x - y)
+          for (let i = a; i <= b; i += 1) {
+            const sliceId = orderedIds[i]
+            if (sliceId !== undefined) next.add(sliceId)
+          }
+        } else if (next.has(id)) {
+          next.delete(id)
+        } else {
+          next.add(id)
+        }
+        lastIndexRef.current = index
+        return next
+      })
+    },
+    [orderedIds]
+  )
+
+  const selectAll = useCallback((ids: ID[]) => {
+    setSelectedState(new Set(ids))
+  }, [])
+
+  const clear = useCallback(() => {
+    setSelectedState(new Set())
+    lastIndexRef.current = null
+  }, [])
+
+  const value = useMemo<SelectionContextValue>(
+    () => ({
+      selected,
+      count: selected.size,
+      isSelected,
+      toggle,
+      selectAll,
+      clear,
+      setSelected
+    }),
+    [selected, isSelected, toggle, selectAll, clear, setSelected]
+  )
+
+  return (
+    <TrackSelectionContext.Provider value={value}>
+      {children}
+    </TrackSelectionContext.Provider>
+  )
+}
+
+export const useTrackSelection = (): SelectionContextValue => {
+  const ctx = useContext(TrackSelectionContext)
+  if (!ctx) {
+    // Safe no-op fallback for usage outside the provider.
+    return {
+      selected: new Set(),
+      count: 0,
+      isSelected: () => false,
+      toggle: () => {},
+      selectAll: () => {},
+      clear: () => {},
+      setSelected: () => {}
+    }
+  }
+  return ctx
+}

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -24,6 +24,9 @@ import { CollectionDogEar } from 'components/collection'
 import { CollectionHeader } from 'components/collection/desktop/CollectionHeader'
 import { PlaylistEditModeBar } from 'components/collection/desktop/edit-mode/PlaylistEditModeBar'
 import { PlaylistEditModeProvider } from 'components/collection/desktop/edit-mode/PlaylistEditModeContext'
+import { TrackBulkActionsBar } from 'components/collection/desktop/edit-mode/tracks/TrackBulkActionsBar'
+import { TrackHistoryProvider } from 'components/collection/desktop/edit-mode/tracks/TrackHistoryContext'
+import { TrackSelectionProvider } from 'components/collection/desktop/edit-mode/tracks/TrackSelectionContext'
 import FilterInput from 'components/filter-input/FilterInput'
 import Page from 'components/page/Page'
 import { SuggestedTracks } from 'components/suggested-tracks'
@@ -300,92 +303,108 @@ const CollectionPage = ({ type }: CollectionPageProps) => {
   ) : null
 
   const collectionMessages = getMessages(isAlbum ? 'album' : 'playlist')
+  const orderedTrackIds = dataSource
+    .map((t: CollectionTrack) => t.track_id)
+    .filter((id): id is number => typeof id === 'number')
   return (
     <PlaylistEditModeProvider
       collectionId={playlistId ?? undefined}
       isOwner={isOwner}
     >
-      <Page
-        title={title}
-        description={pageDescription}
-        canonicalUrl={canonicalUrl}
-        structuredData={structuredData}
-        entityType='collection'
-        hashId={playlistId ? Id.parse(playlistId) : undefined}
-        containerClassName={styles.pageContainer}
-        contentClassName={styles.pageContent}
-        fromOpacity={1}
-        scrollableSearch
-      >
-        <Paper column mb='unit-10' border='default'>
-          <CollectionDogEar collectionId={playlistId ?? 0} borderOffset={0} />
-          <div className={styles.topSectionWrapper}>{topSection}</div>
-          {!pageLoading && isEmpty ? (
-            <EmptyContent
-              isOwner={isOwner}
-              isAlbum={isAlbum}
-              text={customEmptyText}
-            />
-          ) : !pageLoading &&
-            tracks.status === Status.SUCCESS &&
-            dataSource.length === 0 ? (
-            <NoSearchResultsContent />
-          ) : (
-            <div className={styles.tableWrapper}>
-              <TracksTable
-                // @ts-ignore
-                columns={tracksTableColumns}
-                wrapperClassName={styles.tracksTableWrapper}
-                key={playlistName}
-                scrollRef={mainContentRef}
-                loading={pageLoading}
-                userId={accountUserId}
-                playing={playing}
-                activeIndex={activeIndex}
-                data={dataSource}
-                onClickRow={onClickRow}
-                onClickFavorite={toggleSaveTrack}
-                onClickRemove={isOwner ? onClickRemove : undefined}
-                onClickRepost={onClickRepostTrack}
-                onClickPurchase={openPurchaseModal}
-                onReorder={onReorderTracks}
-                onSort={onSortTracks}
-                trackActionsHeader={trackTableHeaderFilter}
-                showArtistInTrackNameColumn={!isAlbum}
-                responsiveColumns={
-                  isAlbum
-                    ? RESPONSIVE_TABLE_POLICIES.collectionAlbumTracks
-                    : RESPONSIVE_TABLE_POLICIES.collectionPlaylistTracks
-                }
-                isReorderable={
-                  accountUserId !== null &&
-                  accountUserId === playlistOwnerId &&
-                  allowReordering
-                }
-                removeText={`${collectionMessages.remove} ${
-                  isAlbum
-                    ? collectionMessages.type.album
-                    : collectionMessages.type.playlist
-                }`}
-                isAlbumPage={isAlbum}
-                isAlbumPremium={
-                  !!metadata && 'is_stream_gated' in metadata
-                    ? metadata?.is_stream_gated
-                    : false
-                }
+      <TrackHistoryProvider collectionId={playlistId ?? undefined}>
+        <TrackSelectionProvider orderedIds={orderedTrackIds}>
+          <Page
+            title={title}
+            description={pageDescription}
+            canonicalUrl={canonicalUrl}
+            structuredData={structuredData}
+            entityType='collection'
+            hashId={playlistId ? Id.parse(playlistId) : undefined}
+            containerClassName={styles.pageContainer}
+            contentClassName={styles.pageContent}
+            fromOpacity={1}
+            scrollableSearch
+          >
+            <Paper column mb='unit-10' border='default'>
+              <CollectionDogEar
+                collectionId={playlistId ?? 0}
+                borderOffset={0}
               />
-            </div>
-          )}
-        </Paper>
+              <div className={styles.topSectionWrapper}>{topSection}</div>
+              {playlistId != null ? (
+                <TrackBulkActionsBar
+                  collectionId={playlistId}
+                  orderedTrackIds={orderedTrackIds}
+                />
+              ) : null}
+              {!pageLoading && isEmpty ? (
+                <EmptyContent
+                  isOwner={isOwner}
+                  isAlbum={isAlbum}
+                  text={customEmptyText}
+                />
+              ) : !pageLoading &&
+                tracks.status === Status.SUCCESS &&
+                dataSource.length === 0 ? (
+                <NoSearchResultsContent />
+              ) : (
+                <div className={styles.tableWrapper}>
+                  <TracksTable
+                    // @ts-ignore
+                    columns={tracksTableColumns}
+                    wrapperClassName={styles.tracksTableWrapper}
+                    key={playlistName}
+                    scrollRef={mainContentRef}
+                    loading={pageLoading}
+                    userId={accountUserId}
+                    playing={playing}
+                    activeIndex={activeIndex}
+                    data={dataSource}
+                    onClickRow={onClickRow}
+                    onClickFavorite={toggleSaveTrack}
+                    onClickRemove={isOwner ? onClickRemove : undefined}
+                    onClickRepost={onClickRepostTrack}
+                    onClickPurchase={openPurchaseModal}
+                    onReorder={onReorderTracks}
+                    onSort={onSortTracks}
+                    trackActionsHeader={trackTableHeaderFilter}
+                    showArtistInTrackNameColumn={!isAlbum}
+                    responsiveColumns={
+                      isAlbum
+                        ? RESPONSIVE_TABLE_POLICIES.collectionAlbumTracks
+                        : RESPONSIVE_TABLE_POLICIES.collectionPlaylistTracks
+                    }
+                    isReorderable={
+                      accountUserId !== null &&
+                      accountUserId === playlistOwnerId &&
+                      allowReordering
+                    }
+                    removeText={`${collectionMessages.remove} ${
+                      isAlbum
+                        ? collectionMessages.type.album
+                        : collectionMessages.type.playlist
+                    }`}
+                    isAlbumPage={isAlbum}
+                    isAlbumPremium={
+                      !!metadata && 'is_stream_gated' in metadata
+                        ? metadata?.is_stream_gated
+                        : false
+                    }
+                  />
+                </div>
+              )}
+            </Paper>
 
-        {playlistId != null && isOwner && !isAlbum ? (
-          <Flex column gap='2xl' pv='2xl' w='100%'>
-            <Divider />
-            <SuggestedTracks collectionId={playlistId} />
-          </Flex>
-        ) : null}
-        <PlaylistEditModeBar />
-      </Page>
+            {playlistId != null && isOwner && !isAlbum ? (
+              <Flex column gap='2xl' pv='2xl' w='100%'>
+                <Divider />
+                <SuggestedTracks collectionId={playlistId} />
+              </Flex>
+            ) : null}
+            <PlaylistEditModeBar />
+          </Page>
+        </TrackSelectionProvider>
+      </TrackHistoryProvider>
     </PlaylistEditModeProvider>
   )
 }


### PR DESCRIPTION
## Summary

Adds a bulk track-curation toolbar to the playlist detail page when in edit mode (added in #14322), with multi-track selection, the bulk operations called out in the spec (copy URLs, remove), and an undo/redo stack for those operations.

Stacked on #14322 → #14321 → #14320 → #14319 → #14318.

## Implementation

- **`TrackSelectionProvider` + `useTrackSelection`**: a Set of selected track IDs plus a "last clicked index" ref. Toggle takes an `{ shift?: boolean }` option that fills in the range across an ordered id list — wired through but not yet hooked up to row clicks (see scope notes).
- **`TrackHistoryProvider` + `useTrackHistoryContext`**: separate undo/redo stacks for `remove` and `add` operations. Undoing a remove dispatches `addTrackToPlaylist(trackId, collectionId, { silent: true })` so it doesn't fire the per-track "Added track to playlist" toast; redo re-issues `removeTrackFromPlaylist`.
- **`TrackBulkActionsBar`** sticks to the top of the track table when edit mode is active. Shows the count of selected tracks and five bulk operations:
  - **Copy URLs** — writes `${origin}${permalink}` for each selected track to the clipboard via `navigator.clipboard.writeText`, with a toast summary ("Copied N track URLs to clipboard").
  - **Remove** — dispatches `removeTrackFromPlaylist` per selected id and pushes a `remove` history entry so each one is undoable.
  - **Undo / Redo** — replays inverse operations against the playlist.
  - **Select all / Clear** — convenience pair.
- **Keyboard shortcuts** (active while in edit mode and focus isn't in a text input):
  - `Cmd/Ctrl+A` → Select all tracks
  - `Cmd/Ctrl+Z` → Undo
  - `Cmd/Ctrl+Shift+Z` or `Cmd/Ctrl+Y` → Redo
  - `Escape` → Clear selection
  - `Delete` / `Backspace` → Remove selected
- The desktop `CollectionPage` is wrapped in both providers alongside the existing edit-mode provider; the bar renders only when there's a selection or when the history stacks are non-empty.

## Scope notes / follow-ups

- Per-row checkbox UI and shift-range row-click select require deeper changes to the existing `TracksTable` (react-table) component and are deferred. Users can currently select all via the bar or `Cmd/Ctrl+A` and operate on the full set; future PR will add row-level selection.
- Undo of a `remove` re-adds the track but uses the existing `addTrackToPlaylist` saga, which appends rather than reinserting at the original index. The history entry already captures the original index for when the saga grows the option to slot a track at a specific position.
- Multi-row drag is similarly deferred to a follow-up that introduces row-level checkbox UI.

## Test plan

- [ ] Enter edit mode on a playlist you own (✏️ in the action row).
- [ ] Press `Cmd+A` → all tracks select; bar shows "N selected".
- [ ] Click **Copy URLs** → clipboard contains one URL per line; toast confirms count.
- [ ] Click **Remove** → all selected tracks are removed; selection clears; single "Removed N tracks" toast.
- [ ] Click **Undo** → tracks reappear at the end of the playlist (note: not original positions — see scope notes).
- [ ] Click **Redo** → tracks are removed again.
- [ ] In a focused TextInput in the header, press `Cmd+A` → selects text inside the input, does NOT select tracks.
- [ ] `Escape` clears selection.
- [ ] `Delete` removes when there's a selection.
- [ ] Visit a playlist you don't own → bar never appears (not in edit mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)