### PR TITLE
fix(mobile): commenting fails on tracks with zero existing comments

### DIFF
--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -172,21 +172,21 @@ const CommentDrawerContent = (props: {
     )
   }
 
-  // Empty state
-  if (!commentIds || !commentIds.length) {
-    return (
-      <Flex p='l'>
-        <NoComments />
-      </Flex>
-    )
-  }
-
+  // Always render BottomSheetFlatList (with ListEmptyComponent for the empty
+  // state) so the bottom sheet can handle keyboard avoidance and touch
+  // propagation correctly. Swapping in a plain <Flex> when there are zero
+  // comments breaks the footer composer's send button on a 0-comment track.
   return (
     <BottomSheetFlatList
       ref={commentListRef}
       data={commentIds}
       keyExtractor={(id) => id.toString()}
       ListHeaderComponent={<Box h='l' />}
+      ListEmptyComponent={
+        <Flex p='l'>
+          <NoComments />
+        </Flex>
+      }
       ListFooterComponent={
         <>
           {isLoadingMorePages ? (


### PR DESCRIPTION
## Summary

- Comment drawer was rendering a plain `<Flex><NoComments /></Flex>` for the empty state and only mounting a `BottomSheetFlatList` once at least one comment existed
- Inside Gorhom's BottomSheetModal, scrollable content must live inside a `BottomSheet*` component for keyboard avoidance + touch propagation to the footer composer to work
- On a 0-comment track, the send-button taps never reached the form's onSubmit handler — the comment couldn't be posted
- Fix: always render `BottomSheetFlatList`, move `NoComments` into `ListEmptyComponent` so bottom-sheet plumbing stays mounted in both states

## Root cause

`packages/mobile/src/components/comments/CommentDrawer.tsx` `CommentDrawerContent` had two return branches:

```tsx
if (!commentIds || !commentIds.length) {
  return <Flex p='l'><NoComments /></Flex>   // no BottomSheet wrapper
}
return <BottomSheetFlatList ... />            // proper wrapper
```

The plain `<Flex>` doesn't participate in Gorhom's gesture/keyboard system, so taps in the footer's `BottomSheetFooter` (the form) get eaten by the gesture recognizer instead of reaching the send button. Swapping the empty-state branch into a `ListEmptyComponent` keeps the `BottomSheetFlatList` mounted in both states and the send-button tap reaches the composer.

## Test plan

- [ ] Mobile: open a track with **zero comments** → tap the comment input → drawer opens → type a comment → tap send → comment appears optimistically (this is what was previously broken)
- [ ] Mobile: open a track with **existing comments** → post a new comment → comment appears optimistically (regression check)
- [ ] Mobile: open a 0-comment track → drawer shows the "Be the first to leave a comment" empty state inside the scroll area (visual regression check)
- [ ] Mobile: scroll behavior of the comment list with multiple comments still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)