### PR TITLE
ci(mobile): symlink react-native CLI for CodePush OTA bundling

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -285,6 +285,15 @@ jobs:
             echo "channel=rc" >> "$GITHUB_OUTPUT"
           fi
 
+      # @bravemobile/react-native-code-push@12.3.2 hardcodes
+      # `node_modules/.bin/react-native` relative to cwd. After #14365 the
+      # react-native dep hoists to root node_modules, so the bin is only at
+      # ./node_modules/.bin/react-native — not packages/mobile/node_modules/.bin/.
+      - name: Symlink react-native CLI into packages/mobile/node_modules/.bin
+        run: |
+          mkdir -p packages/mobile/node_modules/.bin
+          ln -sf "$(pwd)/node_modules/.bin/react-native" packages/mobile/node_modules/.bin/react-native
+
       - name: Publish OTA update (${{ matrix.platform }})
         env:
           OTA_S3_BUCKET: ${{ secrets.OTA_S3_BUCKET }}
@@ -389,6 +398,15 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
+      # @bravemobile/react-native-code-push@12.3.2 hardcodes
+      # `node_modules/.bin/react-native` relative to cwd. After #14365 the
+      # react-native dep hoists to root node_modules, so the bin is only at
+      # ./node_modules/.bin/react-native — not packages/mobile/node_modules/.bin/.
+      - name: Symlink react-native CLI into packages/mobile/node_modules/.bin
+        run: |
+          mkdir -p packages/mobile/node_modules/.bin
+          ln -sf "$(pwd)/node_modules/.bin/react-native" packages/mobile/node_modules/.bin/react-native
 
       - name: Publish OTA update to production (${{ matrix.platform }})
         env:


### PR DESCRIPTION
## Summary
- Fixes Mobile OTA Release (CodePush) jobs failing with `node_modules/.bin/react-native: not found` (exit 127). Example: [run 26308703765](https://github.com/AudiusProject/apps/actions/runs/26308703765/job/77452051457).
- After [#14365](https://github.com/AudiusProject/apps/pull/14365) regenerated the lockfile, `react-native` (and the bin from `@react-native-community/cli`) hoists to the monorepo root `node_modules/`, so `packages/mobile/node_modules/.bin/react-native` no longer exists.
- [`@bravemobile/react-native-code-push@12.3.2`](https://app.unpkg.com/@bravemobile/react-native-code-push@12.3.2/files/cli/dist/functions/runReactNativeBundleCommand.js) hardcodes the relative path `node_modules/.bin/react-native` (cwd is `packages/mobile`) when invoking `react-native bundle`, so the lookup fails.
- Add a symlink step before `npx code-push release` in both `mobile-ota-release` and `mobile-ota-release-production` that points `packages/mobile/node_modules/.bin/react-native` at the hoisted root binary.

## Test plan
- [ ] Mobile OTA Release (CodePush, ios) on this PR's merge to `main` succeeds (or workflow_dispatch w/ `rc` channel).
- [ ] Mobile OTA Release (CodePush, android) on this PR's merge to `main` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)