### PR TITLE
chore: point anti-abuse oracle endpoint at anti-abuse-oracle.audius.engineering

### DIFF
--- a/.changeset/aao-endpoint-engineering.md
+++ b/.changeset/aao-endpoint-engineering.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Point the production anti-abuse oracle endpoint at `https://anti-abuse-oracle.audius.engineering`, replacing the old `https://discoveryprovider.audius.co` host in the SDK services config and supporting clients/services.

--- a/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/actionLog.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/actionLog.ts
@@ -185,7 +185,7 @@ export async function getUserNormalizedScore(userId: number, wallet: string) {
 }
 
 export async function getAAOAttestation(handle: string) {
-  const url = `https://antiabuseoracle.audius.co/abuse/${handle}`
+  const url = `https://anti-abuse-oracle.audius.engineering/abuse/${handle}`
   try {
     const response = await fetch(url)
     if (!response.ok) {

--- a/packages/identity-service/src/utils/antiAbuse.js
+++ b/packages/identity-service/src/utils/antiAbuse.js
@@ -4,7 +4,7 @@ const { logger } = require('../logging')
 const models = require('../models')
 
 const aaoEndpoint =
-  config.get('aaoEndpoint') || 'https://antiabuseoracle.audius.co'
+  config.get('aaoEndpoint') || 'https://anti-abuse-oracle.audius.engineering'
 
 const allowRules = new Set([-17, -18])
 const blockRelayAbuseErrorCodes = new Set([0, 8, 10, 13, 15, 18])

--- a/packages/mobile/src/services/env/env.prod.ts
+++ b/packages/mobile/src/services/env/env.prod.ts
@@ -2,7 +2,7 @@ import type { Env } from '@audius/common/services'
 import Config from 'react-native-config'
 
 export const env: Env = {
-  AAO_ENDPOINT: 'https://discoveryprovider.audius.co',
+  AAO_ENDPOINT: 'https://anti-abuse-oracle.audius.engineering',
   AMPLITUDE_API_KEY: '86760558b8bb1b3aae61656efd4ddacb',
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',

--- a/packages/sdk/src/sdk/config/production.ts
+++ b/packages/sdk/src/sdk/config/production.ts
@@ -24,7 +24,7 @@ export const productionConfig: SdkServicesConfig = {
     ],
     "antiAbuseOracleNodes": {
       "endpoints": [
-        "https://discoveryprovider.audius.co",
+        "https://anti-abuse-oracle.audius.engineering",
         "https://audius-oracle.creatorseed.com",
         "https://oracle.audius.endl.net"
       ],

--- a/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
+++ b/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
@@ -23,7 +23,7 @@ const productionConfig: SdkServicesConfig = {
     storageNodes: [],
     antiAbuseOracleNodes: {
       endpoints: [
-        'https://discoveryprovider.audius.co',
+        'https://anti-abuse-oracle.audius.engineering',
         'https://audius-oracle.creatorseed.com',
         'https://oracle.audius.endl.net'
       ],

--- a/packages/web/src/services/env/env.prod.ts
+++ b/packages/web/src/services/env/env.prod.ts
@@ -1,7 +1,7 @@
 import { Env } from '@audius/common/services'
 
 export const env: Env = {
-  AAO_ENDPOINT: 'https://discoveryprovider.audius.co',
+  AAO_ENDPOINT: 'https://anti-abuse-oracle.audius.engineering',
   AMPLITUDE_API_KEY: '86760558b8bb1b3aae61656efd4ddacb',
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',


### PR DESCRIPTION
## Summary
- Switch the production anti-abuse oracle endpoint from the legacy `https://discoveryprovider.audius.co` host (and the older `https://antiabuseoracle.audius.co` fallback used by identity / the AAO pedalboard plugin) to `https://anti-abuse-oracle.audius.engineering`.
- Updates touch: `packages/web` and `packages/mobile` env.prod, `packages/identity-service` AAO util default, the AAO pedalboard plugin's `getAAOAttestation` URL, the SDK services config (`generateServicesConfig.ts` source + autogenerated `production.ts`).
- Discovery / validator node URLs were intentionally left untouched. Local dev defaults (docker-compose / env.dev) also untouched.

This is the AAO-only slice of #14380; the contest navigation fixes that were mixed into that branch are already up as #14377.

## Test plan
- [ ] Verify `npm run verify` passes
- [ ] Spot-check that web/mobile production builds pick up the new `AAO_ENDPOINT`
- [ ] Confirm identity service still resolves `aaoEndpoint` from env override in production (default change only affects unconfigured environments)
- [ ] Confirm SDK consumers resolve the new endpoint via `antiAbuseOracleSelector` against the registered AAO eth address `0x9811BA3eAB1F2Cd9A2dFeDB19e8c2a69729DC8b6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)