### PR TITLE
fix(protocol-dashboard): remove '1.0.0' validator-version fallback so fetch actually runs

### DIFF
--- a/packages/protocol-dashboard/src/components/RegisterNodeCard/RegisterNodeCard.tsx
+++ b/packages/protocol-dashboard/src/components/RegisterNodeCard/RegisterNodeCard.tsx
@@ -84,7 +84,7 @@ export const RegisterNodeCard = ({ wallet }: { wallet: string }) => {
         <Flex alignItems='center' gap='xl'>
           <Card p='xl' direction='column'>
             <Box>
-              {storageCommitment == null ? (
+              {currentVersion == null ? (
                 <Box mb='xs'>
                   <Loading />
                 </Box>

--- a/packages/protocol-dashboard/src/store/cache/protocol/hooks.ts
+++ b/packages/protocol-dashboard/src/store/cache/protocol/hooks.ts
@@ -38,7 +38,7 @@ export const getCurrentVersion = (
     case ServiceType.ContentNode:
       return state.cache.protocol.services.contentNode.currentVersion
     case ServiceType.Validator:
-      return state.cache.protocol.services.validator?.currentVersion ?? '1.0.0'
+      return state.cache.protocol.services.validator?.currentVersion
   }
 }
 

--- a/packages/protocol-dashboard/src/store/cache/protocol/slice.ts
+++ b/packages/protocol-dashboard/src/store/cache/protocol/slice.ts
@@ -82,8 +82,14 @@ const slice = createSlice({
             action.payload.currentVersion
           break
         case ServiceType.Validator:
-          state.services.validator.currentVersion =
-            action.payload.currentVersion
+          state.services.validator = {
+            ...(state.services.validator ?? {
+              isValid: false,
+              minStake: new BN(0),
+              maxStake: new BN(0)
+            }),
+            currentVersion: action.payload.currentVersion
+          }
           break
       }
     }

--- a/packages/protocol-dashboard/src/store/cache/protocol/slice.ts
+++ b/packages/protocol-dashboard/src/store/cache/protocol/slice.ts
@@ -55,9 +55,18 @@ const slice = createSlice({
       state.delegator.maxDelegators = action.payload.maxDelegators
     },
     setServiceTypeInfo: (state, action: PayloadAction<SetServiceTypeInfo>) => {
-      state.services.discoveryProvider = action.payload.discoveryProvider
-      state.services.contentNode = action.payload.contentNode
-      state.services.validator = action.payload.validator
+      state.services.discoveryProvider = {
+        ...action.payload.discoveryProvider,
+        currentVersion: state.services.discoveryProvider?.currentVersion
+      }
+      state.services.contentNode = {
+        ...action.payload.contentNode,
+        currentVersion: state.services.contentNode?.currentVersion
+      }
+      state.services.validator = {
+        ...action.payload.validator,
+        currentVersion: state.services.validator?.currentVersion
+      }
     },
     setEthBlockNumber: (state, action: PayloadAction<number>) => {
       state.ethBlockNumber = action.payload


### PR DESCRIPTION
## Summary
Follow-up to #14355. The dashboard was still showing `1.0.0` for the Validator current version after that PR shipped. Root cause: the `getCurrentVersion` selector returned `'1.0.0'` as a fallback when `services.validator.currentVersion` was undefined, and `useCurrentVersion` only dispatches `fetchCurrentVersion` when the selected value is `undefined`. The hardcoded fallback short-circuited the dispatch, so the new `getNumberOfVersions` + `getVersion` logic introduced in #14355 never ran.

- Remove the `?? '1.0.0'` fallback from the selector so the fetch dispatches.
- Harden the `setCurrentVersion` reducer to initialize `state.services.validator` if it doesn't exist yet, since `fetchCurrentVersion` can resolve before `fetchServiceStakeValues` populates it.

## Test plan
- [ ] Open the dashboard and confirm `Register a Node` → `Current Version` shows the latest onchain version (currently `1.1.0`) instead of `1.0.0`.
- [ ] Hard refresh and confirm no race-condition crashes from `setCurrentVersion` running before service info loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)