### PR TITLE
fix(mobile): point SOLANA_RELAY_ENDPOINT to dedicated solana-relay host

### DIFF
--- a/packages/mobile/src/services/env/env.prod.ts
+++ b/packages/mobile/src/services/env/env.prod.ts
@@ -70,7 +70,7 @@ export const env: Env = {
   SOLANA_CLUSTER_ENDPOINT:
     'https://carolina-8qh733-fast-mainnet.helius-rpc.com',
   SOLANA_FEE_PAYER_ADDRESS: 'pqx3fvvh6b2eZBfLhTtQ5KxzU3CginmgGTmDCjk8TPP',
-  SOLANA_RELAY_ENDPOINT: 'https://discoveryprovider.audius.co',
+  SOLANA_RELAY_ENDPOINT: 'https://solana-relay.audius.engineering',
   SOLANA_TOKEN_PROGRAM_ADDRESS: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
   SOLANA_WEB3_CLUSTER: 'mainnet-beta',
   SUGGESTED_FOLLOW_HANDLES:


### PR DESCRIPTION
## Summary
- Mirrors the web prod change in e4a04e2815 (#14318-ish) for mobile.
- Switches `packages/mobile/src/services/env/env.prod.ts` from `https://discoveryprovider.audius.co` to `https://solana-relay.audius.engineering`, matching what `packages/web/src/services/env/env.prod.ts` already uses.

## Why
Web prod was already updated and confirmed working, but mobile was still hitting the old endpoint.

## Test plan
- [ ] Build and run mobile against prod; perform a Solana-relayed action (e.g. a tip, USDC purchase, or any other path that uses `SOLANA_RELAY_ENDPOINT`) and confirm requests hit `solana-relay.audius.engineering` and succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)