### PR TITLE
fix(common): show hidden playlists via permalink for logged-out users

### DIFF
--- a/packages/common/src/api/tan-query/collection/__tests__/useCollectionByPermalink.test.ts
+++ b/packages/common/src/api/tan-query/collection/__tests__/useCollectionByPermalink.test.ts
@@ -1,0 +1,136 @@
+import { Id, OptionalId } from '@audius/sdk'
+import { QueryClient } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { userCollectionMetadataFromSDK } from '~/adapters/collection'
+
+import { getCollectionQueryKey } from '../useCollection'
+import {
+  getCollectionByPermalinkQueryFn,
+  getCollectionByPermalinkQueryKey
+} from '../useCollectionByPermalink'
+
+vi.mock('~/adapters/collection', () => ({
+  userCollectionMetadataFromSDK: vi.fn((collection) => collection)
+}))
+
+describe('getCollectionByPermalinkQueryFn', () => {
+  const currentUserId = null
+  let queryClient: QueryClient
+  let sdk: {
+    playlists: {
+      getBulkPlaylists: ReturnType<typeof vi.fn>
+    }
+  }
+
+  const createCollection = (playlistId: number, permalink: string) =>
+    ({
+      playlist_id: playlistId,
+      permalink,
+      playlist_contents: { track_ids: [] }
+    }) as any
+
+  beforeEach(() => {
+    queryClient = new QueryClient()
+    sdk = {
+      playlists: {
+        getBulkPlaylists: vi.fn()
+      }
+    }
+    vi.mocked(userCollectionMetadataFromSDK).mockImplementation(
+      (collection) => collection as any
+    )
+  })
+
+  it('returns and primes a collection id from the permalink response', async () => {
+    const permalink = '/artist/playlist/test-playlist-123'
+    const collection = createCollection(123, permalink)
+    sdk.playlists.getBulkPlaylists.mockResolvedValueOnce({
+      data: [collection]
+    })
+
+    const result = await getCollectionByPermalinkQueryFn(
+      permalink,
+      currentUserId,
+      queryClient,
+      sdk
+    )
+
+    expect(result).toBe(123)
+    expect(sdk.playlists.getBulkPlaylists).toHaveBeenCalledTimes(1)
+    expect(sdk.playlists.getBulkPlaylists).toHaveBeenCalledWith({
+      permalink: [permalink],
+      userId: OptionalId.parse(currentUserId)
+    })
+    expect(queryClient.getQueryData(getCollectionQueryKey(123))).toMatchObject({
+      playlist_id: 123
+    })
+    expect(
+      queryClient.getQueryData(getCollectionByPermalinkQueryKey(permalink))
+    ).toBe(123)
+  })
+
+  it('falls back to the id in the permalink when the route lookup is empty', async () => {
+    const permalink = '/artist/album/hidden-album-456'
+    const collection = createCollection(456, permalink)
+    sdk.playlists.getBulkPlaylists
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [collection] })
+
+    const result = await getCollectionByPermalinkQueryFn(
+      permalink,
+      currentUserId,
+      queryClient,
+      sdk
+    )
+
+    expect(result).toBe(456)
+    expect(sdk.playlists.getBulkPlaylists).toHaveBeenNthCalledWith(1, {
+      permalink: [permalink],
+      userId: OptionalId.parse(currentUserId)
+    })
+    expect(sdk.playlists.getBulkPlaylists).toHaveBeenNthCalledWith(2, {
+      id: [Id.parse(456)],
+      userId: OptionalId.parse(currentUserId)
+    })
+    expect(queryClient.getQueryData(getCollectionQueryKey(456))).toMatchObject({
+      playlist_id: 456
+    })
+  })
+
+  it('ignores fallback id results that do not match the requested permalink', async () => {
+    const permalink = '/artist/playlist/hidden-playlist-789'
+    const collection = createCollection(
+      789,
+      '/another-artist/playlist/hidden-playlist-789'
+    )
+    sdk.playlists.getBulkPlaylists
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [collection] })
+
+    const result = await getCollectionByPermalinkQueryFn(
+      permalink,
+      currentUserId,
+      queryClient,
+      sdk
+    )
+
+    expect(result).toBeUndefined()
+    expect(queryClient.getQueryData(getCollectionQueryKey(789))).toBeUndefined()
+  })
+
+  it('skips fallback when the permalink has no parseable id', async () => {
+    const permalink = '/artist/playlist/no-id-here'
+    sdk.playlists.getBulkPlaylists.mockResolvedValueOnce({ data: [] })
+
+    const result = await getCollectionByPermalinkQueryFn(
+      permalink,
+      currentUserId,
+      queryClient,
+      sdk
+    )
+
+    expect(result).toBeUndefined()
+    expect(sdk.playlists.getBulkPlaylists).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/common/src/api/tan-query/collection/useCollectionByPermalink.ts
+++ b/packages/common/src/api/tan-query/collection/useCollectionByPermalink.ts
@@ -1,10 +1,11 @@
-import { OptionalId } from '@audius/sdk'
+import { Id, OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient, QueryClient } from '@tanstack/react-query'
 import { pick } from 'lodash'
 
 import { userCollectionMetadataFromSDK } from '~/adapters/collection'
 import { useQueryContext } from '~/api/tan-query/utils'
 import { ID } from '~/models/Identifiers'
+import { parsePlaylistIdFromPermalink } from '~/utils'
 
 import { TQCollection } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
@@ -30,22 +31,42 @@ export const getCollectionByPermalinkQueryFn = async (
   queryClient: QueryClient,
   sdk: any
 ) => {
+  const userId = OptionalId.parse(currentUserId)
   const { data = [] } = await sdk.playlists.getBulkPlaylists({
     permalink: [permalink],
-    userId: OptionalId.parse(currentUserId)
+    userId
   })
 
   const collection = userCollectionMetadataFromSDK(data[0])
 
   if (collection) {
-    // Prime related entities
     primeCollectionData({
       collections: [collection],
       queryClient
     })
+    return collection.playlist_id
   }
 
-  return collection?.playlist_id
+  // Permalink lookup filters out hidden (is_private) playlists for
+  // logged-out users, but ID-based lookup honors direct-link access.
+  // Fall back to fetching by the id embedded in the permalink slug.
+  const collectionId = parsePlaylistIdFromPermalink(permalink)
+  if (Number.isNaN(collectionId)) return undefined
+
+  const { data: fallbackData = [] } = await sdk.playlists.getBulkPlaylists({
+    id: [Id.parse(collectionId)],
+    userId
+  })
+  const fallbackCollection = userCollectionMetadataFromSDK(fallbackData[0])
+  // Guard against id collisions with a different playlist's permalink.
+  if (fallbackCollection?.permalink !== permalink) return undefined
+
+  primeCollectionData({
+    collections: [fallbackCollection],
+    queryClient
+  })
+
+  return fallbackCollection.playlist_id
 }
 
 export const useCollectionByPermalink = <TResult = TQCollection>(


### PR DESCRIPTION
## Summary
- Hidden (is_private) playlists were not viewable by logged-out users even via a direct permalink. The API filters them out of permalink-based lookups for unauthenticated requests, but returns them via ID-based lookups — matching how direct-link access works for hidden tracks.
- When the permalink lookup returns empty, fall back to fetching by the id embedded in the playlist permalink slug, then re-verify the returned permalink matches to guard against id collisions.

## Test plan
- [x] Added unit tests covering the success path, the hidden-playlist fallback path, the id-collision rejection path, and the missing-id case.
- [ ] Smoke test in browser: while signed out, open a hidden playlist's permalink and confirm the page loads (previously NOT_FOUND).
- [ ] Verify a public playlist still resolves with a single request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)