### PR TITLE
fix(cache-prime): personalize embedded users on three more endpoints

### DIFF
--- a/.changeset/personalization-three-endpoints.md
+++ b/.changeset/personalization-three-endpoints.md
@@ -1,0 +1,13 @@
+---
+'@audius/sdk': minor
+---
+
+Add an optional `userId?: string` query parameter to three endpoints so the backend can personalize embedded users in `related.users` / collection owners (`does_current_user_follow`, etc.):
+
+- `events.getRemixContests`
+- `users.getContestsByUser`
+- `playlists.getPlaylistsNewReleases`
+
+Without this, the endpoints' handlers (`app.getMyId(c)`) resolved the requester id from the missing `?user_id=` query and got `0`, so embedded user objects came back with `does_current_user_follow: false` for everyone. Clients that primed those into a shared cache (e.g. via `primeRelatedData` / `primeCollectionData`) silently poisoned follow state for the surfaced artists.
+
+Existing callers continue to work unchanged — the field is optional. Pass `Id.parse(currentUserId)` (or whichever id your app treats as "me") to opt in.

--- a/packages/common/src/api/tan-query/collection/useNewAlbumReleases.ts
+++ b/packages/common/src/api/tan-query/collection/useNewAlbumReleases.ts
@@ -1,3 +1,4 @@
+import { Id } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { userCollectionMetadataFromSDK } from '~/adapters/collection'
@@ -7,6 +8,7 @@ import { ID } from '~/models'
 
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, QueryOptions } from '../types'
+import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { entityCacheOptions } from '../utils/entityCacheOptions'
 import { primeCollectionData } from '../utils/primeCollectionData'
 
