### PR TITLE
fix(web): route contest notification inbox rows to Contest page

### DIFF
--- a/packages/web/src/components/notification/Notification/ArtistRemixContestEndedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestEndedNotification.tsx
@@ -10,14 +10,13 @@ import { useDispatch } from 'react-redux'
 import { Link } from 'react-router'
 
 import { push } from 'utils/navigation'
-import { pickWinnersPage } from 'utils/route'
+import { contestPage, pickWinnersPage } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
 import { NotificationHeader } from './components/NotificationHeader'
 import { NotificationTile } from './components/NotificationTile'
 import { NotificationTitle } from './components/NotificationTitle'
-import { getEntityLink } from './utils'
 
 const messages = {
   title: 'Your Remix Contest Ended',
@@ -48,7 +47,7 @@ export const ArtistRemixContestEndedNotification = (
 
   const handleClick = useCallback(() => {
     if (entity) {
-      dispatch(push(getEntityLink(entity)))
+      dispatch(push(contestPage(entity.permalink)))
     }
   }, [entity, dispatch])
 

--- a/packages/web/src/components/notification/Notification/ArtistRemixContestEndingSoonNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestEndingSoonNotification.tsx
@@ -10,13 +10,13 @@ import { useDispatch } from 'react-redux'
 
 import { TrackLink } from 'components/link'
 import { push } from 'utils/navigation'
+import { contestPage } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
 import { NotificationHeader } from './components/NotificationHeader'
 import { NotificationTile } from './components/NotificationTile'
 import { NotificationTitle } from './components/NotificationTitle'
-import { getEntityLink } from './utils'
 
 const messages = {
   title: 'Remix Contest',
@@ -40,7 +40,7 @@ export const ArtistRemixContestEndingSoonNotification = (
 
   const handleClick = useCallback(() => {
     if (entity) {
-      dispatch(push(getEntityLink(entity)))
+      dispatch(push(contestPage(entity.permalink)))
     }
   }, [entity, dispatch])
 

--- a/packages/web/src/components/notification/Notification/ArtistRemixContestSubmissionsNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestSubmissionsNotification.tsx
@@ -10,13 +10,13 @@ import { useDispatch } from 'react-redux'
 
 import { TrackLink } from 'components/link'
 import { push } from 'utils/navigation'
+import { contestPage } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
 import { NotificationHeader } from './components/NotificationHeader'
 import { NotificationTile } from './components/NotificationTile'
 import { NotificationTitle } from './components/NotificationTitle'
-import { getEntityLink } from './utils'
 
 const messages = {
   title: 'New Remix Submission!',
@@ -42,7 +42,7 @@ export const ArtistRemixContestSubmissionsNotification = ({
 
   const handleClick = useCallback(() => {
     if (entity) {
-      dispatch(push(getEntityLink(entity)))
+      dispatch(push(contestPage(entity.permalink)))
     }
   }, [entity, dispatch])
 

--- a/packages/web/src/components/notification/Notification/FanRemixContestEndedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestEndedNotification.tsx
@@ -9,6 +9,7 @@ import { Flex, IconTrophy } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
 import { push } from 'utils/navigation'
+import { contestPage } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
@@ -17,7 +18,6 @@ import { NotificationTile } from './components/NotificationTile'
 import { NotificationTitle } from './components/NotificationTitle'
 import { TrackContent } from './components/TrackContent'
 import { UserNameLink } from './components/UserNameLink'
-import { getEntityLink } from './utils'
 
 const messages = {
   title: 'Remix Contest',
@@ -44,7 +44,7 @@ export const FanRemixContestEndedNotification = (
 
   const handleClick = useCallback(() => {
     if (entity) {
-      dispatch(push(getEntityLink(entity)))
+      dispatch(push(contestPage(entity.permalink)))
     }
   }, [entity, dispatch])
 

--- a/packages/web/src/components/notification/Notification/FanRemixContestEndingSoonNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestEndingSoonNotification.tsx
@@ -9,6 +9,7 @@ import { Flex, IconTrophy } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
 import { push } from 'utils/navigation'
+import { contestPage } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
@@ -17,7 +18,6 @@ import { NotificationTile } from './components/NotificationTile'
 import { NotificationTitle } from './components/NotificationTitle'
 import { TrackContent } from './components/TrackContent'
 import { UserNameLink } from './components/UserNameLink'
-import { getEntityLink } from './utils'
 
 const messages = {
   title: 'Remix Contest',
@@ -44,7 +44,7 @@ export const FanRemixContestEndingSoonNotification = (
 
   const handleClick = useCallback(() => {
     if (entity) {
-      dispatch(push(getEntityLink(entity)))
+      dispatch(push(contestPage(entity.permalink)))
     }
   }, [entity, dispatch])
 

--- a/packages/web/src/components/notification/Notification/FanRemixContestStartedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestStartedNotification.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from 'react-redux'
 
 import { TrackLink } from 'components/link'
 import { push } from 'utils/navigation'
+import { contestPage } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
@@ -18,7 +19,6 @@ import { NotificationTile } from './components/NotificationTile'
 import { NotificationTitle } from './components/NotificationTitle'
 import { TrackContent } from './components/TrackContent'
 import { UserNameLink } from './components/UserNameLink'
-import { getEntityLink } from './utils'
 
 const messages = {
   title: 'New Remix Contest',
@@ -46,7 +46,7 @@ export const FanRemixContestStartedNotification = (
 
   const handleClick = useCallback(() => {
     if (entity) {
-      dispatch(push(getEntityLink(entity)))
+      dispatch(push(contestPage(entity.permalink)))
     }
   }, [entity, dispatch])
 

--- a/packages/web/src/components/notification/Notification/FanRemixContestWinnersSelectedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestWinnersSelectedNotification.tsx
@@ -9,6 +9,7 @@ import { Flex, IconTrophy } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
 import { push } from 'utils/navigation'
+import { contestPage } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
@@ -17,7 +18,6 @@ import { NotificationTile } from './components/NotificationTile'
 import { NotificationTitle } from './components/NotificationTitle'
 import { TrackContent } from './components/TrackContent'
 import { UserNameLink } from './components/UserNameLink'
-import { getEntityLink } from './utils'
 
 const messages = {
   title: 'Remix Contest',
@@ -43,7 +43,7 @@ export const FanRemixContestWinnersSelectedNotification = (
 
   const handleClick = useCallback(() => {
     if (entity) {
-      dispatch(push(getEntityLink(entity)))
+      dispatch(push(contestPage(entity.permalink)))
     }
   }, [entity, dispatch])
 


### PR DESCRIPTION
## Summary
- The 7 remix contest notification tiles in `packages/web/src/components/notification/Notification/` dispatched `push(getEntityLink(entity))`, which navigates to the Track page instead of the Contest page.
- Mirrors the working pattern from `RemixContestUpdateNotification.tsx` and replaces `getEntityLink(entity)` with `contestPage(entity.permalink)` in each file.
- Companion to the mobile fix in #14400 (`fix/mobile-contest-notification-inbox-row`).

Files updated:
- `FanRemixContestStartedNotification.tsx`
- `FanRemixContestEndedNotification.tsx`
- `FanRemixContestEndingSoonNotification.tsx`
- `FanRemixContestWinnersSelectedNotification.tsx`
- `ArtistRemixContestEndedNotification.tsx`
- `ArtistRemixContestEndingSoonNotification.tsx`
- `ArtistRemixContestSubmissionsNotification.tsx`

## Test plan
- [x] `eslint` clean on all 7 files
- [x] `tsc --noEmit` clean for `packages/web`
- [ ] Manually click each contest notification type in the inbox and confirm it lands on the contest page (not the track page). Note: this requires triggering real contest notifications, so it wasn't exercised against the local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)