### PR TITLE
fix(contests): prime correct count cache key in useUserRemixContests

### DIFF
--- a/packages/common/src/api/tan-query/events/useUserRemixContests.ts
+++ b/packages/common/src/api/tan-query/events/useUserRemixContests.ts
@@ -9,7 +9,7 @@ import {
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 
 import { eventMetadataFromSDK } from '~/adapters/event'
-import { getRemixesQueryKey } from '~/api/tan-query/remixes/useRemixes'
+import { getRemixesCountQueryKey } from '~/api/tan-query/remixes/useRemixes'
 import { useQueryContext } from '~/api/tan-query/utils'
 import { primeRelatedData } from '~/api/tan-query/utils/primeRelatedData'
 import { ID } from '~/models'
@@ -97,23 +97,15 @@ export const useUserRemixContests = (
       // N+1.
       primeRelatedData({ related, queryClient })
 
-      // Prime useRemixes({ trackId, pageSize: 0, isContestEntry: true }) so
-      // ContestCard's entry-count badge doesn't fire a count-only request
-      // per card. Mirrors the priming in useAllRemixContests.
+      // Prime the dedicated `useRemixesCount` cache so ContestCard's
+      // entry-count badge doesn't fire a count-only request per card.
       const entryCounts = related?.entryCounts ?? {}
       for (const [hashedTrackId, count] of Object.entries(entryCounts)) {
         const trackId = OptionalHashId.parse(hashedTrackId)
         if (!trackId) continue
         queryClient.setQueryData(
-          getRemixesQueryKey({
-            trackId,
-            pageSize: 0,
-            isContestEntry: true
-          }),
-          {
-            pages: [{ count, tracks: [] }],
-            pageParams: [0]
-          } as unknown as never
+          getRemixesCountQueryKey({ trackId, isContestEntry: true }),
+          count
         )
       }
 


### PR DESCRIPTION
## Summary

The profile Contests tab's submission count badge was stuck on "0 ENTRIES" because the cache priming used the wrong query key.

- `useUserRemixContests` primed `getRemixesQueryKey({ pageSize: 0, isContestEntry: true })` with a fake `InfiniteData` shape (`{ pages: [{ count, tracks: [] }], pageParams: [0] }`).
- But `ContestCard` reads counts via `useRemixesCount`, which is keyed by `getRemixesCountQueryKey` (a flat count, no infinite-data wrapper).
- The keys never matched, so the primed data was unreachable. Every card fell through to its own `/tracks/{id}/remixes?limit=0` request, and the badge showed `0` until that fetch resolved (or longer, if the response was slow or stalled).

## Fix

Prime `getRemixesCountQueryKey` with the raw count instead — exactly the same shape `useRemixesCount` writes back from its `queryFn`. This mirrors the fix already applied to the companion `useAllRemixContests` hook in #14271 ("normalize lineup shape"); the per-user hook was added separately and missed the migration.

Net: counts on the profile Contests tab now paint from the primed cache in a single round-trip, the way `/contests` already does.

## Test plan

- [ ] Visit a host's profile → Contests tab. Confirm each `ContestCard` shows the correct entry count immediately (no `0 ENTRIES` flicker).
- [ ] Confirm no per-card `/tracks/{id}/remixes?limit=0` requests fire on initial load (network panel).
- [ ] Visit `/contests` and confirm nothing regressed there (it already used the correct key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)