### PR TITLE
fix: mobile contest cards too narrow in Explore carousel

### DIFF
--- a/packages/mobile/src/components/contest-card/ContestCard.tsx
+++ b/packages/mobile/src/components/contest-card/ContestCard.tsx
@@ -298,11 +298,7 @@ export const ContestCard = (props: ContestCardProps) => {
       onPress={handlePress}
       border='default'
       shadow='mid'
-      // Floor the card at ~250px so the artist name + badges row in the
-      // header doesn't clip on the narrowest carousels (the mobile
-      // explore "Contests" rail was sized to whatever CardList default
-      // — the QA pass flagged the cards as too skinny).
-      style={{ overflow: 'hidden', borderRadius: 14, minWidth: 250 }}
+      style={{ overflow: 'hidden', borderRadius: 14 }}
       {...other}
     >
       {/* Cover banner */}

--- a/packages/mobile/src/components/core/CardList.tsx
+++ b/packages/mobile/src/components/core/CardList.tsx
@@ -25,6 +25,11 @@ export type CardListProps<ItemT> = Omit<FlatListProps<ItemT>, 'data'> & {
   // Use carousel spacing to override the parent's margins
   // e.g. make carousel start and end at edge of the screen
   carouselSpacing?: number
+
+  // Override the per-item slot width in horizontal mode. Defaults to
+  // `spacing(43)` (172px), which is right for small thumbnail-style cards
+  // (tracks, playlists) but too narrow for the redesigned contest card.
+  horizontalCardWidth?: number | `${number}%`
 }
 
 export type LoadingCard = { _loading: true }
@@ -60,11 +65,12 @@ const useStyles = makeStyles(({ spacing }) => ({
     flexGrow: 0
   },
   cardHorizontal: {
-    width: spacing(43),
     paddingRight: spacing(3),
     paddingBottom: spacing(3)
   }
 }))
+
+const DEFAULT_HORIZONTAL_CARD_WIDTH = 172
 
 export function CardList<ItemT extends {}>(props: CardListProps<ItemT>) {
   const {
@@ -78,6 +84,7 @@ export function CardList<ItemT extends {}>(props: CardListProps<ItemT>) {
     totalCount,
     horizontal: isHorizontal = false,
     carouselSpacing = 0,
+    horizontalCardWidth = DEFAULT_HORIZONTAL_CARD_WIDTH,
     ...other
   } = props
 
@@ -109,7 +116,13 @@ export function CardList<ItemT extends {}>(props: CardListProps<ItemT>) {
         )
 
       return (
-        <View style={isHorizontal ? styles.cardHorizontal : styles.card}>
+        <View
+          style={
+            isHorizontal
+              ? [styles.cardHorizontal, { width: horizontalCardWidth }]
+              : styles.card
+          }
+        >
           {itemElement}
         </View>
       )
@@ -119,7 +132,8 @@ export function CardList<ItemT extends {}>(props: CardListProps<ItemT>) {
       renderItem,
       styles.card,
       styles.cardHorizontal,
-      isHorizontal
+      isHorizontal,
+      horizontalCardWidth
     ]
   )
 

--- a/packages/mobile/src/screens/explore-screen/components/FeaturedRemixContests.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/FeaturedRemixContests.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { useAllRemixContests } from '@audius/common/api'
 import { exploreMessages as messages } from '@audius/common/messages'
+import { useWindowDimensions } from 'react-native'
 
 import { useTheme } from '@audius/harmony-native'
 import { ContestCard } from 'app/components/contest-card'
@@ -12,8 +13,16 @@ import { useDeferredElement } from '../../../hooks/useDeferredElement'
 
 import { ExploreSection } from './ExploreSection'
 
+// Carousel slot width for contest cards. The dedicated /contests screen
+// renders cards at roughly full screen width minus its horizontal margins;
+// the Explore carousel matches that visual width while leaving a small
+// peek of the next card to invite horizontal swipe.
+const CONTEST_CARD_PEEK = 48
+
 export const FeaturedRemixContests = () => {
   const { spacing } = useTheme()
+  const { width: windowWidth } = useWindowDimensions()
+  const contestCardWidth = windowWidth - CONTEST_CARD_PEEK
   const { InViewWrapper, inView } = useDeferredElement()
 
   const { data: allContestTrackIds, isPending: isAllContestsPending } =
@@ -27,6 +36,7 @@ export const FeaturedRemixContests = () => {
           renderItem={({ item }) => <ContestCard trackId={item.trackId} />}
           horizontal
           carouselSpacing={spacing.l}
+          horizontalCardWidth={contestCardWidth}
           isLoading={isAllContestsPending}
           LoadingCardComponent={TrackCardSkeleton}
         />


### PR DESCRIPTION
## Summary

The contest cards in the Explore page "Contests" carousel were rendering far narrower than the cards on the dedicated `/contests` screen, squeezing the host row, the two-line title (clipped mid-word), and the entries pill. The slot wrapper in [packages/mobile/src/components/core/CardList.tsx](packages/mobile/src/components/core/CardList.tsx) was hard-coded to `width: spacing(43)` (172px), which is right for thumbnail-style cards (tracks, playlists) but too narrow for the redesigned contest card. [ContestCard.tsx](packages/mobile/src/components/contest-card/ContestCard.tsx) had previously papered over this with `minWidth: 250` — that let the card render at 250px, but the layout slot stayed at 172px, so adjacent cards visually overlapped.

- **[CardList](packages/mobile/src/components/core/CardList.tsx):** added a `horizontalCardWidth` prop and removed the hard-coded width from the slot style. Defaults to the previous 172px, so existing horizontal carousels (tracks, playlists, etc.) are unchanged.
- **[FeaturedRemixContests](packages/mobile/src/screens/explore-screen/components/FeaturedRemixContests.tsx):** passes `useWindowDimensions().width - 48`, matching the visual width of cards on the dedicated `/contests` screen and leaving a small peek of the next card to invite horizontal swipe.
- **[ContestCard](packages/mobile/src/components/contest-card/ContestCard.tsx):** dropped the now-redundant `minWidth: 250` workaround.

## Test plan

- [ ] Mobile native Explore screen → "Contests" carousel: cards render at roughly full screen width (matching `/contests`) with a small peek of the next card; host row, title, and entries pill no longer squeezed; titles no longer cut off mid-word.
- [ ] Horizontal swipe still works smoothly across the carousel.
- [ ] Other horizontal carousels on Explore (`ForYouTracks`, `FeaturedPlaylists`, etc.) unchanged — they still use 172px slot widths.
- [ ] Dedicated `/contests` screen, profile "Contests" tab, and track-screen "Contests" tile unchanged — those layouts already render cards at full container width and don't go through `CardList`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)