### PR TITLE
fix(mobile): Xcode 26 SDK for iOS upload + hermesc path for Android

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -432,7 +432,7 @@ jobs:
   # iOS Release Candidate: Build and upload
   mobile-build-upload-releasecandidate-ios:
     name: iOS Release Candidate Build & Upload
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [mobile-install, mobile-version-check]
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.mobile-version-check.outputs.version_changed == 'true'
     steps:
@@ -834,7 +834,7 @@ jobs:
   # iOS Production: Build and upload (requires approval)
   mobile-build-upload-production-ios-main:
     name: iOS Production Build & Upload
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [mobile-install, mobile-version-check]
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.mobile-version-check.outputs.version_changed == 'true'
     environment:

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -46,7 +46,12 @@ react {
     // extraPackagerArgs = []
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
+    //   The RN Gradle plugin's hermesc lookup is anchored at `root` and only
+    //   considers `root/node_modules/react-native/sdks/hermesc/...`. Since RN
+    //   is hoisted to the monorepo node_modules, that lookup fails. Point the
+    //   plugin at the hoisted prebuilt hermesc explicitly (%OS-BIN% is
+    //   substituted by the plugin at runtime).
+    hermesCommand = "$rootDir/../../../node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]
@@ -129,7 +134,7 @@ android {
         // versionCode is automatically incremented in CI
         versionCode 1
         // Make sure this is above the currently released Android version in the play store if your changes touch native code:
-        versionName "1.1.531"
+        versionName "1.1.532"
         resValue "string", "build_config_package", "co.audius.app"
         resConfigs "en"
     }

--- a/packages/mobile/ios/AudiusReactNative/Info.plist
+++ b/packages/mobile/ios/AudiusReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.195</string>
+	<string>1.1.196</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/packages/mobile/ios/Gemfile.lock
+++ b/packages/mobile/ios/Gemfile.lock
@@ -302,7 +302,7 @@ DEPENDENCIES
   bigdecimal
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
   concurrent-ruby (< 1.3.4)
-  fastlane (>= 2.228.0)
+  fastlane (= 2.234.0)
   fastlane-plugin-versioning
   logger
   mutex_m

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/mobile",
-  "version": "1.5.182",
+  "version": "1.5.183",
   "private": true,
   "scripts": {
     "android:dev": "ENVFILE=.env.dev turbo run android -- --mode=prodDebug",


### PR DESCRIPTION
## Summary

Two real failures surfaced in [run 26319345276](https://github.com/AudiusProject/apps/actions/runs/26319345276) after the displayer fix in #14394 made fastlane log altool errors again.

### 1. iOS RC + Prod — Apple now requires iOS 26 SDK

altool now returns:
\`\`\`
ERROR: Validation failed (409) SDK version issue. This app was built with the iOS 18.5 SDK.
All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or
later, in order to be uploaded to App Store Connect or submitted for distribution.
(ID: 287c542e-3971-4158-b3c3-71eb1fcd6eb3)
\`\`\`

The \`macos-15\` runners ship Xcode 16.4 (iOS 18.5 SDK) by default — that's why gym archived fine but altool rejected the upload. Switch both iOS jobs to \`macos-26\` (Tahoe, GA), which has Xcode 26 as the only supported major.

### 2. Android RC + Prod — hermesc binary lookup also anchored at the wrong root

\`\`\`
Couldn't determine Hermesc location. Please set \`react.hermesCommand\` to the path of the
hermesc binary file. node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc
\`\`\`

#14394 restored \`react.root\` to its default (\`../.. = packages/mobile\`) to unblock the Hermes JS bundle's \`entryFile\` lookup. But the same gradle plugin uses \`root\` for hermesc detection too (\`PathUtils.kt#detectOSAwareHermesCommand\` → only checks \`root/node_modules/react-native/sdks/hermesc/...\`), and RN is hoisted to the monorepo \`node_modules\` so that path doesn't exist.

Set \`react.hermesCommand\` explicitly to the hoisted prebuilt:
\`\`\`groovy
hermesCommand = "\$rootDir/../../../node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
\`\`\`
The \`%OS-BIN%\` placeholder is substituted by the plugin at runtime (linux64-bin / osx-bin / win64-bin). Verified all three subdirs exist in \`node_modules/react-native/sdks/hermesc/\` after \`npm ci\`.

### Housekeeping
- \`packages/mobile/ios/Gemfile.lock\`: dependency line aligned to \`= 2.234.0\` to match the Gemfile pin from #14394. (The squash-merge of #14394 amended the Gemfile to a pin but kept the lock at the pre-pin \`>= 2.228.0\` constraint; CI was re-resolving every build.)
- Versions bumped to re-fire the build matrix:
  - \`packages/mobile/package.json\`: \`1.5.182\` → \`1.5.183\`
  - iOS Info.plist \`CFBundleShortVersionString\`: \`1.1.195\` → \`1.1.196\`
  - Android \`versionName\`: \`1.1.531\` → \`1.1.532\`

## Test plan
- [ ] Merge → version-check fires all 4 binary jobs
- [ ] Android RC + Prod reach \`fastlane releaseCandidate\` / \`prod\` (no \`Couldn't determine Hermesc location\`)
- [ ] iOS RC + Prod reach App Store Connect (no \`SDK version issue\` 409)
- [ ] Slack notification fires from the success branch of each iOS / Android job

🤖 Generated with [Claude Code](https://claude.com/claude-code)