### PR TITLE
fix(mobile): comment kebab menu desyncs after close

### DIFF
--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -238,8 +238,8 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
   }, [deleteComment, id, parentCommentId, toast])
 
   const handlePress = useCallback(() => {
-    setIsOpen(!isOpen)
-    setIsVisible(!isVisible)
+    setIsOpen(true)
+    setIsVisible(true)
 
     trackEvent(
       make({
@@ -247,7 +247,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
         commentId: id
       })
     )
-  }, [isOpen, isVisible, id])
+  }, [id])
 
   return (
     <>


### PR DESCRIPTION
## Summary

The kebab handler on mobile comments toggled `isOpen` and `isVisible` together, but those two pieces of state intentionally serve different roles:

- `isOpen` drives the open/close **animation**
- `isVisible` controls whether the drawer is **mounted** (kept true during the close animation, set to false in `onClosed`)

Because `onClose` and `onClosed` flip them on separate ticks, there is a brief window during the close animation where `isOpen=false` but `isVisible=true`. A tap on the kebab during that window inverts both via the toggle, leaving the drawer **unmounted while state thinks it's open**. The next tap then has to dig itself out of the broken state, so the kebab appears not to respond.

The fix is to make `handlePress` explicitly **open** the menu. Closing is already fully owned by the drawer's `onClose` / `onClosed` callbacks (row tap, backdrop tap, or swipe-down).

## Test plan

- [ ] Tap kebab on your own comment → drawer appears with Edit / Delete options
- [ ] Tap kebab on another user's comment → drawer appears with Flag, Mute User, etc.
- [ ] Tap a row → drawer closes; tap kebab again → drawer reopens on the first tap
- [ ] Tap backdrop to dismiss; tap kebab → drawer reopens on the first tap
- [ ] Tap kebab rapidly while drawer is animating closed → drawer always opens cleanly, never stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)