### PR TITLE
ci(mobile): cache deps + parallelize OTA + decouple lint to speed up OTA ~3x

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -28,10 +28,74 @@ env:
   NODE_VERSION: '22.21.1'
 
 jobs:
-  # Initialize: Install dependencies, lint & typecheck
-  mobile-init:
-    name: Mobile Init (Install, Lint & Typecheck)
+  # Install dependencies and warm the node_modules cache shared by every downstream job.
+  # Kept separate from lint/typecheck so OTA + build jobs don't wait on verify (~3.5 min).
+  mobile-install:
+    name: Mobile Install
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Create concatenated patch file
+        id: patch-file
+        run: |
+          ls -d -- packages/*/patches/*.patch 2>/dev/null | xargs cat > combined-patch-file.txt || touch combined-patch-file.txt
+          echo "patch_checksum=$(sha256sum combined-patch-file.txt | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/mobile/node_modules
+            packages/common/node_modules
+            packages/libs/node_modules
+            packages/libs/dist
+            packages/sdk/node_modules
+            packages/sdk/dist
+            packages/harmony/node_modules
+            packages/dotenv-linter/bin
+          key: npm-cache-mobile-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-${{ steps.patch-file.outputs.patch_checksum }}
+          restore-keys: |
+            npm-cache-mobile-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-
+            npm-cache-mobile-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+
+      - name: Install dependencies
+        env:
+          CI: true
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: |
+          if [[ -d node_modules ]]; then
+            echo "Using cached node_modules, running postinstall..."
+            npm run postinstall
+            # Ensure dotenv-linter binary is installed (install script downloads it)
+            if [[ ! -f packages/dotenv-linter/bin/dotenv-linter ]]; then
+              echo "dotenv-linter binary missing, running install script..."
+              (cd packages/dotenv-linter && npm run install)
+            fi
+          else
+            echo "No cache found, running fresh install..."
+            # Clear npm cache to avoid EEXIST conflicts
+            npm cache clean --force || true
+            # Try npm ci first, fallback to npm install if lock file is out of sync
+            npm ci --prefer-offline || npm install --prefer-offline
+          fi
+
+  # Verify: lint & typecheck. Runs in parallel with OTA/build jobs — failure still fails the workflow,
+  # but does not block the OTA publish on the critical path.
+  mobile-verify:
+    name: Mobile Verify (Lint & Typecheck)
+    runs-on: ubuntu-latest
+    needs: mobile-install
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -81,16 +145,13 @@ jobs:
           if [[ -d node_modules ]]; then
             echo "Using cached node_modules, running postinstall..."
             npm run postinstall
-            # Ensure dotenv-linter binary is installed (install script downloads it)
             if [[ ! -f packages/dotenv-linter/bin/dotenv-linter ]]; then
               echo "dotenv-linter binary missing, running install script..."
               (cd packages/dotenv-linter && npm run install)
             fi
           else
             echo "No cache found, running fresh install..."
-            # Clear npm cache to avoid EEXIST conflicts
             npm cache clean --force || true
-            # Try npm ci first, fallback to npm install if lock file is out of sync
             npm ci --prefer-offline || npm install --prefer-offline
           fi
 
@@ -100,7 +161,7 @@ jobs:
   mobile-version-check:
     name: Mobile Version Change Check
     runs-on: ubuntu-latest
-    needs: mobile-init
+    needs: mobile-install
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     outputs:
       current_version: ${{ steps.version-check.outputs.current_version }}
@@ -129,12 +190,17 @@ jobs:
             echo "version_unchanged=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # OTA Release: publish JS bundle updates when native app version is unchanged
+  # OTA Release: publish JS bundle updates when native app version is unchanged.
+  # Matrixed over platforms so iOS and Android publish in parallel.
   mobile-ota-release:
-    name: Mobile OTA Release (CodePush)
+    name: Mobile OTA Release (CodePush, ${{ matrix.platform }})
     runs-on: ubuntu-latest
-    needs: [mobile-init, mobile-version-check]
+    needs: [mobile-install, mobile-version-check]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.mobile-version-check.outputs.version_unchanged == 'true') || (github.event_name == 'workflow_dispatch' && (github.event.inputs.ota_channel == 'rc' || github.event.inputs.ota_channel == ''))
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -148,11 +214,48 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
+      - name: Create concatenated patch file
+        id: patch-file
+        run: |
+          ls -d -- packages/*/patches/*.patch 2>/dev/null | xargs cat > combined-patch-file.txt || touch combined-patch-file.txt
+          echo "patch_checksum=$(sha256sum combined-patch-file.txt | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/mobile/node_modules
+            packages/common/node_modules
+            packages/libs/node_modules
+            packages/libs/dist
+            packages/sdk/node_modules
+            packages/sdk/dist
+            packages/harmony/node_modules
+            packages/dotenv-linter/bin
+          key: npm-cache-mobile-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-${{ steps.patch-file.outputs.patch_checksum }}
+          restore-keys: |
+            npm-cache-mobile-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-
+            npm-cache-mobile-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+
       - name: Install dependencies
         env:
           CI: true
           NODE_OPTIONS: --max-old-space-size=8192
-        run: npm ci --prefer-offline || npm install --prefer-offline
+        run: |
+          if [[ -d node_modules ]]; then
+            echo "Using cached node_modules, running postinstall..."
+            npm run postinstall
+            if [[ ! -f packages/dotenv-linter/bin/dotenv-linter ]]; then
+              echo "dotenv-linter binary missing, running install script..."
+              (cd packages/dotenv-linter && npm run install)
+            fi
+          else
+            echo "No cache found, running fresh install..."
+            npm cache clean --force || true
+            npm ci --prefer-offline || npm install --prefer-offline
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -170,7 +273,7 @@ jobs:
             echo "channel=rc" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish OTA updates (iOS + Android)
+      - name: Publish OTA update (${{ matrix.platform }})
         env:
           OTA_S3_BUCKET: ${{ secrets.OTA_S3_BUCKET }}
           OTA_S3_PREFIX: mobile-ota
@@ -185,32 +288,29 @@ jobs:
           OTA_APP_VERSION="${MAJOR}.${MINOR}.${OTA_PATCH}"
 
           cd packages/mobile
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ios --identifier "$OTA_CHANNEL" || true
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform android --identifier "$OTA_CHANNEL" || true
+          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ${{ matrix.platform }} --identifier "$OTA_CHANNEL" || true
 
           npx code-push release \
             --binary-version "$BINARY_VERSION" \
             --app-version "$OTA_APP_VERSION" \
-            --platform ios \
+            --platform ${{ matrix.platform }} \
             --identifier "$OTA_CHANNEL" \
             --entry-file index.js
 
-          npx code-push release \
-            --binary-version "$BINARY_VERSION" \
-            --app-version "$OTA_APP_VERSION" \
-            --platform android \
-            --identifier "$OTA_CHANNEL" \
-            --entry-file index.js
-
-  # OTA Release (Production): manual + environment approval gate
+  # OTA Release (Production): manual + environment approval gate.
+  # Matrixed over platforms so iOS and Android publish in parallel.
   mobile-ota-release-production:
-    name: Mobile OTA Release (Production, Approved)
+    name: Mobile OTA Release (Production, ${{ matrix.platform }})
     runs-on: ubuntu-latest
-    needs: [mobile-init, mobile-version-check]
+    needs: [mobile-install, mobile-version-check]
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.ota_channel == 'production'
     environment:
       name: mobile-production-ota
       url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -224,11 +324,48 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
+      - name: Create concatenated patch file
+        id: patch-file
+        run: |
+          ls -d -- packages/*/patches/*.patch 2>/dev/null | xargs cat > combined-patch-file.txt || touch combined-patch-file.txt
+          echo "patch_checksum=$(sha256sum combined-patch-file.txt | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/mobile/node_modules
+            packages/common/node_modules
+            packages/libs/node_modules
+            packages/libs/dist
+            packages/sdk/node_modules
+            packages/sdk/dist
+            packages/harmony/node_modules
+            packages/dotenv-linter/bin
+          key: npm-cache-mobile-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-${{ steps.patch-file.outputs.patch_checksum }}
+          restore-keys: |
+            npm-cache-mobile-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-
+            npm-cache-mobile-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+
       - name: Install dependencies
         env:
           CI: true
           NODE_OPTIONS: --max-old-space-size=8192
-        run: npm ci --prefer-offline || npm install --prefer-offline
+        run: |
+          if [[ -d node_modules ]]; then
+            echo "Using cached node_modules, running postinstall..."
+            npm run postinstall
+            if [[ ! -f packages/dotenv-linter/bin/dotenv-linter ]]; then
+              echo "dotenv-linter binary missing, running install script..."
+              (cd packages/dotenv-linter && npm run install)
+            fi
+          else
+            echo "No cache found, running fresh install..."
+            npm cache clean --force || true
+            npm ci --prefer-offline || npm install --prefer-offline
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -237,7 +374,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Publish OTA updates to production (iOS + Android)
+      - name: Publish OTA update to production (${{ matrix.platform }})
         env:
           OTA_S3_BUCKET: ${{ secrets.OTA_S3_BUCKET }}
           OTA_S3_PREFIX: mobile-ota
@@ -251,20 +388,12 @@ jobs:
           OTA_APP_VERSION="${MAJOR}.${MINOR}.${OTA_PATCH}"
 
           cd packages/mobile
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ios --identifier "$OTA_CHANNEL" || true
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform android --identifier "$OTA_CHANNEL" || true
+          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ${{ matrix.platform }} --identifier "$OTA_CHANNEL" || true
 
           npx code-push release \
             --binary-version "$BINARY_VERSION" \
             --app-version "$OTA_APP_VERSION" \
-            --platform ios \
-            --identifier "$OTA_CHANNEL" \
-            --entry-file index.js
-
-          npx code-push release \
-            --binary-version "$BINARY_VERSION" \
-            --app-version "$OTA_APP_VERSION" \
-            --platform android \
+            --platform ${{ matrix.platform }} \
             --identifier "$OTA_CHANNEL" \
             --entry-file index.js
 
@@ -272,7 +401,7 @@ jobs:
   mobile-build-upload-releasecandidate-ios:
     name: iOS Release Candidate Build & Upload
     runs-on: macos-15
-    needs: [mobile-init, mobile-version-check]
+    needs: [mobile-install, mobile-version-check]
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.mobile-version-check.outputs.version_changed == 'true'
     steps:
       - name: Checkout code
@@ -446,7 +575,7 @@ jobs:
   mobile-build-upload-releasecandidate-android:
     name: Android Release Candidate Build & Upload
     runs-on: ubuntu-latest
-    needs: [mobile-init, mobile-version-check]
+    needs: [mobile-install, mobile-version-check]
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.mobile-version-check.outputs.version_changed == 'true'
     steps:
       - name: Checkout code
@@ -662,7 +791,7 @@ jobs:
   mobile-build-upload-production-ios-main:
     name: iOS Production Build & Upload
     runs-on: macos-15
-    needs: [mobile-init, mobile-version-check]
+    needs: [mobile-install, mobile-version-check]
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.mobile-version-check.outputs.version_changed == 'true'
     environment:
       name: mobile-production-ios
@@ -823,7 +952,7 @@ jobs:
   mobile-build-upload-production-android-main:
     name: Android Production Build & Upload
     runs-on: ubuntu-latest
-    needs: [mobile-init, mobile-version-check]
+    needs: [mobile-install, mobile-version-check]
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.mobile-version-check.outputs.version_changed == 'true'
     environment:
       name: mobile-production-android


### PR DESCRIPTION
## Summary

Mobile OTA publish on merge-to-main takes **~21 min** today. This PR drops it to **~6-7 min** on the critical path with three changes to [`.github/workflows/mobile.yml`](.github/workflows/mobile.yml).

### 1. Cache `node_modules` in `mobile-ota-release(-production)` — ~5 min saved
The OTA job ran `npm ci` cold every time (5m37s on [run 25822024076](https://github.com/AudiusProject/apps/actions/runs/25822024076)). The install job 7 minutes earlier already has the right `actions/cache@v4` block — the OTA job was just missing it. Now restored from the same key; install drops to ~30s.

### 2. Matrix the OTA job over `[ios, android]` — ~5 min saved
The publish step ran iOS and Android `code-push release` calls sequentially in one step (10m9s). Now matrixed so the two platforms run as parallel matrix-runs of the same job. Each does its own Metro bundle + S3 upload. `fail-fast: false` so one platform's failure doesn't kill the other's upload.

### 3. Split `mobile-init` into `mobile-install` + `mobile-verify` — ~3 min saved on critical path
`mobile-init` previously did install (~30s) + lint/typecheck (~3m28s) in one job, and every downstream job (OTA + 4 build jobs) had to wait on the full 4m27s before starting.

- `mobile-install` — checkout + cache + install only (~1 min).
- `mobile-verify` — lint + typecheck, depends on `mobile-install`. Runs in parallel with all downstream jobs. Still fails the workflow if lint/types break, but no longer gates publish.

All `needs: [mobile-init, …]` references updated to `mobile-install`.

### New dependency graph

```
mobile-install (~1m)
├── mobile-verify (~3.5m)         ← runs in parallel, still gates workflow success
├── mobile-version-check (~10s)
│   ├── mobile-ota-release [ios]      ← parallel matrix run
│   ├── mobile-ota-release [android]  ← parallel matrix run
│   └── (native build jobs, gated on version bump as before)
```

Critical path on the hot path (JS-only merge, no version bump): ~1m install + ~10s version-check + ~5m OTA = **~6-7 min** wall-clock, vs. ~21 min before.

## Test plan

- [ ] YAML parses cleanly (verified locally with `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/mobile.yml'))\"`)
- [ ] On merge to `main` with no version bump:
  - [ ] `mobile-install` runs first and populates the node_modules cache
  - [ ] `mobile-verify` runs in parallel with `mobile-ota-release` (no longer gates it)
  - [ ] `mobile-ota-release` appears as two parallel matrix runs (`ios`, `android`)
  - [ ] Both matrix runs hit the node_modules cache (install step ~30s, not ~5min)
  - [ ] Both publish to S3 under `mobile-ota/bundles/{ios,android}/rc/…`
  - [ ] Total wall-clock for the run is ~6-7 min vs. the prior ~21 min
- [ ] On a version-bump merge, the native build jobs still run as before (they depend on `mobile-install` + `mobile-version-check`, same shape as before)
- [ ] `workflow_dispatch` with `ota_channel=production` still triggers the production OTA job (now matrixed)
- [ ] If lint/typecheck breaks on `main`, the workflow as a whole still fails (via `mobile-verify`) even though the OTA publish completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)