### PR TITLE
fix(mobile): contest followers screen blank when limit exceeds 100

### DIFF
--- a/packages/mobile/src/screens/contest-screen/ContestFollowersScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestFollowersScreen.tsx
@@ -18,15 +18,17 @@ const messages = {
  * We reuse the shared `UserList` + `UserListScreen` scaffolding that
  * powers Followers/Following/Mutuals, wired up to `useEventFollowers`
  * instead of the per-user follow hooks. The event-followers hook
- * isn't paginated today, so we request a healthy upper bound (200)
- * and render what comes back — pagination can be wired in later
- * without touching this screen if the hook grows it.
+ * isn't paginated today, so we request the same upper bound the web
+ * modal uses (100) — values above that come back empty from the
+ * indexer's response, which is what was producing a blank list.
+ * Pagination can be wired in later without touching this screen if
+ * the hook grows it.
  */
 export const ContestFollowersScreen = () => {
   const { params } = useRoute<'ContestFollowers'>()
   const { eventId } = params
 
-  const { userIds, isPending } = useEventFollowers({ eventId, limit: 200 })
+  const { userIds, isPending } = useEventFollowers({ eventId, limit: 100 })
 
   return (
     <UserListScreen title={messages.title} titleIcon={IconUserFollowers}>


### PR DESCRIPTION
## Summary

The mobile **Contest Followers** screen (the dedicated list opened from the
"FOLLOWERS (N)" card on a remix contest page) was rendering as a blank
white screen under its "FOLLOWERS" header — no rows, no skeletons, no empty
state.

Root cause: the screen requested `useEventFollowers({ eventId, limit: 200 })`,
while the equivalent web caller (`ContestFollowersModal`) uses `limit: 100`.
Above that ceiling the `/events/{eventId}/followers` response comes back
empty, so `userIds` resolved to `[]`, `isPending` flipped to `false`, and the
shared `UserList` rendered nothing.

The avatar pile on the contest details tab kept working because it requests
`limit: 7` via `EventFollowersCard`, well under the ceiling.

## Fix

- [ContestFollowersScreen.tsx](packages/mobile/src/screens/contest-screen/ContestFollowersScreen.tsx) now requests `limit: 100`, matching the web modal.
- Updated the surrounding docstring to record why we hold at 100 so future
  readers don't bump it back up.

## Test plan

- [ ] Open a remix contest with a few followers on mobile
- [ ] Tap the "FOLLOWERS (N)" card on the details tab
- [ ] Confirm the dedicated screen now lists the follower rows instead of
      rendering a blank "FOLLOWERS" header
- [ ] Confirm the avatar pile on the details tab still renders (limit 7,
      unchanged path)
- [ ] Web: confirm the `ContestFollowersModal` is unaffected (no changes
      touched the hook or the web caller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)