### PR TITLE
fix(notifications): personalize embedded users in related response

### DIFF
--- a/.changeset/notifications-path-id-rename.md
+++ b/.changeset/notifications-path-id-rename.md
@@ -1,0 +1,22 @@
+---
+'@audius/sdk': major
+---
+
+Rename the path field on `getNotifications` and `getPlaylistUpdates` from `userId` to `id`, matching the convention used by every `/users/{id}/…` method. Add an optional `userId` query field that carries the requester id for personalization of embedded `related.users` (e.g. `does_current_user_follow`).
+
+**Migration:**
+
+```ts
+// Before
+sdk.notifications.getNotifications({ userId: 'aE9MA' })
+sdk.notifications.getPlaylistUpdates({ userId: 'aE9MA' })
+
+// After
+sdk.notifications.getNotifications({
+  id: 'aE9MA',          // notifications owner (was `userId`)
+  userId: 'aE9MA'       // requester id, for personalization of related.users
+})
+sdk.notifications.getPlaylistUpdates({ id: 'aE9MA', userId: 'aE9MA' })
+```
+
+The two ids differ only when a manager reads a managed user's notifications; in the normal flow they're the same value. The wire format and server URL are unchanged — only the request type shape was renamed to remove a collision between the path and the new query parameter.

--- a/packages/common/src/api/tan-query/notifications/useNotificationUnreadCount.ts
+++ b/packages/common/src/api/tan-query/notifications/useNotificationUnreadCount.ts
@@ -35,14 +35,14 @@ export const useNotificationUnreadCount = () => {
       const response = await (
         sdk.notifications as {
           getNotifications: (params: {
-            userId: string
+            id: string
             limit?: number
           }) => Promise<{
             data?: { unreadCount?: number }
           }>
         }
       ).getNotifications({
-        userId: Id.parse(currentUserId),
+        id: Id.parse(currentUserId),
         limit: 0
       })
       return response?.data?.unreadCount ?? 0

--- a/packages/common/src/api/tan-query/notifications/useNotifications.ts
+++ b/packages/common/src/api/tan-query/notifications/useNotifications.ts
@@ -77,6 +77,10 @@ export const useNotifications = (options?: QueryOptions) => {
       const sdk = await audiusSdk()
       const response = await sdk.notifications.getNotifications({
         userId: Id.parse(currentUserId),
+        // Requester id sent as `?user_id=`. Needed so the backend personalizes
+        // embedded related.users (e.g. does_current_user_follow) — the path
+        // userId alone identifies the notifications owner, not the requester.
+        userId2: Id.parse(currentUserId),
         limit: DEFAULT_LIMIT,
         timestamp: pageParam?.timestamp,
         groupId: pageParam?.groupId

--- a/packages/common/src/api/tan-query/notifications/useNotifications.ts
+++ b/packages/common/src/api/tan-query/notifications/useNotifications.ts
@@ -76,11 +76,11 @@ export const useNotifications = (options?: QueryOptions) => {
     queryFn: async ({ pageParam = null }) => {
       const sdk = await audiusSdk()
       const response = await sdk.notifications.getNotifications({
+        id: Id.parse(currentUserId),
+        // Requester id sent as `?user_id=` so the backend personalizes
+        // embedded related.users (e.g. does_current_user_follow). The path
+        // id alone identifies the notifications owner, not the requester.
         userId: Id.parse(currentUserId),
-        // Requester id sent as `?user_id=`. Needed so the backend personalizes
-        // embedded related.users (e.g. does_current_user_follow) — the path
-        // userId alone identifies the notifications owner, not the requester.
-        userId2: Id.parse(currentUserId),
         limit: DEFAULT_LIMIT,
         timestamp: pageParam?.timestamp,
         groupId: pageParam?.groupId

--- a/packages/common/src/api/tan-query/playlist-updates/usePlaylistUpdates.ts
+++ b/packages/common/src/api/tan-query/playlist-updates/usePlaylistUpdates.ts
@@ -38,18 +38,18 @@ export const usePlaylistUpdates = <TResult = PlaylistUpdate[]>(
       const sdk = await audiusSdk()
       // sdk.notifications.getPlaylistUpdates is not currently typed in the
       // public SDK surface; cast to the expected shape used in the legacy saga.
-      // userId2 carries the requester id as `?user_id=` so the backend can
+      // userId carries the requester id as `?user_id=` so the backend can
       // personalize related.users in the response.
       const response = (await (
         sdk.notifications as {
           getPlaylistUpdates: (params: {
-            userId: string
-            userId2?: string
+            id: string
+            userId?: string
           }) => Promise<PlaylistUpdatesResponse>
         }
       ).getPlaylistUpdates({
-        userId: Id.parse(currentUserId),
-        userId2: Id.parse(currentUserId)
+        id: Id.parse(currentUserId),
+        userId: Id.parse(currentUserId)
       })) as PlaylistUpdatesResponse | undefined
 
       return transformAndCleanList(

--- a/packages/common/src/api/tan-query/playlist-updates/usePlaylistUpdates.ts
+++ b/packages/common/src/api/tan-query/playlist-updates/usePlaylistUpdates.ts
@@ -38,14 +38,18 @@ export const usePlaylistUpdates = <TResult = PlaylistUpdate[]>(
       const sdk = await audiusSdk()
       // sdk.notifications.getPlaylistUpdates is not currently typed in the
       // public SDK surface; cast to the expected shape used in the legacy saga.
+      // userId2 carries the requester id as `?user_id=` so the backend can
+      // personalize related.users in the response.
       const response = (await (
         sdk.notifications as {
           getPlaylistUpdates: (params: {
             userId: string
+            userId2?: string
           }) => Promise<PlaylistUpdatesResponse>
         }
       ).getPlaylistUpdates({
-        userId: Id.parse(currentUserId)
+        userId: Id.parse(currentUserId),
+        userId2: Id.parse(currentUserId)
       })) as PlaylistUpdatesResponse | undefined
 
       return transformAndCleanList(

--- a/packages/sdk/src/sdk/api/generated/default/apis/NotificationsApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/NotificationsApi.ts
@@ -27,6 +27,7 @@ import {
 
 export interface GetNotificationsRequest {
     userId: string;
+    userId2?: string;
     timestamp?: number;
     groupId?: string;
     limit?: number;
@@ -35,6 +36,7 @@ export interface GetNotificationsRequest {
 
 export interface GetPlaylistUpdatesRequest {
     userId: string;
+    userId2?: string;
 }
 
 /**
@@ -52,6 +54,10 @@ export class NotificationsApi extends runtime.BaseAPI {
         }
 
         const queryParameters: any = {};
+
+        if (params.userId2 !== undefined) {
+            queryParameters['user_id'] = params.userId2;
+        }
 
         if (params.timestamp !== undefined) {
             queryParameters['timestamp'] = params.timestamp;
@@ -99,6 +105,10 @@ export class NotificationsApi extends runtime.BaseAPI {
         }
 
         const queryParameters: any = {};
+
+        if (params.userId2 !== undefined) {
+            queryParameters['user_id'] = params.userId2;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 

--- a/packages/sdk/src/sdk/api/generated/default/apis/NotificationsApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/NotificationsApi.ts
@@ -26,8 +26,8 @@ import {
 } from '../models';
 
 export interface GetNotificationsRequest {
-    userId: string;
-    userId2?: string;
+    id: string;
+    userId?: string;
     timestamp?: number;
     groupId?: string;
     limit?: number;
@@ -35,8 +35,8 @@ export interface GetNotificationsRequest {
 }
 
 export interface GetPlaylistUpdatesRequest {
-    userId: string;
-    userId2?: string;
+    id: string;
+    userId?: string;
 }
 
 /**
@@ -49,14 +49,14 @@ export class NotificationsApi extends runtime.BaseAPI {
      * Get notifications for user ID
      */
     async getNotificationsRaw(params: GetNotificationsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<NotificationsResponse>> {
-        if (params.userId === null || params.userId === undefined) {
-            throw new runtime.RequiredError('userId','Required parameter params.userId was null or undefined when calling getNotifications.');
+        if (params.id === null || params.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter params.id was null or undefined when calling getNotifications.');
         }
 
         const queryParameters: any = {};
 
-        if (params.userId2 !== undefined) {
-            queryParameters['user_id'] = params.userId2;
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
         }
 
         if (params.timestamp !== undefined) {
@@ -78,7 +78,7 @@ export class NotificationsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/notifications/{user_id}`.replace(`{${"user_id"}}`, encodeURIComponent(String(params.userId))),
+            path: `/notifications/{id}`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
@@ -100,20 +100,20 @@ export class NotificationsApi extends runtime.BaseAPI {
      * Get playlists the user has saved that have been updated for user ID
      */
     async getPlaylistUpdatesRaw(params: GetPlaylistUpdatesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PlaylistUpdatesResponse>> {
-        if (params.userId === null || params.userId === undefined) {
-            throw new runtime.RequiredError('userId','Required parameter params.userId was null or undefined when calling getPlaylistUpdates.');
+        if (params.id === null || params.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter params.id was null or undefined when calling getPlaylistUpdates.');
         }
 
         const queryParameters: any = {};
 
-        if (params.userId2 !== undefined) {
-            queryParameters['user_id'] = params.userId2;
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/notifications/{user_id}/playlist_updates`.replace(`{${"user_id"}}`, encodeURIComponent(String(params.userId))),
+            path: `/notifications/{id}/playlist_updates`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -686,14 +686,6 @@ export interface GetUserFeedRequest {
     encodedDataSignature?: string;
 }
 
-export interface GetUserForYouFeedRequest {
-    id: string;
-    limit?: number;
-    offset?: number;
-    maxPerArtist?: number;
-    userId?: string;
-}
-
 export interface GetUserIDsByAddressesRequest {
     address: Array<string>;
 }
@@ -4172,62 +4164,6 @@ export class UsersApi extends runtime.BaseAPI {
      */
     async getUserFeed(params: GetUserFeedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserFeedResponse> {
         const response = await this.getUserFeedRaw(params, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * @hidden
-     * Returns a personalized For You feed for the user identified in the path. Twitter-style multi-source pipeline — candidate retrieval (in-network, trending, underground, similar-artist) → linear ranking (recency decay × engagement × social affinity, weighted by source) → diversity (per-artist cap + consecutive-same-artist lookahead).
-     * Get For You feed for user
-     */
-    async getUserForYouFeedRaw(params: GetUserForYouFeedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Tracks>> {
-        if (params.id === null || params.id === undefined) {
-            throw new runtime.RequiredError('id','Required parameter params.id was null or undefined when calling getUserForYouFeed.');
-        }
-
-        const queryParameters: any = {};
-
-        if (params.limit !== undefined) {
-            queryParameters['limit'] = params.limit;
-        }
-
-        if (params.offset !== undefined) {
-            queryParameters['offset'] = params.offset;
-        }
-
-        if (params.maxPerArtist !== undefined) {
-            queryParameters['max_per_artist'] = params.maxPerArtist;
-        }
-
-        if (params.userId !== undefined) {
-            queryParameters['user_id'] = params.userId;
-        }
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        if (!headerParameters["Authorization"] && this.configuration && this.configuration.accessToken) {
-            const token = await this.configuration.accessToken("OAuth2", ["read"]);
-            if (token) {
-                headerParameters["Authorization"] = token;
-            }
-        }
-
-        const response = await this.request({
-            path: `/users/{id}/feed/for-you`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => TracksFromJSON(jsonValue));
-    }
-
-    /**
-     * Returns a personalized For You feed for the user identified in the path. Twitter-style multi-source pipeline — candidate retrieval (in-network, trending, underground, similar-artist) → linear ranking (recency decay × engagement × social affinity, weighted by source) → diversity (per-artist cap + consecutive-same-artist lookahead).
-     * Get For You feed for user
-     */
-    async getUserForYouFeed(params: GetUserForYouFeedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Tracks> {
-        const response = await this.getUserForYouFeedRaw(params, initOverrides);
         return await response.value();
     }
 


### PR DESCRIPTION
## Summary

- Regenerate `@audius/sdk` to pick up the new `user_id` query parameter and renamed path placeholder on `GET /notifications/{id}` and `GET /notifications/{id}/playlist_updates` (api PRs [AudiusProject/api#837](https://github.com/AudiusProject/api/pull/837) + [AudiusProject/api#838](https://github.com/AudiusProject/api/pull/838), both merged).
- Pass the current user id through every call site so the backend personalizes embedded `related.users` in the response (`does_current_user_follow`, etc.).

## Why

The notifications endpoint embeds user objects in `related.users`. The backend personalizes those via `MyID: app.getMyId(c)` in [`api/v1_notifications.go:336`](https://github.com/AudiusProject/api/blob/main/api/v1_notifications.go#L336), and [`getMyId`](https://github.com/AudiusProject/api/blob/main/api/resolve_middleware.go#L30) reads from the **query string** `?user_id=`, not the URL path. The SDK only put the id in the path, so on the backend `MyID = 0` and the SQL [short-circuited](https://github.com/AudiusProject/api/blob/main/api/dbv1/get_users.sql.go#L129-L136) `does_current_user_follow` to `false` for every embedded user.

On a cold app boot, `useNotifications` fires early and `primeRelatedData` writes those un-personalized users into the tan-query cache. `primeUserData` only writes when the slot is empty (no `forceReplace`), so the bad entries stick until the user navigates to that profile and a personalized `getUser` fetch overwrites the cache. That's why visiting `@audius` directly and refreshing makes the Following state appear correct.

A backend-only fix would collapse two semantically distinct ids (notifications owner vs. requester) — incorrect when a manager reads a managed user's notifications. The fix is client-side: send the requester id as `?user_id=`, keep the path id for whose notifications.

## Changes

| File | Change |
| --- | --- |
| `packages/sdk/src/sdk/api/generated/default/apis/NotificationsApi.ts` | Regenerated. Path field renames `userId` → `id`; new `userId?: string` query field carries the requester id. |
| `packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts` | Incidental drift: `getUserForYouFeed` was removed upstream and the generated copy was stale. |
| `packages/common/src/api/tan-query/notifications/useNotifications.ts` | Pass `{ id, userId }` to the SDK. |
| `packages/common/src/api/tan-query/notifications/useNotificationUnreadCount.ts` | Update local cast type and call site to use `id` as the path field. (No requester id passed here — the unread count doesn't hydrate `related.users`.) |
| `packages/common/src/api/tan-query/playlist-updates/usePlaylistUpdates.ts` | Pass `{ id, userId }` to the SDK; widen the local cast type. |

## Breaking SDK change (external consumers)

The path field on `GetNotificationsRequest` and `GetPlaylistUpdatesRequest` renames from `userId` to `id`. External `@audius/sdk` consumers of these two methods will need to rename the field. Wire format and server behaviour are unchanged.

## Test plan

- [ ] CI green (typecheck/lint/tests).
- [ ] On a fresh app load with a signed-in account that follows `@audius`: confirm Following state renders correctly on lists hydrated from notification responses (e.g. notification panel actor avatars, recommended profiles surfaced from related users) without first having to navigate to `@audius`'s profile.
- [ ] Network inspector on the notifications request shows `?user_id=<hashed-current-user-id>` and `does_current_user_follow: true` for users actually followed in `related.users`.
- [ ] Manager flow: read notifications while acting as a managed user. `?user_id=` carries whatever the app treats as "current user" (the managed user in normal manager-switched state); personalization in the response reflects that perspective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)