### PR TITLE
chore(mobile): bump versions for release + restore Node in Android CI

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -673,6 +673,20 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # The "Free disk space" step above removes $AGENT_TOOLSDIRECTORY, which
+      # also wipes the Node 24 install from the earlier setup-node step. Without
+      # this re-setup, npm ci falls back to the runner's system Node 22 and the
+      # mobile workspace's "engines" check fails with EBADENGINE.
+      - name: Setup Node.js (after disk cleanup)
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Upgrade npm to 11.10.0 (after disk cleanup)
+        run: npm install -g npm@11.10.0
+
       - name: Create concatenated patch file
         id: patch-file
         run: |
@@ -1050,6 +1064,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      # The "Free disk space" step above removes $AGENT_TOOLSDIRECTORY, which
+      # also wipes the Node 24 install from the earlier setup-node step. Without
+      # this re-setup, npm ci falls back to the runner's system Node 22 and the
+      # mobile workspace's "engines" check fails with EBADENGINE.
+      - name: Setup Node.js (after disk cleanup)
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Upgrade npm to 11.10.0 (after disk cleanup)
+        run: npm install -g npm@11.10.0
 
       - name: Create concatenated patch file
         id: patch-file

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -128,7 +128,7 @@ android {
         // versionCode is automatically incremented in CI
         versionCode 1
         // Make sure this is above the currently released Android version in the play store if your changes touch native code:
-        versionName "1.1.529"
+        versionName "1.1.530"
         resValue "string", "build_config_package", "co.audius.app"
         resConfigs "en"
     }

--- a/packages/mobile/ios/AudiusReactNative/Info.plist
+++ b/packages/mobile/ios/AudiusReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.193</string>
+	<string>1.1.194</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/mobile",
-  "version": "1.5.180",
+  "version": "1.5.181",
   "private": true,
   "scripts": {
     "android:dev": "ENVFILE=.env.dev turbo run android -- --mode=prodDebug",


### PR DESCRIPTION
## Summary

Two changes needed to actually publish a release on main:

1. **Version bump for the binary build jobs to fire again.** The `mobile-version-check` job compares `packages/mobile/package.json` `version` between `HEAD` and `HEAD^`. Once **1.5.180** landed (PR #14365 / commit [51cf0b2eb5](https://github.com/AudiusProject/apps/commit/51cf0b2eb5)), every subsequent commit reported `version_changed=false`, so the iOS RC, Android RC, iOS Production, and Android Production jobs all got skipped. Bumps:
   - `packages/mobile/package.json`: `1.5.180` → `1.5.181`
   - `packages/mobile/ios/AudiusReactNative/Info.plist` `CFBundleShortVersionString`: `1.1.193` → `1.1.194`
   - `packages/mobile/android/app/build.gradle` `versionName`: `1.1.529` → `1.1.530`

2. **Android RC + Android Production CI no longer falls back to Node 22.** In [run 26246576840](https://github.com/AudiusProject/apps/actions/runs/26246576840), both Android jobs failed `npm ci` with:
   ```
   npm error code EBADENGINE
   npm error notsup Required: {"node":">=24.10.0","npm":">=11.10.0"}
   npm error notsup Actual:   {"npm":"10.9.8","node":"v22.22.3"}
   ```
   The job order is `Setup Node.js → Setup Android SDK → Free disk space → Setup Java (after disk cleanup) → … → Install dependencies`. The "Free disk space" step does `sudo rm -rf "$AGENT_TOOLSDIRECTORY"`, which is where `actions/setup-node@v4` placed Node 24 — so by the time `npm ci` runs, only the runner's system Node 22 is on PATH. Java is intentionally re-set-up after cleanup; Node was not. This PR adds a matching `Setup Node.js (after disk cleanup)` step (plus the npm 11 upgrade) in both Android jobs.

The iOS failures in that run were caused by an unrelated duplicate `make` import in `ContestScreen.tsx`, which has already been fixed on main by [802487bb3a](https://github.com/AudiusProject/apps/commit/802487bb3a).

## Test plan
- [ ] Merge → Mobile CI/CD on main fires all four binary build/upload jobs (version_changed=true)
- [ ] iOS RC build & upload succeeds end-to-end
- [ ] Android RC build & upload reaches \`fastlane releaseCandidate\` (Node 24 visible in install step logs)
- [ ] iOS Production + Android Production gated on environment approval as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)