### PR TITLE
fix(mobile): remove duplicate analytics import in ContestScreen

### DIFF
--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -35,7 +35,6 @@ import { useDispatch } from 'react-redux'
 import { Button, Divider, Flex, Text } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
 import { ProfilePicture } from 'app/components/core/ProfilePicture'
-import { make, track as trackEvent } from 'app/services/analytics'
 import {
   CollapsibleTabNavigator,
   collapsibleTabScreen


### PR DESCRIPTION
## Summary
- Fixes mobile CI failure (typecheck + lint) caused by a duplicate `import { make, track as trackEvent } from 'app/services/analytics'` in [ContestScreen.tsx](packages/mobile/src/screens/contest-screen/ContestScreen.tsx).
- The duplicate (out-of-order) copy is removed; the properly ordered import is retained.

## Test plan
- [ ] CI mobile `verify` (typecheck, lint, lint:env) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)