### PR TITLE
ci(mobile): collapse OTA matrix to single job with parallel code-push

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -191,16 +191,13 @@ jobs:
           fi
 
   # OTA Release: publish JS bundle updates when native app version is unchanged.
-  # Matrixed over platforms so iOS and Android publish in parallel.
+  # iOS and Android code-push run in parallel as background processes within
+  # one runner so the node_modules setup only happens once.
   mobile-ota-release:
-    name: Mobile OTA Release (CodePush, ${{ matrix.platform }})
+    name: Mobile OTA Release (CodePush)
     runs-on: ubuntu-latest
     needs: [mobile-install, mobile-version-check]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.mobile-version-check.outputs.version_unchanged == 'true') || (github.event_name == 'workflow_dispatch' && (github.event.inputs.ota_channel == 'rc' || github.event.inputs.ota_channel == ''))
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ios, android]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -273,13 +270,13 @@ jobs:
             echo "channel=rc" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish OTA update (${{ matrix.platform }})
+      - name: Publish OTA update (iOS + Android in parallel)
         env:
           OTA_S3_BUCKET: ${{ secrets.OTA_S3_BUCKET }}
           OTA_S3_PREFIX: mobile-ota
           OTA_PUBLIC_BASE_URL: https://download.audius.co/mobile-ota
         run: |
-          set -euo pipefail
+          set -uo pipefail
           BINARY_VERSION="${{ needs.mobile-version-check.outputs.current_version }}"
           OTA_CHANNEL="${{ steps.ota-channel.outputs.channel }}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BINARY_VERSION"
@@ -288,29 +285,49 @@ jobs:
           OTA_APP_VERSION="${MAJOR}.${MINOR}.${OTA_PATCH}"
 
           cd packages/mobile
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ${{ matrix.platform }} --identifier "$OTA_CHANNEL" || true
 
-          npx code-push release \
-            --binary-version "$BINARY_VERSION" \
-            --app-version "$OTA_APP_VERSION" \
-            --platform ${{ matrix.platform }} \
-            --identifier "$OTA_CHANNEL" \
-            --entry-file index.js
+          publish_platform() {
+            local platform="$1"
+            npx code-push create-history --binary-version "$BINARY_VERSION" --platform "$platform" --identifier "$OTA_CHANNEL" || true
+            npx code-push release \
+              --binary-version "$BINARY_VERSION" \
+              --app-version "$OTA_APP_VERSION" \
+              --platform "$platform" \
+              --identifier "$OTA_CHANNEL" \
+              --entry-file index.js
+          }
+
+          publish_platform ios > ios.log 2>&1 &
+          IOS_PID=$!
+          publish_platform android > android.log 2>&1 &
+          ANDROID_PID=$!
+
+          wait "$IOS_PID"; IOS_STATUS=$?
+          wait "$ANDROID_PID"; ANDROID_STATUS=$?
+
+          echo "::group::iOS code-push output"
+          cat ios.log
+          echo "::endgroup::"
+          echo "::group::Android code-push output"
+          cat android.log
+          echo "::endgroup::"
+
+          if [[ $IOS_STATUS -ne 0 || $ANDROID_STATUS -ne 0 ]]; then
+            echo "iOS exit: $IOS_STATUS, Android exit: $ANDROID_STATUS"
+            exit 1
+          fi
 
   # OTA Release (Production): manual + environment approval gate.
-  # Matrixed over platforms so iOS and Android publish in parallel.
+  # iOS and Android code-push run in parallel as background processes within
+  # one runner so the node_modules setup only happens once.
   mobile-ota-release-production:
-    name: Mobile OTA Release (Production, ${{ matrix.platform }})
+    name: Mobile OTA Release (Production)
     runs-on: ubuntu-latest
     needs: [mobile-install, mobile-version-check]
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.ota_channel == 'production'
     environment:
       name: mobile-production-ota
       url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ios, android]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -374,13 +391,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Publish OTA update to production (${{ matrix.platform }})
+      - name: Publish OTA update to production (iOS + Android in parallel)
         env:
           OTA_S3_BUCKET: ${{ secrets.OTA_S3_BUCKET }}
           OTA_S3_PREFIX: mobile-ota
           OTA_PUBLIC_BASE_URL: https://download.audius.co/mobile-ota
         run: |
