### PR TITLE
chore(common): fix pre-existing lint errors

### DIFF
--- a/packages/common/src/api/tan-query/developer-apps/useDeleteDeveloperApp.ts
+++ b/packages/common/src/api/tan-query/developer-apps/useDeleteDeveloperApp.ts
@@ -3,7 +3,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { useQueryContext } from '~/api/tan-query/utils'
 import { DeveloperApp } from '~/schemas/developerApps'
+
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
+
 import { getDeveloperAppsQueryKey } from './useDeveloperApps'
 
 export const useDeleteDeveloperApp = () => {

--- a/packages/common/src/services/auth/authService.ts
+++ b/packages/common/src/services/auth/authService.ts
@@ -61,11 +61,7 @@ export const createAuthService = ({
     createKey
   })
 
-  const signIn = async (
-    email: string,
-    password: string,
-    otp?: string
-  ) => {
+  const signIn = async (email: string, password: string, otp?: string) => {
     const wallet = await hedgehogInstance.login({
       email,
       username: email,


### PR DESCRIPTION
## Summary
- Auto-fixed 3 pre-existing lint errors in `@audius/common` that fail the root-level `npm run verify` even on `main`.
- `useDeleteDeveloperApp.ts` — `import/order` (missing blank line between import groups).
- `authService.ts` — `prettier/prettier` (collapsed multi-line function signature).

Web CI scopes its lint job to `packages/web`, so these didn't surface in PR checks. Pure formatting — no behavior change.

## Test plan
- [x] `cd packages/common && npm run lint` — clean.
- [x] `git diff` shows only whitespace/formatting.