@@ -28,6 +30,7 @@ export const useNewAlbumReleases = (
   const { limit = 10 } = args
   const { audiusSdk } = useQueryContext()
   const queryClient = useQueryClient()
+  const { data: currentUserId } = useCurrentUserId()
 
   const idQuery = useQuery({
     queryKey: getNewAlbumReleasesQueryKey({ limit }),
@@ -35,7 +38,11 @@ export const useNewAlbumReleases = (
       const sdk = await audiusSdk()
       const { data = [] } = await sdk.playlists.getPlaylistsNewReleases({
         limit,
-        type: 'album'
+        type: 'album',
+        // Requester id so the backend personalizes embedded album-owner users
+        // (e.g. does_current_user_follow). primeCollectionData fans these out
+        // into the shared user cache, so without this they'd poison it.
+        userId: currentUserId ? Id.parse(currentUserId) : undefined
       })
       const collections = transformAndCleanList(
         data,

--- a/packages/common/src/api/tan-query/events/useAllRemixContests.ts
+++ b/packages/common/src/api/tan-query/events/useAllRemixContests.ts
@@ -2,6 +2,7 @@ import {
   EventEntityTypeEnum,
   EventEventTypeEnum,
   GetRemixContestsStatusEnum,
+  Id,
   OptionalHashId,
   Event as SDKEvent
 } from '@audius/sdk'
@@ -16,6 +17,7 @@ import { removeNullable } from '~/utils'
 
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, QueryOptions } from '../types'
+import { useCurrentUserId } from '../users/account/useCurrentUserId'
 
 import { getEventIdsByEntityIdQueryKey, getEventQueryKey } from './utils'
 
@@ -61,6 +63,7 @@ export const useAllRemixContests = (
 ) => {
   const { audiusSdk } = useQueryContext()
   const queryClient = useQueryClient()
+  const { data: currentUserId } = useCurrentUserId()
 
   return useInfiniteQuery({
     queryKey: getAllRemixContestsQueryKey({ pageSize, status }),
@@ -74,7 +77,11 @@ export const useAllRemixContests = (
       const { data, related } = await sdk.events.getRemixContests({
         limit: pageSize,
         offset: pageParam,
-        status
+        status,
+        // Requester id so the backend personalizes embedded related.users
+        // (e.g. does_current_user_follow). Without it the cache primes those
+        // users un-personalized and other surfaces read the bad state.
+        userId: currentUserId ? Id.parse(currentUserId) : undefined
       })
 
       // Prime related tracks + users (full objects, delivered alongside the

--- a/packages/common/src/api/tan-query/events/useUserRemixContests.ts
+++ b/packages/common/src/api/tan-query/events/useUserRemixContests.ts
@@ -17,6 +17,7 @@ import { removeNullable } from '~/utils'
 
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, QueryOptions } from '../types'
+import { useCurrentUserId } from '../users/account/useCurrentUserId'
 
 import { getEventIdsByEntityIdQueryKey, getEventQueryKey } from './utils'
 
@@ -67,6 +68,7 @@ export const useUserRemixContests = (
 ) => {
   const { audiusSdk } = useQueryContext()
   const queryClient = useQueryClient()
+  const { data: currentUserId } = useCurrentUserId()
 
   return useInfiniteQuery({
     queryKey: getUserRemixContestsQueryKey({ userId, pageSize, status }),
@@ -82,7 +84,11 @@ export const useUserRemixContests = (
         id: Id.parse(userId),
         limit: pageSize,
         offset: pageParam,
-        status
+        status,
+        // Requester id so the backend personalizes embedded related.users
+        // (e.g. does_current_user_follow). Path `id` is the contest host;
+        // query `userId` is the current user viewing the page.
+        userId: currentUserId ? Id.parse(currentUserId) : undefined
       })
 
       // Prime related tracks + users (full objects, delivered alongside the

--- a/packages/sdk/src/sdk/api/generated/default/apis/EventsApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/EventsApi.ts
@@ -97,6 +97,7 @@ export interface GetRemixContestsRequest {
     offset?: number;
     limit?: number;
     status?: GetRemixContestsStatusEnum;
+    userId?: string;
 }
 
 export interface UnfollowEventRequest {
@@ -548,6 +549,10 @@ export class EventsApi extends runtime.BaseAPI {
 
         if (params.status !== undefined) {
             queryParameters['status'] = params.status;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/packages/sdk/src/sdk/api/generated/default/apis/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/PlaylistsApi.ts
@@ -96,6 +96,7 @@ export interface GetPlaylistsNewReleasesRequest {
     offset?: number;
     limit?: number;
     type?: GetPlaylistsNewReleasesTypeEnum;
+    userId?: string;
 }
 
 export interface GetTrendingPlaylistsRequest {
@@ -531,6 +532,10 @@ export class PlaylistsApi extends runtime.BaseAPI {
 
         if (params.type !== undefined) {
             queryParameters['type'] = params.type;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -322,6 +322,7 @@ export interface GetContestsByUserRequest {
     offset?: number;
     limit?: number;
     status?: GetContestsByUserStatusEnum;
+    userId?: string;
 }
 
 export interface GetFollowersRequest {
@@ -1737,6 +1738,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (params.status !== undefined) {
             queryParameters['status'] = params.status;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};


### PR DESCRIPTION
## Summary

Three more hooks were priming un-personalized users into the shared user cache — same bug class as the notifications fix in [#14366](https://github.com/AudiusProject/apps/pull/14366). API spec change merged in [AudiusProject/api#839](https://github.com/AudiusProject/api/pull/839); this PR consumes it.

| Hook | SDK call | Prime |
| --- | --- | --- |
| `useAllRemixContests` | `events.getRemixContests` | `primeRelatedData` |
| `useUserRemixContests` | `users.getContestsByUser` | `primeRelatedData` |
| `useNewAlbumReleases` | `playlists.getPlaylistsNewReleases` | `primeCollectionData` → `primeUserData` |

In every case the backend handler already calls `app.getMyId(c)` to feed `MyID` into the `Parallel` query that hydrates embedded users — the query param just wasn't being sent because the SDK request type didn't expose it. With no value, `MyID = 0` and the SQL [short-circuited](https://github.com/AudiusProject/api/blob/main/api/dbv1/get_users.sql.go#L129-L136) `does_current_user_follow` to false for every embedded user. Clients then primed those into a shared cache that other surfaces read.

## Changes

| File | Change |
| --- | --- |
| `packages/sdk/src/sdk/api/generated/default/apis/EventsApi.ts` | Add `userId?: string` to `GetRemixContestsRequest`; map to `queryParameters['user_id']`. |
| `packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts` | Add `userId?: string` to `GetContestsByUserRequest`; map to `queryParameters['user_id']`. Path field is still `id` (the contest host); query `userId` is the requester. |
| `packages/sdk/src/sdk/api/generated/default/apis/PlaylistsApi.ts` | Add `userId?: string` to `GetPlaylistsNewReleasesRequest`; map to `queryParameters['user_id']`. |
| `packages/common/src/api/tan-query/events/useAllRemixContests.ts` | Pull `currentUserId` via `useCurrentUserId`; pass as `userId`. |
| `packages/common/src/api/tan-query/events/useUserRemixContests.ts` | Same. Note this hook already took a `userId` prop for the contest host — that maps to the path `id`. `currentUserId` is separately threaded as the query. |
| `packages/common/src/api/tan-query/collection/useNewAlbumReleases.ts` | Pull `currentUserId`; pass as `userId`. |
| `.changeset/personalization-three-endpoints.md` | Minor `@audius/sdk` bump for the new optional fields. |

## Note on the SDK files in this diff

I edited the generated `*.ts` files by hand here because `npm install` in my environment was blocked by a date-pinned registry constraint, which broke `node_modules` and stopped both `gen.js` and the rollup build from running. The edits are deterministic — they replicate the exact pattern openapi-generator already produces for analogous endpoints (e.g. `GetTrendingPlaylistsRequest` in the same `PlaylistsApi.ts`). A fresh `npm run gen` on a clean checkout should produce the same diff. Worth a quick visual confirmation during review.

## Test plan

- [ ] CI green (typecheck/lint/tests).
- [ ] On a fresh app load with a signed-in account: explore → contests carousel, an artist's contests tab, and browse → new albums all show correct Following state for surfaced artists without first having to navigate to each profile.
- [ ] Network inspector on each of the three endpoints carries `?user_id=<hashed-current-user-id>` and `does_current_user_follow: true` for users actually followed in `related.users` / collection owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)