### PR TITLE
fix(mobile): route all contest notifications to Contest screen

### DIFF
--- a/packages/mobile/src/hooks/useNotificationNavigation.ts
+++ b/packages/mobile/src/hooks/useNotificationNavigation.ts
@@ -39,6 +39,7 @@ import type {
   CommentReactionNotification,
   AnnouncementPushNotification,
   FanClubTextPostNotification,
+  FanRemixContestStartedNotification,
   FanRemixContestSubmissionNotification
 } from '@audius/common/store'
 import {
@@ -333,7 +334,11 @@ export const useNotificationNavigation = () => {
       [NotificationType.CommentMention]: entityHandler,
       [NotificationType.CommentThread]: entityHandler,
       [NotificationType.CommentReaction]: entityHandler,
-      [NotificationType.FanRemixContestStarted]: entityHandler,
+      [NotificationType.FanRemixContestStarted]: (
+        notification: FanRemixContestStartedNotification
+      ) => {
+        navigation.navigate('Contest', { trackId: notification.entityId })
+      },
       [NotificationType.FanRemixContestEnded]: entityHandler,
       [NotificationType.FanRemixContestEndingSoon]: entityHandler,
       [NotificationType.FanRemixContestWinnersSelected]: entityHandler,

--- a/packages/mobile/src/hooks/useNotificationNavigation.ts
+++ b/packages/mobile/src/hooks/useNotificationNavigation.ts
@@ -40,7 +40,14 @@ import type {
   AnnouncementPushNotification,
   FanClubTextPostNotification,
   FanRemixContestStartedNotification,
-  FanRemixContestSubmissionNotification
+  FanRemixContestEndingSoonNotification,
+  FanRemixContestEndedNotification,
+  FanRemixContestWinnersSelectedNotification,
+  RemixContestUpdateNotification,
+  FanRemixContestSubmissionNotification,
+  ArtistRemixContestEndedNotification,
+  ArtistRemixContestEndingSoonNotification,
+  ArtistRemixContestSubmissionsNotification
 } from '@audius/common/store'
 import {
   NotificationType,
@@ -222,6 +229,26 @@ export const useNotificationNavigation = () => {
     [navigation, linkTo]
   )
 
+  // All contest-related notifications carry the contest's host track in
+  // `entityId` and should land on that contest's screen. The Contest
+  // screen accepts `{ trackId }` and resolves its own event/comments.
+  const contestHandler = useCallback(
+    (
+      notification:
+        | FanRemixContestStartedNotification
+        | FanRemixContestEndingSoonNotification
+        | FanRemixContestEndedNotification
+        | FanRemixContestWinnersSelectedNotification
+        | RemixContestUpdateNotification
+        | ArtistRemixContestEndedNotification
+        | ArtistRemixContestEndingSoonNotification
+        | ArtistRemixContestSubmissionsNotification
+    ) => {
+      navigation.navigate('Contest', { trackId: notification.entityId })
+    },
+    [navigation]
+  )
+
   const notificationTypeHandlerMap = useMemo(
     () => ({
       [NotificationType.AddTrackToPlaylist]: (
@@ -334,24 +361,25 @@ export const useNotificationNavigation = () => {
       [NotificationType.CommentMention]: entityHandler,
       [NotificationType.CommentThread]: entityHandler,
       [NotificationType.CommentReaction]: entityHandler,
-      [NotificationType.FanRemixContestStarted]: (
-        notification: FanRemixContestStartedNotification
-      ) => {
-        navigation.navigate('Contest', { trackId: notification.entityId })
-      },
-      [NotificationType.FanRemixContestEnded]: entityHandler,
-      [NotificationType.FanRemixContestEndingSoon]: entityHandler,
-      [NotificationType.FanRemixContestWinnersSelected]: entityHandler,
-      [NotificationType.RemixContestUpdate]: entityHandler,
+      [NotificationType.FanRemixContestStarted]: contestHandler,
+      [NotificationType.FanRemixContestEnded]: contestHandler,
+      [NotificationType.FanRemixContestEndingSoon]: contestHandler,
+      [NotificationType.FanRemixContestWinnersSelected]: contestHandler,
+      [NotificationType.RemixContestUpdate]: contestHandler,
       [NotificationType.FanRemixContestSubmission]: (
         notification: FanRemixContestSubmissionNotification
       ) => {
+        // The submission notification fires when a fan's remix is submitted
+        // to a contest — landing on the submitted track (not the contest)
+        // matches the web destination and lets the recipient play it.
         navigation.navigate('Track', {
           trackId: notification.submissionTrackId,
           canBeUnlisted: false
         })
       },
-      [NotificationType.ArtistRemixContestEnded]: entityHandler,
+      [NotificationType.ArtistRemixContestEnded]: contestHandler,
+      [NotificationType.ArtistRemixContestEndingSoon]: contestHandler,
+      [NotificationType.ArtistRemixContestSubmissions]: contestHandler,
       [NotificationType.FanClubTextPost]: (
         notification: FanClubTextPostNotification & { ticker?: string }
       ) => {
@@ -368,6 +396,7 @@ export const useNotificationNavigation = () => {
       announcementHandler,
       socialActionHandler,
       entityHandler,
+      contestHandler,
       milestoneHandler,
       userIdHandler,
       messagesHandler,

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestStartedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestStartedNotification.tsx
@@ -36,7 +36,7 @@ export const FanRemixContestStartedNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }


### PR DESCRIPTION
## Summary

Most remix-contest notifications still mapped to the generic `entityHandler` in `useNotificationNavigation.ts`. That handler routes `Entity.Track` notifications to the Track screen, but every contest notification is meant to land on the contest page for the host track.

Two of them weren't mapped at all (`ArtistRemixContestEndingSoon`, `ArtistRemixContestSubmissions`) — tapping those pushes was a silent no-op.

This PR introduces a shared `contestHandler` and routes every contest notification through it:

| Notification | Before | After |
|---|---|---|
| FanRemixContestStarted | Track | **Contest** |
| FanRemixContestEnded | Track (no entityType → fell through to no-op) | **Contest** |
| FanRemixContestEndingSoon | Track | **Contest** |
| FanRemixContestWinnersSelected | Track | **Contest** |
| RemixContestUpdate | Track / NotificationUsers | **Contest** |
| FanRemixContestSubmission | Submission Track | **Submission Track** *(unchanged — matches web; lets the recipient play the remix)* |
| ArtistRemixContestEnded | Track | **Contest** |
| ArtistRemixContestEndingSoon | **No-op (unmapped)** | **Contest** |
| ArtistRemixContestSubmissions | **No-op (unmapped)** | **Contest** |

The Contest screen accepts `{ trackId }` and resolves the event, comments, and tabs internally. `entityId` on every contest notification is the host track id, which is exactly what the screen wants.

## Test plan

For each notification type, send yourself a push and tap from the lock screen / notification center:

- [ ] `FanRemixContestStarted` → opens Contest page for the host track
- [ ] `FanRemixContestEndingSoon` → opens Contest page
- [ ] `FanRemixContestEnded` → opens Contest page (was a no-op before)
- [ ] `FanRemixContestWinnersSelected` → opens Contest page
- [ ] `RemixContestUpdate` → opens Contest page
- [ ] `FanRemixContestSubmission` → opens the submission's Track page (unchanged)
- [ ] `ArtistRemixContestEnded` → opens Contest page
- [ ] `ArtistRemixContestEndingSoon` → opens Contest page (was a no-op before)
- [ ] `ArtistRemixContestSubmissions` → opens Contest page (was a no-op before)
- [ ] Tap an in-app inbox row of each kind — same destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)