### PR TITLE
feat(mobile): port feed filter button to native app

### DIFF
--- a/packages/mobile/src/screens/feed-screen/FeedFilters.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedFilters.tsx
@@ -1,18 +1,19 @@
+import { useCallback } from 'react'
+
 import { FeedFilter } from '@audius/common/models'
-import { ScrollView, View } from 'react-native'
+import { FilterButton, useTheme } from '@audius/harmony-native'
+import { View } from 'react-native'
 
-import { Flex, SelectablePill, useTheme } from '@audius/harmony-native'
-
-const filterLabels: Record<FeedFilter, string> = {
-  [FeedFilter.ALL]: 'All Posts',
-  [FeedFilter.ORIGINAL]: 'Original Posts',
-  [FeedFilter.REPOST]: 'Reposts'
+const messages = {
+  allPosts: 'All Posts',
+  originalPosts: 'Original Posts',
+  reposts: 'Reposts'
 }
 
-const filters: FeedFilter[] = [
-  FeedFilter.ALL,
-  FeedFilter.ORIGINAL,
-  FeedFilter.REPOST
+const filterOptions = [
+  { label: messages.allPosts, value: FeedFilter.ALL },
+  { label: messages.originalPosts, value: FeedFilter.ORIGINAL },
+  { label: messages.reposts, value: FeedFilter.REPOST }
 ]
 
 type FeedFiltersProps = {
@@ -25,36 +26,33 @@ export const FeedFilters = ({
   onSelectFilter
 }: FeedFiltersProps) => {
   const { spacing, color } = useTheme()
+
+  const handleChange = useCallback(
+    (value: string | undefined) => {
+      if (!value) return
+      onSelectFilter(value as FeedFilter)
+    },
+    [onSelectFilter]
+  )
+
   return (
     <View
       style={{
         backgroundColor: color.background.white,
-        paddingBottom: spacing.s
+        paddingHorizontal: spacing.l,
+        paddingBottom: spacing.s,
+        alignItems: 'flex-start'
       }}
     >
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={{ paddingHorizontal: spacing.l }}
-      >
-        <Flex direction='row' alignItems='center' gap='s'>
-          {filters.map((filter) => (
-            <SelectablePill
-              key={filter}
-              type='radio'
-              size='small'
-              value={filter}
-              label={filterLabels[filter]}
-              isSelected={currentFilter === filter}
-              onChange={(value, isSelected) => {
-                if (!isSelected) return
-                onSelectFilter(value as FeedFilter)
-              }}
-              disableUnselectAnimation
-            />
-          ))}
-        </Flex>
-      </ScrollView>
+      <FilterButton
+        label={messages.allPosts}
+        value={currentFilter}
+        variant='replaceLabel'
+        onChange={handleChange}
+        options={filterOptions}
+        size='small'
+        disableSearch
+      />
     </View>
   )
 }


### PR DESCRIPTION
## Summary
- Port the chronological-feed FilterButton from web ([apps#14315](https://github.com/AudiusProject/apps/pull/14315)) to the React Native mobile app, which was missed in the original PR.
- Mobile's `FeedFilters` was still rendering the old horizontal-scrolling `SelectablePill` pills; this swaps them for the `replaceLabel` `FilterButton` to match web.
- `FilterButton` is already exported from `@audius/harmony-native` and the `FilterButton` screen is wired in `AppTabScreen`, so no infra changes are needed.

## Test plan
- [ ] Open the app, navigate to Feed → Chronological tab. Confirm the filter button appears (instead of the three pills).
- [ ] Tap the button → the filter selection screen opens with All Posts / Original Posts / Reposts.
- [ ] Select each option and confirm the feed re-queries with the correct filter and the button label updates.
- [ ] Switch to the For You tab and confirm the filter button is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)