### PR TITLE
fix: stale follow state on profile after navigating from notification

### DIFF
--- a/.changeset/fix-notification-related-users-stale-follow.md
+++ b/.changeset/fix-notification-related-users-stale-follow.md
@@ -1,0 +1,7 @@
+---
+'@audius/common': patch
+'@audius/web': patch
+'@audius/mobile': patch
+---
+
+Fix profile page showing the wrong follow state after navigating from a "new track" user-subscription notification. The notifications endpoint now returns a `related.users` block hydrated server-side, but without the requester's perspective — `does_current_user_follow` is omitted. `primeRelatedData` was writing those partial users into the tan-query user cache; because `useUser` / `useUserByHandle` use `staleTime: Infinity` and `primeUserData` skips overwriting an existing entry, the partial prime persisted and the profile page rendered "Follow" for accounts the viewer was already following. Skip the prime when the related user lacks current-user fields and let `useUser`'s batcher fetch fresh data with `currentUserId` instead. (Other `primeRelatedData` callers — comments, events — are unaffected when their server responses include current-user context, and self-heal once the notifications API hydrates the perspective too.)

--- a/packages/common/src/api/tan-query/utils/primeRelatedData.ts
+++ b/packages/common/src/api/tan-query/utils/primeRelatedData.ts
@@ -33,12 +33,32 @@ export const primeRelatedData = ({
   const { users, tracks, playlists } = related
 
   if (users && users.length > 0) {
-    primeUserData({
-      users: transformAndCleanList(users, userMetadataFromSDK),
-      queryClient,
-      forceReplace,
-      skipQueryData
-    })
+    // `related` users are hydrated server-side. When the server omits the
+    // requester's perspective (`does_current_user_follow` and other
+    // current-user fields), priming would shadow any later authoritative
+    // fetch — `useUser` / `useUserByHandle` use `staleTime: Infinity` and
+    // `primeUserData` skips overwriting an existing cache entry, so the
+    // partial prime would persist and the profile page would render stale
+    // follow state. Skip the prime in that case and let `useUser`'s
+    // batcher fetch fresh data with `currentUserId`.
+    // (The TS type claims `does_current_user_follow: boolean`, but the
+    // SDK leaves it `undefined` when the server omits the key.)
+    const primedUsers = transformAndCleanList(
+      users,
+      userMetadataFromSDK
+    ).filter(
+      (user) =>
+        (user as { does_current_user_follow?: boolean })
+          .does_current_user_follow !== undefined
+    )
+    if (primedUsers.length > 0) {
+      primeUserData({
+        users: primedUsers,
+        queryClient,
+        forceReplace,
+        skipQueryData
+      })
+    }
   }
 
   if (tracks && tracks.length > 0) {


### PR DESCRIPTION
## Summary

Fix profile page showing the wrong follow state after navigating from a "new track" user-subscription notification.

## Root cause

The [Perf] commit (#14287) made `/v1/notifications` return a `related.users` block hydrated server-side, and wired `useNotifications` to call `primeRelatedData({ related, queryClient })` to seed the tan-query cache and skip per-page N+1 user fetches. The server, however, hydrates those related users **without the requester's perspective** — `does_current_user_follow` (and other `*_current_user_*` fields) are omitted.

`primeUserData` writes those partial users into the user cache and the user-by-handle cache. Combined with:

- `entityCacheOptions` setting `staleTime: Infinity` / `gcTime: Infinity` on `useUser` / `useUserByHandle` ([entityCacheOptions.ts](packages/common/src/api/tan-query/utils/entityCacheOptions.ts))
- `primeUserData`'s skip-overwrite guard `!queryClient.getQueryData(...)` that intentionally preserves "richer" cached data ([primeUserData.ts](packages/common/src/api/tan-query/utils/primeUserData.ts:22))

…the partial prime sticks. Any later authoritative `getUserByHandle` / `getBulkUsers` fetch is either short-circuited by the cache hit, or — when it does run — refuses to overwrite. The profile page reads `profile.does_current_user_follow` ([useProfilePage.ts:346](packages/web/src/pages/profile-page/useProfilePage.ts:346)), which is `undefined`, and renders "Follow" for accounts the viewer is actually following.

The bug shows up on both platforms:
- **Web** — notification navigates to `profilePage(user.handle)`; `useUserByHandle` cache-hits on the primed handle mapping → `useUser` cache-hits on the primed (partial) user.
- **Mobile** — notification navigates to `Profile, { id: notification.userId }` ([useNotificationNavigation.ts:304](packages/mobile/src/hooks/useNotificationNavigation.ts:304)); `useUser` cache-hits on the primed (partial) user directly.

## Fix

In `primeRelatedData`, filter out `related.users` entries whose `does_current_user_follow` is `undefined` before priming. Those users are not safe to cache as canonical user data — let `useUser`'s batched `getBulkUsers` call (which sends `currentUserId`) fetch fresh, full data on demand. When the API server starts hydrating the requester's perspective on related users, the filter becomes a no-op and the perf optimization re-engages automatically — no follow-up client change needed.

Other `primeRelatedData` callers (comments, events) are unaffected if their server responses already include current-user context; if they don't, this is the correct behavior for them too.

## Test plan

- [ ] Open the app while signed in
- [ ] Receive (or already have) a "new track" notification from an account you follow
- [ ] Click the notification — for multi-upload notifications it routes to the artist's profile; verify the header shows "Following", not "Follow"
- [ ] Repeat for single-upload notifications by tapping the artist name (also routes to profile)
- [ ] Repeat on mobile (where navigation uses `userId`, not `handle`)
- [ ] Sanity-check the notification panel itself still renders avatars + names (priming is skipped, but `useUser`'s batcher fetches them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)