-          set -euo pipefail
+          set -uo pipefail
           BINARY_VERSION="${{ needs.mobile-version-check.outputs.current_version }}"
           OTA_CHANNEL="production"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BINARY_VERSION"
@@ -388,14 +405,37 @@ jobs:
           OTA_APP_VERSION="${MAJOR}.${MINOR}.${OTA_PATCH}"
 
           cd packages/mobile
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ${{ matrix.platform }} --identifier "$OTA_CHANNEL" || true
 
-          npx code-push release \
-            --binary-version "$BINARY_VERSION" \
-            --app-version "$OTA_APP_VERSION" \
-            --platform ${{ matrix.platform }} \
-            --identifier "$OTA_CHANNEL" \
-            --entry-file index.js
+          publish_platform() {
+            local platform="$1"
+            npx code-push create-history --binary-version "$BINARY_VERSION" --platform "$platform" --identifier "$OTA_CHANNEL" || true
+            npx code-push release \
+              --binary-version "$BINARY_VERSION" \
+              --app-version "$OTA_APP_VERSION" \
+              --platform "$platform" \
+              --identifier "$OTA_CHANNEL" \
+              --entry-file index.js
+          }
+
+          publish_platform ios > ios.log 2>&1 &
+          IOS_PID=$!
+          publish_platform android > android.log 2>&1 &
+          ANDROID_PID=$!
+
+          wait "$IOS_PID"; IOS_STATUS=$?
+          wait "$ANDROID_PID"; ANDROID_STATUS=$?
+
+          echo "::group::iOS code-push output"
+          cat ios.log
+          echo "::endgroup::"
+          echo "::group::Android code-push output"
+          cat android.log
+          echo "::endgroup::"
+
+          if [[ $IOS_STATUS -ne 0 || $ANDROID_STATUS -ne 0 ]]; then
+            echo "iOS exit: $IOS_STATUS, Android exit: $ANDROID_STATUS"
+            exit 1
+          fi
 
   # iOS Release Candidate: Build and upload
   mobile-build-upload-releasecandidate-ios:


### PR DESCRIPTION
## Summary

Builds on [#14326](https://github.com/AudiusProject/apps/pull/14326) (which already added node_modules cache reuse in the OTA job and decoupled OTA from `mobile-verify`) by further collapsing the iOS/Android OTA matrix into a single job.

- The previous matrix (`platform: [ios, android]`) parallelized publishing but at the cost of running the full setup pipeline — checkout, `setup-node`, patch checksum, cache restore, `npm run postinstall`/`npm ci`, AWS config — on two separate runners. That setup is the bulk of the wall time on each runner.
- This change runs both platforms on one runner and parallelizes only the `code-push create-history`/`code-push release` calls via background processes (`ios & android & wait`), which is the part that actually benefits from running concurrently. Per-platform stdout/stderr is captured to log files and emitted under `::group::` headers so each platform's output stays readable. Exit status from both platforms is aggregated so a failure on either still fails the job.
- Applied symmetrically to both `mobile-ota-release` (rc channel) and `mobile-ota-release-production` (production channel).

For reference, the three optimizations described in the brief map to:
1. **Cache reuse in OTA** — already in `main` (#14326); cache key `npm-cache-mobile-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}-${{ steps.patch-file.outputs.patch_checksum }}` matches the `mobile-install` writer, and the install step short-circuits to `npm run postinstall` on hit.
2. **Parallel iOS + Android code-push** — this PR (background processes within one job).
3. **Decouple from verify/lint** — already in `main` (#14326); OTA depends on `[mobile-install, mobile-version-check]`, not `mobile-verify`.

## Test plan

- [ ] Workflow YAML parses (validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger an `rc` OTA release (push to `main` without a version bump, or `workflow_dispatch` with `ota_channel=rc`) and confirm both iOS and Android `code-push release` calls complete successfully and the published bundles are reachable
- [ ] Trigger a `production` OTA release via `workflow_dispatch` with `ota_channel=production` and confirm the environment approval gate still fires and both platforms publish
- [ ] Force-fail one platform (e.g. invalid `OTA_APP_VERSION`) and confirm the job still fails even though the other platform succeeded — both logs should appear in the job output

🤖 Generated with [Claude Code](https://claude.com/claude-code)