### PR TITLE
fix(web): match Recent Comments tile background to Related Artists

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/RecentComments.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/RecentComments.tsx
@@ -171,7 +171,7 @@ export const RecentComments = ({ userId }: { userId: number }) => {
         borderRadius='m'
         shadow='mid'
         p='l'
-        backgroundColor='surface1'
+        backgroundColor='white'
       >
         {trail.map((style, index) => (
           <CommentListItem


### PR DESCRIPTION
## Summary

The **Recent Comments** sidebar tile on the desktop profile page was rendering with `backgroundColor='surface1'` (Harmony secondary-surface gray), while the **Related Artists** tile directly below it uses `backgroundColor='white'` (via `ProfilePictureListTile`'s Paper). The mismatch made the left-nav column look inconsistent.

Switch Recent Comments to `white` so the two tiles share the lighter background.

## Change

One-line edit in `packages/web/src/pages/profile-page/components/desktop/RecentComments.tsx`:

```diff
-        backgroundColor='surface1'
+        backgroundColor='white'
```

Visual-only. No data-fetching, animation, or layout logic touched.

## Test plan

- [ ] Open any artist profile (e.g. `/rac`) on desktop web. Confirm the Recent Comments tile and the Related Artists tile in the left nav now have the same white background.
- [ ] Light mode + dark mode: the tile still reads correctly against the page background in both themes (Harmony's `white` token is theme-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)