### PR TITLE
fix(web): contest skeleton title block reads as text, not a slab

### DIFF
--- a/packages/web/src/components/contest-card/ContestCard.tsx
+++ b/packages/web/src/components/contest-card/ContestCard.tsx
@@ -188,11 +188,14 @@ export const ContestCardSkeleton = (
   // doesn't pop in shorter than the resolved card. Hero rows render
   // heading/l (line-height 40) and grid rows render heading/m
   // (line-height 32); both clamp to two lines, giving an 80 / 64 px
-  // title block respectively. Earlier iterations rendered a single 28px
-  // line, which was the source of the "skeleton loader is the wrong
-  // size on the explore page" QA pass.
+  // title block respectively. The title placeholder is rendered as two
+  // stacked bars sized to the real heading text rather than a single
+  // solid block — same reserved height, but visually reads as text
+  // instead of looming as a single dense rectangle the way the earlier
+  // 64px slab did on the explore grid.
   const variant = props.variant ?? 'grid'
   const titleBlockHeight = variant === 'hero' ? 80 : 64
+  const titleLineHeight = variant === 'hero' ? 28 : 22
   return (
     <Paper
       direction='column'
@@ -213,7 +216,15 @@ export const ContestCardSkeleton = (
         </Flex>
         <Divider orientation='horizontal' />
         <Flex direction='column' gap='s'>
-          <Skeleton h={titleBlockHeight} w='80%' />
+          <Flex
+            direction='column'
+            gap='s'
+            justifyContent='center'
+            css={{ height: titleBlockHeight }}
+          >
+            <Skeleton h={titleLineHeight} w='80%' />
+            <Skeleton h={titleLineHeight} w='55%' />
+          </Flex>
           <Flex gap='s'>
             <Skeleton h={22} w={72} />
           </Flex>


### PR DESCRIPTION
## Summary
- The Explore page's Contests row had skeletons that reserved the correct overall card height (313px to match the resolved `ContestCard`), but the title placeholder was a single solid `80% wide x 64px tall` grey bar. Even though the dimensions matched, the dense slab read as visually too big alongside the lighter 1-2 lines of heading text it was standing in for.
- Splits that 64px (grid) / 80px (hero) title block into two stacked skeleton bars sized to the real heading line-height (22px for `heading/m`, 28px for `heading/l`), centered inside a container fixed at the same total height. Card total dimensions are unchanged - measured 320x313 in skeleton and resolved states at 1440x900 - so no layout shift when data resolves.

## Test plan
- [x] Load `/explore` at 1440x900 with the Contests row offscreen-triggered; measure the skeleton card -> 320x313, same as the resolved `ContestCard`.
- [x] Watch the transition from skeleton -> resolved: contest titles drop in without the row jumping.
- [ ] Spot-check the `hero` variant (used on the dedicated `/contests` page) - the same logic applies (80px block, 28px bars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)