### PR TITLE
fix(web): use relative paths when navigating after contest submit

### DIFF
--- a/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
+++ b/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
@@ -48,7 +48,7 @@ import Page from 'components/page/Page'
 import { useRequiresAccount } from 'hooks/useRequiresAccount'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 import { track, make } from 'services/analytics'
-import { fullContestPage, fullTrackPage } from 'utils/route'
+import { contestPage } from 'utils/route'
 
 import {
   TimeInput,
@@ -442,11 +442,7 @@ export const HostRemixContestPage = () => {
       navigate(CONTESTS_PAGE)
       return
     }
-    navigate(
-      isEdit
-        ? fullContestPage(primaryPermalink)
-        : fullTrackPage(primaryPermalink)
-    )
+    navigate(isEdit ? contestPage(primaryPermalink) : primaryPermalink)
   }, [clearDraft, isEdit, navigate, primaryPermalink])
 
   const handleSubmit = useCallback(() => {
@@ -519,7 +515,7 @@ export const HostRemixContestPage = () => {
 
     clearDraft()
     if (effectivePermalink) {
-      navigate(fullContestPage(effectivePermalink))
+      navigate(contestPage(effectivePermalink))
     } else {
       navigate(CONTESTS_PAGE)
     }
@@ -561,7 +557,7 @@ export const HostRemixContestPage = () => {
     }
     clearDraft()
     if (primaryPermalink) {
-      navigate(fullTrackPage(primaryPermalink))
+      navigate(primaryPermalink)
     }
   }, [
     clearDraft,

--- a/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
+++ b/packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx
@@ -161,7 +161,7 @@ export const HostRemixContestPage = () => {
     isContestEntry: true
   })
 
-  const { mutate: createEvent } = useCreateEvent()
+  const { mutateAsync: createEvent } = useCreateEvent()
   const { mutate: updateEvent } = useUpdateEvent()
   const { mutate: deleteEvent } = useDeleteEvent()
 
@@ -445,7 +445,7 @@ export const HostRemixContestPage = () => {
     navigate(isEdit ? contestPage(primaryPermalink) : primaryPermalink)
   }, [clearDraft, isEdit, navigate, primaryPermalink])
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
     const parsedTime = parseTime(timeValue)
     if (!parsedTime) return
 
@@ -496,14 +496,21 @@ export const HostRemixContestPage = () => {
         })
       )
     } else {
-      createEvent({
-        eventType: EventEventTypeEnum.RemixContest,
-        entityType: EventEntityTypeEnum.Track,
-        entityId: entityTrackId,
-        eventData,
-        endDate,
-        userId: currentUserId
-      })
+      try {
+        await createEvent({
+          eventType: EventEventTypeEnum.RemixContest,
+          entityType: EventEntityTypeEnum.Track,
+          entityId: entityTrackId,
+          eventData,
+          endDate,
+          userId: currentUserId
+        })
+      } catch {
+        // Mutation's onError already surfaces a toast; stay on the form so
+        // the user can retry instead of navigating to a half-created
+        // contest page.
+        return
+      }
 
       track(
         make({


### PR DESCRIPTION
## Summary
- Submitting / cancelling / deleting a contest navigated to a full absolute URL (`http://audius.co/...`) via react-router's `navigate()`, which treats it as a relative path. Result: blank screens at malformed URLs like `/host-contest/https:/audius.co/<handle>/contest/<slug>`.
- Switched the three `navigate()` calls in [HostRemixContestPage.tsx](packages/web/src/pages/host-remix-contest-page/HostRemixContestPage.tsx) from `fullContestPage` / `fullTrackPage` to the relative `contestPage` helper (and the raw `permalink` for the track-page redirect).
- `fullContestPage` / `fullTrackPage` remain valid for share/canonical URLs — they should just never be passed to `navigate()`.

## Test plan
- [ ] Create a new remix contest from `/host-contest` (track-less entry) and submit → lands on the contest page (`/<handle>/contest/<slug>`), not a blank page.
- [ ] Create a contest from `/<handle>/<slug>/host-contest` and submit → lands on the contest page.
- [ ] Edit an existing contest and submit → lands on the contest page.
- [ ] Cancel during create → lands on the track page (`/<handle>/<slug>`).
- [ ] Cancel during edit → lands on the contest page.
- [ ] Delete a contest → lands on the track page.
- [ ] Cancel with no permalink (track-less, no source track chosen yet) → lands on `/contests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)