### PR TITLE
fix(feed): anchor filter button to the right side, match Trending pattern

### DIFF
--- a/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
@@ -113,8 +113,14 @@ const FeedPageContent = ({ containerRef }: FeedPageContentProps) => {
       titleRowRef={titleRowRef}
       icon={IconFeed}
       primary={messages.feedHeaderTitle}
-      rightDecorator={
-        <Flex gap='s' alignItems='center'>
+      bottomBar={
+        <Flex
+          w='100%'
+          alignItems='center'
+          justifyContent='space-between'
+          gap='m'
+          pb='l'
+        >
           <FeedTabs currentTab={feedTab} onSelectTab={onSelectTab} />
           {isForYou ? null : (
             <FeedFilters

--- a/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
@@ -113,7 +113,12 @@ const FeedPageMobileContent = ({
   useEffect(() => {
     setHeader(
       <Header title={messages.title} className={styles.header}>
-        <Flex gap='s' alignItems='center' justifyContent='center'>
+        <Flex
+          w='100%'
+          gap='s'
+          alignItems='center'
+          justifyContent='space-between'
+        >
           <FeedTabs currentTab={feedTab} onSelectTab={handleSelectTab} />
           {isForYou ? null : (
             <FeedFilters


### PR DESCRIPTION
## Summary

The feed filter button (the dropdown next to the Chronological tab) was sitting **inline next to the feed tabs** in the Header's `rightDecorator` slot, instead of being anchored to the right edge of the header like Trending does.

Move both the `FeedTabs` and `FeedFilters` from `rightDecorator` into the Header `bottomBar` slot, wrapped in `<Flex w='100%' justifyContent='space-between'>` — this is the exact pattern [TrendingPageContent](packages/web/src/pages/trending-page/components/desktop/TrendingPageContent.tsx) uses (tabs on the left, filter buttons on the right). The mobile-web header gets the equivalent change: `justifyContent` flips from `center` to `space-between` with `w='100%'`, so the filter is pushed to the right edge.

When the **For You** tab is active there is no filter button — only the tabs render — which matches existing behavior.

This supersedes [#14315](https://github.com/AudiusProject/apps/pull/14315), which introduced the filter button but kept it clumped next to the tabs.

## Files changed

- [packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx](packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx) — `rightDecorator` → `bottomBar` with `space-between`
- [packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx](packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx) — `justifyContent='center'` → `space-between` with `w='100%'`

## Test plan

> Note: the dev server was not available in this worktree, so the change has not been visually verified in a browser yet. The diff is a structural prop change (slot + flex alignment) — no logic, no new components.

- [ ] Desktop: open feed page, Chronological tab → confirm the filter button sits at the **right edge** of the header (not next to the tabs), tabs are on the left, separated by full-width space-between
- [ ] Desktop: switch to For You → confirm filter button is hidden, only tabs render
- [ ] Desktop: open the filter dropdown → confirm `All Posts` / `Original Posts` / `Reposts` options work and filter the lineup
- [ ] Mobile-web: repeat the above checks — filter button should sit at the right edge of the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)