### PR TITLE
fix(mobile): route contest notification inbox row taps to Contest screen

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Notifications/ArtistRemixContestEndedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ArtistRemixContestEndedNotification.tsx
@@ -34,7 +34,7 @@ export const ArtistRemixContestEndedNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ArtistRemixContestEndingSoonNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ArtistRemixContestEndingSoonNotification.tsx
@@ -36,7 +36,7 @@ export const ArtistRemixContestEndingSoonNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ArtistRemixContestSubmissionsNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ArtistRemixContestSubmissionsNotification.tsx
@@ -38,7 +38,7 @@ export const ArtistRemixContestSubmissionsNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestEndedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestEndedNotification.tsx
@@ -36,7 +36,7 @@ export const FanRemixContestEndedNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestEndingSoonNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestEndingSoonNotification.tsx
@@ -36,7 +36,7 @@ export const FanRemixContestEndingSoonNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestWinnersSelectedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestWinnersSelectedNotification.tsx
@@ -35,7 +35,7 @@ export const FanRemixContestWinnersSelectedNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RemixContestUpdateNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RemixContestUpdateNotification.tsx
@@ -36,7 +36,7 @@ export const RemixContestUpdateNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.push('Track', {
+      navigation.push('Contest', {
         trackId: track.track_id
       })
     }


### PR DESCRIPTION
## Summary
- Updates the remaining contest notification row components' `handlePress` to push the `Contest` screen instead of `Track`, matching the `contestHandler` deep-link fix from #14384 and the existing `FanRemixContestStartedNotification` behavior.
- Affects: `FanRemixContestEnded`, `FanRemixContestEndingSoon`, `FanRemixContestWinnersSelected`, `RemixContestUpdate`, `ArtistRemixContestEnded`, `ArtistRemixContestEndingSoon`, `ArtistRemixContestSubmissions`.
- `FanRemixContestSubmissionNotification` intentionally still pushes `Track` (plays the submitted remix) and is unchanged.

## Test plan
- [ ] Tap each contest notification type in the in-app notifications inbox and confirm it navigates to the Contest screen (not the Track screen).
- [ ] Verify `FanRemixContestSubmissionNotification` still navigates to the submitted track.
- [ ] Verify push notification tap still routes to Contest (unchanged behavior from #14384).

🤖 Generated with [Claude Code](https://claude.com/claude-code)