### PR TITLE
feat(identity): add lastActiveAt column for inactivity detection

### DIFF
--- a/packages/identity-service/sequelize/migrations/20260526000000-add-last-active-at.js
+++ b/packages/identity-service/sequelize/migrations/20260526000000-add-last-active-at.js
@@ -1,0 +1,33 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        'Users',
+        'lastActiveAt',
+        {
+          type: Sequelize.DATE,
+          allowNull: true
+        },
+        { transaction }
+      )
+
+      await queryInterface.addIndex('Users', ['lastActiveAt'], {
+        transaction,
+        name: 'idx_users_lastActiveAt'
+      })
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeIndex('Users', 'idx_users_lastActiveAt', {
+        transaction
+      })
+      await queryInterface.removeColumn('Users', 'lastActiveAt', {
+        transaction
+      })
+    })
+  }
+}

--- a/packages/identity-service/src/models/user.js
+++ b/packages/identity-service/src/models/user.js
@@ -69,6 +69,14 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.DATE,
         allowNull: false
       },
+      // Touched on every app open via the authenticated startup ping
+      // (GET /user/email). Used for inactivity detection — finer-grained
+      // and lazier than lastSeenDate, which only moves at user creation
+      // and on relay.
+      lastActiveAt: {
+        type: DataTypes.DATE,
+        allowNull: true
+      },
       isGuest: {
         type: DataTypes.BOOLEAN,
         allowNull: false,

--- a/packages/identity-service/src/routes/idSignals.js
+++ b/packages/identity-service/src/routes/idSignals.js
@@ -77,7 +77,18 @@ module.exports = function (app) {
     '/record_ip',
     authMiddleware,
     handleResponse(async (req) => {
-      const { blockchainUserId, handle } = req.user
+      const { id: userRowId, blockchainUserId, handle } = req.user
+
+      // Fired by the client's recordIPIfNotRecent saga on app open
+      // (throttled to once per 24h per device), so this is also our
+      // signal that the user is active. Fire-and-forget — never block
+      // the IP-record response on this side effect.
+      models.User.update(
+        { lastActiveAt: new Date() },
+        { where: { id: userRowId } }
+      ).catch((err) => {
+        req.logger.error({ err }, 'Failed to update lastActiveAt')
+      })
 
       try {
         const userIP = getIP(req)

--- a/packages/identity-service/src/routes/user.js
+++ b/packages/identity-service/src/routes/user.js
@@ -150,29 +150,17 @@ module.exports = function (app) {
   )
 
   /**
-   * Retrieve authenticated user's email address.
-   *
-   * Doubles as the post-auth startup ping fired on every app open
-   * (after Hedgehog's GET /authentication restores credentials), so we
-   * use it as the write site for `lastActiveAt`. The update is
-   * fire-and-forget — never block the response on it.
+   * Retrieve authenticated user's email address
    */
   app.get(
     '/user/email',
     authMiddleware,
     handleResponse(async (req, _res, _next) => {
-      const { id: userRowId, blockchainUserId } = req.user
+      const { blockchainUserId } = req.user
       const userData = await models.User.findOne({
         where: {
           blockchainUserId
         }
-      })
-
-      models.User.update(
-        { lastActiveAt: new Date() },
-        { where: { id: userRowId } }
-      ).catch((err) => {
-        req.logger.error({ err }, 'Failed to update lastActiveAt')
       })
 
       return successResponse({

--- a/packages/identity-service/src/routes/user.js
+++ b/packages/identity-service/src/routes/user.js
@@ -65,11 +65,13 @@ module.exports = function (app) {
 
         try {
           const isDeliverable = await isEmailDeliverable(email, req.logger)
+          const now = new Date()
           await models.User.create({
             email,
             // Store non checksummed wallet address
             walletAddress: body.walletAddress.toLowerCase(),
-            lastSeenDate: Date.now(),
+            lastSeenDate: now,
+            lastActiveAt: now,
             IP,
             isEmailDeliverable: isDeliverable,
             isGuest: body.isGuest
@@ -148,17 +150,29 @@ module.exports = function (app) {
   )
 
   /**
-   * Retrieve authenticated user's email address
+   * Retrieve authenticated user's email address.
+   *
+   * Doubles as the post-auth startup ping fired on every app open
+   * (after Hedgehog's GET /authentication restores credentials), so we
+   * use it as the write site for `lastActiveAt`. The update is
+   * fire-and-forget — never block the response on it.
    */
   app.get(
     '/user/email',
     authMiddleware,
     handleResponse(async (req, _res, _next) => {
-      const { blockchainUserId } = req.user
+      const { id: userRowId, blockchainUserId } = req.user
       const userData = await models.User.findOne({
         where: {
           blockchainUserId
         }
+      })
+
+      models.User.update(
+        { lastActiveAt: new Date() },
+        { where: { id: userRowId } }
+      ).catch((err) => {
+        req.logger.error({ err }, 'Failed to update lastActiveAt')
       })
 
       return successResponse({


### PR DESCRIPTION
## Summary

Adds a `lastActiveAt` (`TIMESTAMP WITH TIME ZONE`, nullable) column on the identity-service `Users` table, refreshed on every authenticated app open. Drives the 3-day inactivity detection we want to build on top of identity.

The existing `lastSeenDate` is only written at user creation (its comment claims it *could* be updated on relay, but that was never wired up) and is `NOT NULL`, so we can't repurpose it cleanly. This change is purely additive — `lastSeenDate` writes are untouched.

## Where it's written

- **POST `/user`** (signup) — set alongside `lastSeenDate` at user creation.
- **POST `/record_ip`** — fire-and-forget `User.update({ lastActiveAt: now })`. This is the auth'd app-open ping: client-side, `fetchAccountAsync` (`packages/common/src/store/account/sagas.ts:235`) calls `recordIPIfNotRecent`, which is throttled to once per 24h per device and only runs once we have a session. That cadence is the right granularity for a 3-day inactivity signal and gentler on the DB than touching every authenticated request. Failures are logged but never block the response.

## What I tried first and threw out

Initially wrote into `GET /user/email` thinking it was the post-auth startup ping. Grepping all call sites showed it only fires during OAuth login (`packages/web/src/pages/oauth-login-page/*`) and the email-change flow (web change-email modal, mobile change-email screen) — never on a returning user's cold start. Reverted that change in 2nd commit.

## Migration

`20260526000000-add-last-active-at.js`:

- `addColumn` `Users.lastActiveAt` (`Sequelize.DATE`, `allowNull: true`)
- `addIndex` `idx_users_lastActiveAt` for `WHERE \"lastActiveAt\" < NOW() - INTERVAL '3 days'` scans

`down` reverses both.

## Caveats worth flagging

- **Guest users** (no handle yet) skip `recordIPIfNotRecent` (`sagas.ts:232` guard). They get `lastActiveAt` from signup but it won't advance until they claim a handle. Matches existing `lastSeenDate` behavior — same gap.
- The 24h client-side throttle is per-device, keyed in localStorage. If the user clears localStorage or switches devices, `/record_ip` fires more often. Still fine for a 3-day window.

## Test plan

- [ ] Migration: `npx sequelize-cli db:migrate` adds the column + index; `db:migrate:undo` removes them cleanly.
- [ ] Sign up a new user → row has `lastActiveAt = lastSeenDate ≈ now`.
- [ ] Cold-start the app as an existing user with `localStorage` cleared (or `IP_STORAGE_KEY` removed) → `POST /record_ip` fires and `lastActiveAt` advances to ~now. The 200 response shape (just `userIP`) is unchanged.
- [ ] Repeat within 24h → no `/record_ip` request fires (client throttle); `lastActiveAt` stays at the previous value. Acceptable for a 3-day window.
- [ ] Simulate the update path failing (e.g. transient DB hiccup) → `/record_ip` still returns 200; error is logged on identity.
- [ ] `EXPLAIN SELECT id FROM \"Users\" WHERE \"lastActiveAt\" < NOW() - INTERVAL '3 days'` uses `idx_users_lastActiveAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)