### PR TITLE
staking: forward solana_rpc_endpoint and eth_rpc_endpoint env vars

### DIFF
--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -41,6 +41,10 @@ services:
         app_name: staking
         TURBO_TEAM: '${TURBO_TEAM}'
         TURBO_TOKEN: '${TURBO_TOKEN}'
+    env_file: .env
+    environment:
+      solana_rpc_endpoint: '${SOLANA_RPC_ENDPOINT}'
+      eth_rpc_endpoint: '${ETH_RPC_ENDPOINT}'
     restart: always
     profiles:
       - pedalboard


### PR DESCRIPTION
## Summary
- The staking pedalboard service reads `process.env.solana_rpc_endpoint` and `process.env.eth_rpc_endpoint`, but the prod compose entry never forwarded them — the container would boot with both undefined.
- Adds `env_file: .env` plus an `environment:` block forwarding `SOLANA_RPC_ENDPOINT` and `ETH_RPC_ENDPOINT`, matching the pattern other pedalboard services use (e.g. `solana-relay`).

## Context
Pairs with the staking-service migration to the standalone pedalboard repo: https://github.com/AudiusProject/pedalboard (separate PR). That PR contains the `ClaimsManager` runtime fix, the `tsc`/`node dist` build setup, the `/health` endpoint, and the port pin to `6000` — but none of that helps if the RPC URLs never reach the container.

## Test plan
- [ ] Bring up the prod compose stack with `SOLANA_RPC_ENDPOINT` and `ETH_RPC_ENDPOINT` set in `.env`.
- [ ] `docker compose exec staking env | grep _rpc_endpoint` — confirm both are set.
- [ ] `curl http://staking:6000/init-round` — confirm the route does not crash on `process.env.eth_rpc_endpoint!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)