### PR TITLE
fix(mobile): stop cold-launch keyboard flash on explore search

### DIFF
--- a/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/SearchExploreHeader.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react'
 
 import { exploreMessages as messages } from '@audius/common/messages'
-import { useNavigation } from '@react-navigation/native'
+import { useIsFocused, useNavigation } from '@react-navigation/native'
 import type { ScrollView } from 'react-native'
 import { Keyboard } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -40,6 +40,7 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   const { params } = useExploreRoute<'SearchExplore'>()
   const { drawerHelpers } = useContext(AppDrawerContext)
   const navigation = useNavigation()
+  const isFocused = useIsFocused()
   const { isOpen: isNowPlayingDrawerOpen } = useDrawer('NowPlaying')
   const textInputRef = useRef<any>(null)
 
@@ -59,13 +60,18 @@ export const SearchExploreHeader = (props: SearchExploreHeaderProps) => {
   // Without this, the keyboard re-appears whenever the app returns from
   // background while explore is the active tab. Consume the param by setting
   // it back to false so a subsequent search-icon tap can re-trigger focus.
+  //
+  // Gate on isFocused so a stale autoFocus param can't summon the keyboard
+  // while the explore tab isn't the active tab — this is what caused the
+  // brief keyboard flash on cold launch when the explore screen mounted
+  // off-screen with autoFocus: true already on its route.
   useEffect(() => {
-    if (params?.autoFocus === true) {
+    if (params?.autoFocus === true && isFocused) {
       textInputRef.current?.focus()
       // @ts-expect-error: setParams is not typed on the generic NavigationProp, but is available on StackNavigationProp
       navigation.setParams?.({ autoFocus: false })
     }
-  }, [params?.autoFocus, navigation])
+  }, [params?.autoFocus, navigation, isFocused])
 
   const handleOpenLeftNavDrawer = useCallback(() => {
     if (isNowPlayingDrawerOpen) return


### PR DESCRIPTION
## Summary

- Follow-up to [apps#14289](https://github.com/AudiusProject/apps/pull/14289). That PR stopped the keyboard from re-appearing on background→foreground, but a brief keyboard flash still happened on app **cold launch**.
- Root cause: the explore screen's `useEffect` calls `.focus()` whenever `params?.autoFocus === true`, regardless of whether the explore tab is the active tab. If the explore screen mounts off-screen with a stale `autoFocus: true` on its route, the focus call fires anyway and briefly summons the keyboard.
- Fix: gate the focus call on `useIsFocused()` so the param is only consumed while the explore tab is actually the active tab. The intentional search-icon-tap flow still works — navigating to explore puts the tab in focus before the effect runs.

## Test plan

- [ ] Cold-start the app → no keyboard flash on initial load (regardless of which tab was last active before the kill)
- [ ] Tap search icon from any tab header → explore opens with keyboard up and input focused
- [ ] On explore, dismiss keyboard, switch to another tab, return to explore → keyboard does NOT reappear
- [ ] On explore with keyboard up, background the app, return from background → keyboard does NOT reappear (still works after this change)
- [ ] Tap search icon → keyboard reappears, dismiss it, tap search icon again → keyboard reappears (param re-trigger still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)