### PR TITLE
feat(web): paginate the audio transactions page

### DIFF
--- a/packages/common/src/api/tan-query/purchases/useAudioTransactions.ts
+++ b/packages/common/src/api/tan-query/purchases/useAudioTransactions.ts
@@ -1,13 +1,14 @@
+import { useCallback, useRef } from 'react'
+
 import {
   GetAudioTransactionsSortMethodEnum,
   GetAudioTransactionsSortDirectionEnum,
   Id
 } from '@audius/sdk'
-import { useQuery } from '@tanstack/react-query'
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
 
 import { audioTransactionFromSdk } from '~/adapters/audioTransactions'
 import { useQueryContext } from '~/api/tan-query/utils'
-import { ID } from '~/models'
 import { TransactionDetails } from '~/store/ui/transaction-details/types'
 import { Nullable } from '~/utils/typeUtils'
 
@@ -16,60 +17,65 @@ import { QueryKey, QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 
 type GetAudioTransactionsArgs = {
-  page?: number
   pageSize?: number
   sortMethod?: GetAudioTransactionsSortMethodEnum
   sortDirection?: GetAudioTransactionsSortDirectionEnum
 }
 
+// /v1/users/{id}/transactions/audio caps `limit` at 100 server-side. Keep the
+// page size at or below that.
 export const DEFAULT_AUDIO_TRANSACTIONS_BATCH_SIZE = 50
 
 export const getAudioTransactionsQueryKey = ({
   userId,
-  page,
   sortMethod,
   sortDirection,
   pageSize
-}: GetAudioTransactionsArgs & { userId: Nullable<ID> | undefined }) =>
+}: GetAudioTransactionsArgs & { userId: Nullable<number> | undefined }) =>
   [
     QUERY_KEYS.audioTransactions,
     userId,
     {
-      page,
       sortMethod,
       sortDirection,
       pageSize
     }
-  ] as unknown as QueryKey<TransactionDetails[]>
+  ] as unknown as QueryKey<InfiniteData<TransactionDetails[]>>
 
 export const useAudioTransactions = (
-  args: GetAudioTransactionsArgs,
+  args: GetAudioTransactionsArgs = {},
   options?: QueryOptions
 ) => {
   const { audiusSdk } = useQueryContext()
   const { data: userId } = useCurrentUserId()
   const {
-    page = 0,
     pageSize = DEFAULT_AUDIO_TRANSACTIONS_BATCH_SIZE,
     sortMethod,
     sortDirection
   } = args
 
-  const queryResults = useQuery({
+  const queryResult = useInfiniteQuery({
     queryKey: getAudioTransactionsQueryKey({
       userId,
-      page,
       sortMethod,
       sortDirection,
       pageSize
     }),
-    queryFn: async () => {
+    initialPageParam: 0,
+    getNextPageParam: (
+      lastPage: TransactionDetails[],
+      allPages: TransactionDetails[][]
+    ) => {
+      if (lastPage.length < pageSize) return undefined
+      return allPages.length * pageSize
+    },
+    queryFn: async ({ pageParam }) => {
       if (!userId) return []
 
       const sdk = await audiusSdk()
       const response = await sdk.users.getAudioTransactions({
         id: Id.parse(userId),
-        offset: page * pageSize,
+        offset: pageParam,
         limit: pageSize,
         sortMethod,
         sortDirection
@@ -79,9 +85,24 @@ export const useAudioTransactions = (
 
       return response.data.map(audioTransactionFromSdk)
     },
+    select: (data) => data.pages.flat(),
     ...options,
     enabled: options?.enabled !== false && !!userId
   })
 
-  return queryResults
+  // Stable identity for loadNextPage so the consuming Table's `loadMoreRows`
+  // doesn't change every render. Mirrors the pattern in usePurchases.
+  const queryResultRef = useRef(queryResult)
+  queryResultRef.current = queryResult
+  const loadNextPage = useCallback(() => {
+    const q = queryResultRef.current
+    if (q.isFetching || !q.hasNextPage) return undefined
+    return q.fetchNextPage()
+  }, [])
+
+  return {
+    ...queryResult,
+    data: queryResult.data,
+    loadNextPage
+  }
 }

--- a/packages/web/src/pages/audio-page/AudioWalletTransactions.tsx
+++ b/packages/web/src/pages/audio-page/AudioWalletTransactions.tsx
@@ -36,12 +36,6 @@ const messages = {
 
 const AUDIO_TRANSACTIONS_SHOW_MORE_LIMIT = 5
 
-// /v1/users/{id}/transactions/audio caps `limit` at 100 server-side. The page
-// fetches in a single batch (no pagination UI), so this is also the most we'll
-// ever render at once. Power users with more than 100 transactions see only the
-// most recent 100 until a "load more" affordance is added.
-const AUDIO_TRANSACTIONS_SERVER_MAX_LIMIT = 100
-
 const Disclaimer = () => {
   const setVisibility = useSetVisibility()
   return (
@@ -82,23 +76,17 @@ export const AudioWalletTransactions = () => {
   const { data: audioTransactionsCount = 0, isPending: isCountLoading } =
     useAudioTransactionsCount()
 
-  const requestedPageSize = Math.min(
-    audioTransactionsCount > 0
-      ? audioTransactionsCount
-      : DEFAULT_AUDIO_TRANSACTIONS_BATCH_SIZE,
-    AUDIO_TRANSACTIONS_SERVER_MAX_LIMIT
+  const {
+    data: audioTransactions = [],
+    isPending: isTransactionsLoading,
+    loadNextPage
+  } = useAudioTransactions(
+    {
+      sortMethod,
+      sortDirection
+    },
+    { refetchOnMount: 'always' }
   )
-
-  const { data: audioTransactions = [], isPending: isTransactionsLoading } =
-    useAudioTransactions(
-      {
-        page: 0,
-        pageSize: requestedPageSize,
-        sortMethod,
-        sortDirection
-      },
-      { refetchOnMount: 'always' }
-    )
 
   // Defaults: sort method = date, sort direction = desc
   const onSort = useCallback(
@@ -149,6 +137,10 @@ export const AudioWalletTransactions = () => {
           onClickRow={onClickRow}
           showMoreLimit={AUDIO_TRANSACTIONS_SHOW_MORE_LIMIT}
           scrollRef={mainContentRef}
+          fetchMore={loadNextPage}
+          totalRowCount={audioTransactionsCount}
+          fetchBatchSize={DEFAULT_AUDIO_TRANSACTIONS_BATCH_SIZE}
+          isVirtualized={true}
         />
       )}
     </Flex>

--- a/packages/web/src/pages/audio-page/AudioWalletTransactions.tsx
+++ b/packages/web/src/pages/audio-page/AudioWalletTransactions.tsx
@@ -36,6 +36,12 @@ const messages = {
 
 const AUDIO_TRANSACTIONS_SHOW_MORE_LIMIT = 5
 
+// /v1/users/{id}/transactions/audio caps `limit` at 100 server-side. The page
+// fetches in a single batch (no pagination UI), so this is also the most we'll
+// ever render at once. Power users with more than 100 transactions see only the
+// most recent 100 until a "load more" affordance is added.
+const AUDIO_TRANSACTIONS_SERVER_MAX_LIMIT = 100
+
 const Disclaimer = () => {
   const setVisibility = useSetVisibility()
   return (
@@ -76,10 +82,12 @@ export const AudioWalletTransactions = () => {
   const { data: audioTransactionsCount = 0, isPending: isCountLoading } =
     useAudioTransactionsCount()
 
-  const requestedPageSize =
+  const requestedPageSize = Math.min(
     audioTransactionsCount > 0
       ? audioTransactionsCount
-      : DEFAULT_AUDIO_TRANSACTIONS_BATCH_SIZE
+      : DEFAULT_AUDIO_TRANSACTIONS_BATCH_SIZE,
+    AUDIO_TRANSACTIONS_SERVER_MAX_LIMIT
+  )
 
   const { data: audioTransactions = [], isPending: isTransactionsLoading } =
     useAudioTransactions(


### PR DESCRIPTION
## Summary

Replaces the "fetch everything in one shot" pattern on the AUDIO transactions page with proper infinite pagination, matching what the USDC purchases / sales / withdrawals tables already do.

## Background

\`AudioWalletTransactions.tsx\` was setting \`pageSize = audioTransactionsCount\` so the table could render every transaction in a single fetch (the table has no built-in pagination UI). For users with more than 100 transactions, this exceeded the server-side validator on \`/v1/users/{id}/transactions/audio\` (\`limit\` max=100), and the request failed outright — power users saw an empty page.

The first commit on this branch just clamped the requested size at 100 (stopping the bleeding). This second commit replaces the workaround with real pagination.

## Changes

**\`useAudioTransactions\`** (\`packages/common\`)
- Convert from \`useQuery\` to \`useInfiniteQuery\` with \`getNextPageParam\` keyed on accumulated page count × pageSize.
- Expose \`loadNextPage\` with a stable identity (ref-based, matches the pattern in \`usePurchases\`).
- Default \`pageSize\` stays at 50.

**\`AudioWalletTransactions.tsx\`** (\`packages/web\`)
- Drop the count-based \`pageSize\` hack and the \`Math.min(..., 100)\` clamp from the previous commit.
- Pass \`fetchMore={loadNextPage}\`, \`totalRowCount={audioTransactionsCount}\`, \`fetchBatchSize={DEFAULT_AUDIO_TRANSACTIONS_BATCH_SIZE}\`, \`isVirtualized={true}\` to \`AudioTransactionsTable\`. Same wiring as \`PurchasesTab → PurchasesTable\`.

## Server-side win

This also bounds the worst-case input to the slow \`ORDER BY transaction_type\` plan I flagged in [api#844](https://github.com/AudiusProject/api/pull/844): the server can now never be asked for more than 50 rows per request, capping the cost of the materialize-and-sort plan.

## Test plan

- [ ] As a low-activity user (< 50 audio txns): page renders identically to before.
- [ ] As a heavy user (> 50): initial fetch returns 50, scrolling triggers \`loadNextPage\` which fetches the next 50, repeats until \`totalRowCount\` is reached.
- [ ] Sort toggles (date / transaction_type, asc / desc) reset the infinite query correctly via queryKey change.
- [ ] Power user with > 100 txns no longer sees an empty page (the bug this branch was opened for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)