### PR TITLE
feat(for-you): switch useForYouFeed to dedicated /users/{id}/feed/for-you endpoint

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
@@ -55,7 +55,7 @@ export const useForYouFeed = (
       const isFirstPage = pageParam === 0
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       const sdk = await audiusSdk()
-      const { data = [] } = await sdk.users.getUserFeedForYou({
+      const { data = [] } = await sdk.users.getUserForYouFeed({
         id: Id.parse(currentUserId),
         userId: Id.parse(currentUserId),
         limit: currentPageSize,

--- a/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
@@ -1,4 +1,4 @@
-import { Id, GetUserRecommendedTracksTimeRangeEnum } from '@audius/sdk'
+import { Id } from '@audius/sdk'
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
@@ -24,11 +24,9 @@ export const getForYouFeedQueryKey = (userId: ID | null | undefined) => {
 }
 
 /**
- * "For You" feed for the Feed page. Backed by the same recommended-tracks
- * endpoint that powers the Explore page's For You section
- * (`GET /v1/users/{id}/recommended-tracks`). The dedicated
- * `/feed/for-you` endpoint has been retired in favor of consolidating on
- * the recommended-tracks source — see the API repo for the deletion.
+ * "For You" feed for the Feed page. Backed by the dedicated
+ * `GET /v1/users/{id}/feed/for-you` endpoint — a lean 3-source pipeline
+ * (in-network, trending, underground) with linear ranking and diversity pass.
  */
 export const useForYouFeed = (
   {
@@ -57,12 +55,11 @@ export const useForYouFeed = (
       const isFirstPage = pageParam === 0
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       const sdk = await audiusSdk()
-      const { data = [] } = await sdk.users.getUserRecommendedTracks({
+      const { data = [] } = await sdk.users.getUserFeedForYou({
         id: Id.parse(currentUserId),
         userId: Id.parse(currentUserId),
         limit: currentPageSize,
-        offset: pageParam,
-        timeRange: GetUserRecommendedTracksTimeRangeEnum.Week
+        offset: pageParam
       })
 
       const tracks = primeTrackData({

--- a/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -744,6 +744,14 @@ export interface GetUserRecommendedTracksRequest {
     timeRange?: GetUserRecommendedTracksTimeRangeEnum;
 }
 
+export interface GetUserFeedForYouRequest {
+    id: string;
+    offset?: number;
+    limit?: number;
+    userId?: string;
+    maxPerArtist?: number;
+}
+
 export interface GetUserTracksDownloadCountRequest {
     id: string;
 }
@@ -4169,6 +4177,61 @@ export class UsersApi extends runtime.BaseAPI {
      */
     async getUserFeed(params: GetUserFeedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserFeedResponse> {
         const response = await this.getUserFeedRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Gets the personalized For You feed for a user.
+     * Twitter-style multi-source pipeline — candidate retrieval (in-network,
+     * trending, underground) → linear ranking → diversity pass.
+     */
+    async getUserFeedForYouRaw(params: GetUserFeedForYouRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Tracks>> {
+        if (params.id === null || params.id === undefined) {
+            throw new runtime.RequiredError('id', 'Required parameter params.id was null or undefined when calling getUserFeedForYou.');
+        }
+
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.maxPerArtist !== undefined) {
+            queryParameters['max_per_artist'] = params.maxPerArtist;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (!headerParameters["Authorization"] && this.configuration && this.configuration.accessToken) {
+            const token = await this.configuration.accessToken("OAuth2", ["read"]);
+            if (token) {
+                headerParameters["Authorization"] = token;
+            }
+        }
+
+        const response = await this.request({
+            path: `/users/{id}/feed/for-you`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => TracksFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the personalized For You feed for a user.
+     */
+    async getUserFeedForYou(params: GetUserFeedForYouRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Tracks> {
+        const response = await this.getUserFeedForYouRaw(params, initOverrides);
         return await response.value();
     }
 

--- a/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -687,6 +687,14 @@ export interface GetUserFeedRequest {
     encodedDataSignature?: string;
 }
 
+export interface GetUserForYouFeedRequest {
+    id: string;
+    limit?: number;
+    offset?: number;
+    maxPerArtist?: number;
+    userId?: string;
+}
+
 export interface GetUserIDsByAddressesRequest {
     address: Array<string>;
 }
@@ -742,14 +750,6 @@ export interface GetUserRecommendedTracksRequest {
     limit?: number;
     userId?: string;
     timeRange?: GetUserRecommendedTracksTimeRangeEnum;
-}
-
-export interface GetUserFeedForYouRequest {
-    id: string;
-    offset?: number;
-    limit?: number;
-    userId?: string;
-    maxPerArtist?: number;
 }
 
 export interface GetUserTracksDownloadCountRequest {
@@ -4181,31 +4181,31 @@ export class UsersApi extends runtime.BaseAPI {
     }
 
     /**
-     * Gets the personalized For You feed for a user.
-     * Twitter-style multi-source pipeline — candidate retrieval (in-network,
-     * trending, underground) → linear ranking → diversity pass.
+     * @hidden
+     * Returns a personalized For You feed for the user identified in the path. Twitter-style multi-source pipeline — candidate retrieval (in-network, trending, underground) → linear ranking (recency decay × engagement × social affinity, weighted by source) → diversity (per-artist cap + consecutive-same-artist lookahead).
+     * Get For You feed for user
      */
-    async getUserFeedForYouRaw(params: GetUserFeedForYouRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Tracks>> {
+    async getUserForYouFeedRaw(params: GetUserForYouFeedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Tracks>> {
         if (params.id === null || params.id === undefined) {
-            throw new runtime.RequiredError('id', 'Required parameter params.id was null or undefined when calling getUserFeedForYou.');
+            throw new runtime.RequiredError('id','Required parameter params.id was null or undefined when calling getUserForYouFeed.');
         }
 
         const queryParameters: any = {};
-
-        if (params.offset !== undefined) {
-            queryParameters['offset'] = params.offset;
-        }
 
         if (params.limit !== undefined) {
             queryParameters['limit'] = params.limit;
         }
 
-        if (params.userId !== undefined) {
-            queryParameters['user_id'] = params.userId;
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
         }
 
         if (params.maxPerArtist !== undefined) {
             queryParameters['max_per_artist'] = params.maxPerArtist;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -4228,10 +4228,11 @@ export class UsersApi extends runtime.BaseAPI {
     }
 
     /**
-     * Gets the personalized For You feed for a user.
+     * Returns a personalized For You feed for the user identified in the path. Twitter-style multi-source pipeline — candidate retrieval (in-network, trending, underground) → linear ranking (recency decay × engagement × social affinity, weighted by source) → diversity (per-artist cap + consecutive-same-artist lookahead).
+     * Get For You feed for user
      */
-    async getUserFeedForYou(params: GetUserFeedForYouRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Tracks> {
-        const response = await this.getUserFeedForYouRaw(params, initOverrides);
+    async getUserForYouFeed(params: GetUserForYouFeedRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Tracks> {
+        const response = await this.getUserForYouFeedRaw(params, initOverrides);
         return await response.value();
     }
 


### PR DESCRIPTION
## Summary
- Adds `getUserFeedForYou` method to the generated `UsersApi` SDK (mirrors the pattern of `getUserRecommendedTracks` — same request shape minus `timeRange`, same `Tracks` response type)
- Updates `useForYouFeed` to call the new method, dropping the now-unused `timeRange` param
- The previous implementation fell back to the generic `recommended-tracks` endpoint; this wires the hook to the purpose-built pipeline introduced in AudiusProject/api#817

## Test plan
- [ ] Feed page For You tab loads tracks from the new endpoint
- [ ] Pagination (load more) works correctly
- [ ] Unauthenticated users see an empty state (hook is disabled when `currentUserId` is null)
- [ ] Explore page recommended tracks are unaffected (still use `getUserRecommendedTracks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)