### PR TITLE
feat(mobile): add queue icon to mini player

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
@@ -1,5 +1,10 @@
+import { useCallback } from 'react'
+
 import { useCurrentUserId, useToggleFavoriteTrack } from '@audius/common/api'
-import { useGatedContentAccess } from '@audius/common/hooks'
+import {
+  useGatedContentAccess,
+  useQueueNewFeatureBadge
+} from '@audius/common/hooks'
 import { FavoriteSource, SquareSizes } from '@audius/common/models'
 import type { Track, User } from '@audius/common/models'
 import { playbackSelectors } from '@audius/common/store'
@@ -7,9 +12,10 @@ import type { Nullable } from '@audius/common/utils'
 import { TouchableOpacity, Animated, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
-import { IconLock } from '@audius/harmony-native'
+import { IconButton, IconIndent, IconLock } from '@audius/harmony-native'
 import { FavoriteButton } from 'app/components/favorite-button'
 import Text from 'app/components/text'
+import { useDrawer } from 'app/hooks/useDrawer'
 import { makeStyles } from 'app/styles'
 import { useColor } from 'app/utils/theme'
 import { zIndex } from 'app/utils/zIndex'
@@ -23,7 +29,8 @@ import { NOW_PLAYING_HEIGHT, PLAY_BAR_HEIGHT } from './constants'
 const { getPreviewing } = playbackSelectors
 
 const messages = {
-  preview: 'PREVIEW'
+  preview: 'PREVIEW',
+  queueLabel: 'Queue'
 }
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
@@ -58,6 +65,11 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
     flexDirection: 'row',
     justifyContent: 'flex-start',
     gap: spacing(3)
+  },
+  queueContainer: {
+    flexShrink: 0,
+    alignItems: 'center',
+    justifyContent: 'center'
   },
   playContainer: {
     flexShrink: 1,
@@ -151,6 +163,18 @@ export const PlayBar = (props: PlayBarProps) => {
     source: FavoriteSource.PLAYBAR
   })
 
+  const { onOpen: openQueue } = useDrawer('Queue')
+  const {
+    showBadge: showQueueNewFeatureBadge,
+    dismiss: dismissQueueNewFeatureBadge
+  } = useQueueNewFeatureBadge()
+  const handleOpenQueue = useCallback(() => {
+    if (showQueueNewFeatureBadge) {
+      dismissQueueNewFeatureBadge()
+    }
+    openQueue()
+  }, [showQueueNewFeatureBadge, dismissQueueNewFeatureBadge, openQueue])
+
   const renderFavoriteButton = () => {
     return (
       <FavoriteButton
@@ -231,6 +255,15 @@ export const PlayBar = (props: PlayBarProps) => {
             </View>
           ) : null}
         </TouchableOpacity>
+        <View style={styles.queueContainer}>
+          <IconButton
+            icon={IconIndent}
+            onPress={handleOpenQueue}
+            size='l'
+            color={showQueueNewFeatureBadge ? 'active' : 'default'}
+            aria-label={messages.queueLabel}
+          />
+        </View>
         <View style={styles.playContainer}>
           <PlayButton wrapperStyle={styles.playIcon} />
         </View>


### PR DESCRIPTION
## Summary
- Adds a queue icon (`IconIndent`) to the collapsed now-playing bar (PlayBar) so users can open the play queue directly from the mini player.
- Previously the queue button only lived in the expanded now-playing drawer (`ActionsBar`), requiring users to pull the drawer up first to reach it.
- Reuses the same `useDrawer('Queue')` hook + `useQueueNewFeatureBadge` dismissal flow as `ActionsBar`, so the queue drawer opens the same way and the new-feature badge is dismissed consistently.

The icon sits between the track info and the play button on the right side of the bar, in its own non-shrinking container. The track info container already has `flexShrink: 1`, so long titles/artists absorb the extra width.

## Test plan
- [ ] Run the mobile app and play a track to reveal the mini player at the bottom.
- [ ] Tap the queue icon in the mini player and verify the Queue drawer opens immediately (without first expanding the now-playing drawer).
- [ ] Tap the queue icon for the first time and confirm the "new feature" badge color (active tint) appears, then disappears after the first tap (badge dismissal).
- [ ] Verify the existing favorite, track info, and play button still render correctly and remain tappable with normal-length titles.
- [ ] Verify with a long track title / long artist name that the layout doesn't crowd or clip the queue icon.
- [ ] Verify the mini player fade animation as the now-playing drawer is dragged up still behaves correctly (queue icon fades with the rest of the bar).
- [ ] Verify on a USDC-gated / preview-locked track: favorite is hidden as before, queue icon remains visible and tappable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)