### PR TITLE
fix(web): seed contest source track from URL when permalink resolves

### DIFF
--- a/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
+++ b/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
@@ -281,6 +281,26 @@ export const HostRemixContestPage = () => {
     hasHydratedRef.current = true
   }, [remixContest, draft])
 
+  // On the track-scoped route (/:handle/:slug/host-contest) the URL
+  // identifies the source track, but `useTrackByPermalink` is async — by
+  // the time it resolves, the `useState` initializer above has already
+  // captured `primaryTrackId === undefined` and seeded `sourceTrackIds`
+  // to `[]`. Without this sync, the Source Track section shows "+ Add
+  // Track" instead of the URL's track and the Launch button stays
+  // disabled forever (`sourceTrackIds.length === 0`), so clicking Launch
+  // appears to do nothing. Run once when `primaryTrackId` first
+  // resolves; skip if state was already populated from a draft or
+  // existing contest, and never re-populate after a user removes the
+  // row.
+  const hasSeededPrimaryTrackRef = useRef(false)
+  useEffect(() => {
+    if (hasSeededPrimaryTrackRef.current) return
+    if (!primaryTrackId) return
+    hasSeededPrimaryTrackRef.current = true
+    if (sourceTrackIds.length > 0) return
+    setSourceTrackIds([primaryTrackId])
+  }, [primaryTrackId, sourceTrackIds.length])
+
   // The event's backing track: prefer the URL-scoped primary track, and
   // fall back to the (required) first Source Track when entering from the
   // track-less /host-contest route. This is the `entity_id` on create /


### PR DESCRIPTION
## Summary

Clicking **Launch** on the Host Remix Contest page produced no action, error, or modal when the user entered via the track-scoped route (`/:handle/:slug/host-contest`) — e.g. via the **Host Remix Contest** overflow-menu item on a track tile.

### Root cause

`useTrackByPermalink(...)` resolves asynchronously, but the form seeds `sourceTrackIds` via `useState(... primaryTrackId ? [primaryTrackId] : [])`. `useState` initializers only run on first mount, and on first mount `primaryTrackId === undefined` — so `sourceTrackIds` started empty and there was no `useEffect` to sync it once the track resolved. The Source Track section then rendered "+ Add Track" instead of the URL's track, and the Launch button stayed disabled (`sourceTrackIds.length === 0`).

The async race existed since [#14151](https://github.com/AudiusProject/apps/pull/14151), but the visible breakage was introduced in [#14174](https://github.com/AudiusProject/apps/pull/14174) when `sourceTrackIds.length === 0` was added to the Launch button's `disabled` check.

### Fix

Add a one-shot `useEffect` that seeds `sourceTrackIds` from `primaryTrackId` when it first resolves. Guarded by a ref so it:
- doesn't overwrite drafts or existing-contest hydration (`sourceTrackIds.length > 0` exits early),
- doesn't re-populate after the user removes the row (the ref locks the effect after the first run).

## Test plan

- [ ] As a logged-in artist, open one of your tracks and pick **Host Remix Contest** from the overflow menu.
- [ ] On the resulting `/{handle}/{slug}/host-contest` page, the **SOURCE TRACK** section should show the URL's track instead of the **+ Add Track** button.
- [ ] Fill out date / time / description, click **Launch** — the contest is created and the page redirects to `/{handle}/contest/{slug}`.
- [ ] Trackless route (`/host-contest` from the Contests page) still requires a manual pick and behaves unchanged.
- [ ] Edit mode (existing contest) still hydrates source tracks from `event_data.sourceTrackIds` and is unaffected.
- [ ] Removing the source-track row no longer auto-re-populates from the URL.

Note: I could not browser-verify locally — the page is gated by `useRequiresAccount()` and reproducing the bug requires being signed in as the track's owner on a real (prod-data) track. The change typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)