### PR TITLE
fix(protocol-dashboard): fetch latest validator version via getNumberOfVersions

### DIFF
--- a/packages/protocol-dashboard/src/store/cache/protocol/hooks.ts
+++ b/packages/protocol-dashboard/src/store/cache/protocol/hooks.ts
@@ -84,7 +84,12 @@ export function fetchCurrentVersion(
   serviceType: ServiceType
 ): ThunkAction<void, AppState, Audius, Action<string>> {
   return async (dispatch, getState, aud) => {
-    const currentVersion = await aud.NodeType.getCurrentVersion(serviceType)
+    const numberOfVersions =
+      await aud.NodeType.getNumberOfVersions(serviceType)
+    const currentVersion = await aud.NodeType.getVersion(
+      serviceType,
+      numberOfVersions - 1
+    )
     dispatch(setCurrentVersion({ serviceType, currentVersion }))
   }
 }


### PR DESCRIPTION
## Summary
- `getCurrentVersion` on the ServiceTypeManager contract was returning a stale version (1.0.0) for the `Validator` service type — the home page and other locations using `useCurrentVersion(ServiceType.Validator)` displayed the wrong number.
- Switch `fetchCurrentVersion` to read the latest registered version by calling `getNumberOfVersions(serviceType)` and then `getVersion(serviceType, numberOfVersions - 1)`. The latest onchain validator version (1.1.0) now shows correctly.

## Test plan
- [ ] Open the dashboard logged out — verify the `Register a Node` card shows the latest onchain version (currently `1.1.0`) instead of `1.0.0`.
- [ ] Open a user/services page that renders `RegisterNodeCard` — verify the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)