### PR TITLE
fix(mobile): render DrawerPortal inside BottomSheetModalProvider so comment kebab opens

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -142,10 +142,17 @@ const App = () => {
                                     <NotificationReminder />
                                     <RateCtaReminder />
                                     <PortalHost name='ChatReactionsPortal' />
+                                    {/* DrawerPortal must live INSIDE
+                                        BottomSheetModalProvider — its inner
+                                        PortalProvider isolates the registry,
+                                        so a <Portal hostName='DrawerPortal'>
+                                        from within a bottom sheet (e.g. the
+                                        comment kebab) would otherwise
+                                        silently fail to find the host. */}
+                                    <PortalHost name='DrawerPortal' />
                                   </NiceModal.Provider>
                                 </CommentDrawerProvider>
                               </BottomSheetModalProvider>
-                              <PortalHost name='DrawerPortal' />
                             </NavigationContainer>
                           </ErrorBoundary>
                         </PortalProvider>


### PR DESCRIPTION
## Summary

The kebab overflow menu on a comment in the mobile Comment Drawer wasn't opening — tapping it did nothing. This is a follow-up to [#14385](https://github.com/AudiusProject/apps/pull/14385) which removed a redundant `CommentSectionProvider` wrap but didn't actually fix the user-facing bug.

## Root cause

`@gorhom/bottom-sheet`'s `BottomSheetModalProvider` wraps its children in its own nested `<PortalProvider rootHostName='bottom-sheet-portal-XXX'>` with an isolated host registry. `@gorhom/portal` resolves a Portal's `hostName` against the **nearest** `PortalProvider` only — it does not walk up to outer providers.

With the `DrawerPortal` host registered as a sibling of `BottomSheetModalProvider`, any `<Portal hostName='DrawerPortal'>` rendered from inside a bottom sheet (the kebab on a comment row, or the track-owner overflow in `CommentDrawerHeader`) resolved through the **inner** provider, found no `DrawerPortal` host, and silently rendered nowhere. `onPress` fired, state updated, but the action drawer never appeared.

## Fix

Move `<PortalHost name='DrawerPortal' />` from outside `BottomSheetModalProvider` to inside it (alongside `ChatReactionsPortal`). Now it's registered in the same registry the inner Portals look up. External callers (e.g. `ContestCommentsList` outside any bottom sheet) still find it through the same provider chain because there's only one `PortalProvider` between them and the host.

## Test plan

- [x] Tap kebab on a comment in the mobile Comment Drawer → action drawer appears with Share / Mute Thread / Edit / Delete
- [ ] Tap kebab on another user's comment → drawer appears with Flag, Mute User, etc.
- [ ] Tap a row in the action drawer → drawer closes, action runs
- [ ] Tap backdrop to dismiss the action drawer; tap kebab again → drawer reopens on first tap
- [ ] Verify `ContestCommentsList` kebab still works (caller outside any bottom sheet)
- [ ] Track-owner kebab in `CommentDrawerHeader` still works (same `DrawerPortal` host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)