### PR TITLE
fix(mobile): comment kebab swallowed by redundant CommentSectionProvider

### DIFF
--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react'
 
 import { useUser } from '@audius/common/api'
 import {
-  CommentSectionProvider,
   useCurrentCommentSection,
   useDeleteComment,
   useUpdateCommentNotificationSetting,
@@ -262,14 +261,12 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
 
       <Portal hostName='DrawerPortal'>
         {isVisible ? (
-          <CommentSectionProvider entityId={entityId}>
-            <ActionDrawerWithoutRedux
-              rows={rows}
-              isOpen={isOpen}
-              onClose={() => setIsOpen(false)}
-              onClosed={() => setIsVisible(false)}
-            />
-          </CommentSectionProvider>
+          <ActionDrawerWithoutRedux
+            rows={rows}
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            onClosed={() => setIsVisible(false)}
+          />
         ) : null}
 
         {isFlagAndHideConfirmationVisible ? (


### PR DESCRIPTION
## Summary

Follow-up to #14342, which only fixed half the kebab bug. Users are still reporting that tapping the `⋮` on a comment in the comments drawer does nothing.

The action drawer rendered inside the portal is wrapped in a redundant `CommentSectionProvider`:

```tsx
// CommentOverflowMenu.tsx (current main)
<Portal hostName='DrawerPortal'>
  {isVisible ? (
    <CommentSectionProvider entityId={entityId}>   // ← problem
      <ActionDrawerWithoutRedux ... />
    </CommentSectionProvider>
  ) : null}
</Portal>
```

`CommentSectionProvider` re-runs `useTrack(entityId)` at the portal target's position in the React tree and short-circuits:

```ts
// packages/common/src/context/comments/commentsContext.tsx:232
if (!track) {
  return null
}
```

When `useTrack` returns `undefined` on the first render in this position, the action drawer is unmounted before it can render — the kebab "does nothing." Nothing inside `ActionDrawerWithoutRedux` actually consumes the comment section context: the `rows` array is constructed in the outer render (where the provider already exists) and the row callbacks close over that scope. `CommentDrawerHeader` portals an `ActionDrawerWithoutRedux` to the same host without this wrapper and works fine.

This fix was identified in the abandoned branch [`097e2f376c`](https://github.com/AudiusProject/apps/commit/097e2f376c) alongside the toggle-desync fix that ended up in #14342, but the provider-removal half was dropped when the merged PR was rewritten.

## Test plan

- [ ] Open a track, open the comments drawer
- [ ] Tap the kebab on your own comment → action drawer slides up with Edit / Delete
- [ ] Tap the kebab on another user's comment → drawer slides up with Flag / Mute User, etc.
- [ ] Repeat on a freshly-cold-started app (so the track query has to rehydrate from persisted cache) — drawer should still open on the first tap
- [ ] Close the drawer (row tap / backdrop / swipe) → kebab still opens on the very next tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)