### PR TITLE
ci(mobile): stop OTA workflow from wiping CodePush release history

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -197,6 +197,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [mobile-install, mobile-version-check]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.mobile-version-check.outputs.version_unchanged == 'true') || (github.event_name == 'workflow_dispatch' && (github.event.inputs.ota_channel == 'rc' || github.event.inputs.ota_channel == ''))
+    # Serialize per-platform publishes so two concurrent runs can't read-modify-write
+    # the same s3://.../mobile-ota/histories/<platform>/rc/<binary>.json and clobber each
+    # other's release entry.
+    concurrency:
+      group: mobile-ota-release-rc-${{ matrix.platform }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -288,8 +294,6 @@ jobs:
           OTA_APP_VERSION="${MAJOR}.${MINOR}.${OTA_PATCH}"
 
           cd packages/mobile
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ${{ matrix.platform }} --identifier "$OTA_CHANNEL" || true
-
           npx code-push release \
             --binary-version "$BINARY_VERSION" \
             --app-version "$OTA_APP_VERSION" \
@@ -307,6 +311,9 @@ jobs:
     environment:
       name: mobile-production-ota
       url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    concurrency:
+      group: mobile-ota-release-production-${{ matrix.platform }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -388,8 +395,6 @@ jobs:
           OTA_APP_VERSION="${MAJOR}.${MINOR}.${OTA_PATCH}"
 
           cd packages/mobile
-          npx code-push create-history --binary-version "$BINARY_VERSION" --platform ${{ matrix.platform }} --identifier "$OTA_CHANNEL" || true
-
           npx code-push release \
             --binary-version "$BINARY_VERSION" \
             --app-version "$OTA_APP_VERSION" \


### PR DESCRIPTION
## Summary

The OTA jobs in `.github/workflows/mobile.yml` call `code-push create-history` on every push and every `workflow_dispatch`. That command writes a fresh history JSON containing only the binary-version placeholder and uploads it to `s3://.../mobile-ota/histories/<platform>/<channel>/<binary>.json`, overwriting every prior entry. The subsequent `code-push release` step then reads that wiped file and writes it back with just `[placeholder, latest_OTA]`, so each run silently drops every previously-published OTA bundle for that binary version.

### User-facing symptom: cycling

On RC, every push to main triggers a new OTA run. While each run is in flight, the history file sits in one of two bad states:

1. **Wipe window (~3–5 minutes between `create-history` upload and `release` upload):** the file holds only the binary placeholder. A device opening the app and running `CodePush.sync()` during this window fetches a history whose "latest enabled release" is the placeholder (empty `downloadUrl`). That's treated as "no update available," and CodePush has no record of the OTA the device already has pending — so the pending-update banner ([packages/mobile/src/components/ota-update-banner/OtaUpdateBanner.tsx:75](packages/mobile/src/components/ota-update-banner/OtaUpdateBanner.tsx:75)) goes away.

2. **Concurrent runs racing on the same JSON:** when two pushes land close together, both call `getReleaseHistory → setReleaseHistory` on the same S3 path. With the wipe gone there's still a read-modify-write race; with the wipe present it's worse because a later `create-history` truncates back to `[placeholder]` before the earlier run's `release` step has finished its read-modify-write.

Together those two flows produce the symptom the user described — banner appears, disappears a few minutes later when the next run's `create-history` lands, then comes back when that run's `release` step writes a new bundle.

### Live evidence

All four history files currently hold exactly one real OTA each, with every earlier release gone:

- `download.audius.co/mobile-ota/histories/ios/rc/1.5.179.json` → `[1.5.179, 1.5.100776]`
- `download.audius.co/mobile-ota/histories/ios/production/1.5.179.json` → `[1.5.179, 1.5.100775]`
- `download.audius.co/mobile-ota/histories/android/rc/1.5.179.json` → `[1.5.179, 1.5.100776]`
- `download.audius.co/mobile-ota/histories/android/production/1.5.179.json` → `[1.5.179, 1.5.100775]`

### Why removing the call is safe

[packages/mobile/OTA_UPDATES.md:55](packages/mobile/OTA_UPDATES.md:55) describes `create-history` as a one-time init when shipping a new native binary, not part of the OTA release loop. And the client ([packages/mobile/src/app/ota-updates.ts:94](packages/mobile/src/app/ota-updates.ts:94)) already substitutes a no-update placeholder when the history JSON is missing or empty, so the call isn't needed to keep CodePush from throwing "There is no latest release." On a brand-new binary version `code-push release` will see a 404 from `getReleaseHistory`, return `{}`, append its entry, and create the file from scratch with just the new OTA — which the client treats correctly.

### Concurrency group

Adds a per-platform concurrency group on both OTA jobs (`mobile-ota-release-rc-<platform>` and `mobile-ota-release-production-<platform>`). With the wipe removed, each run still does a read-modify-write on the history JSON; an unserialized race between two pushes landing close together would let a later writer clobber an earlier release's entry. `cancel-in-progress: false` queues subsequent runs rather than killing a publish mid-upload.

### Out of scope

- Backfilling lost OTA history entries (would need to rebuild from S3 bundle listings — separate cleanup).
- PR #14331 (single-runner OTA collapse) will need the same edits when it rebases on this.

## Test plan

- [ ] Workflow YAML parses (validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Land this, then push a no-op commit (or `workflow_dispatch` on `rc`) and confirm `code-push release` no longer prints a wipe step — only the release/upload — and the resulting `histories/ios/rc/1.5.179.json` keeps the previous OTA entry and appends the new one.
- [ ] Repeat with `workflow_dispatch ota_channel=production` and confirm the production history file grows instead of resetting.
- [ ] Trigger two pushes in quick succession and confirm the second OTA waits (concurrency queue) instead of overlapping the first.
- [ ] Observe RC devices over a few OTA cycles and confirm the pending-update banner stays sticky once shown (no more disappear-then-reappear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)