### PR TITLE
feat(lineup): render mixed track + collection entries inline in every lineup

### DIFF
--- a/packages/mobile/src/components/lineup/TrackLineup.tsx
+++ b/packages/mobile/src/components/lineup/TrackLineup.tsx
@@ -8,6 +8,7 @@ import {
   type ReactElement
 } from 'react'
 
+import type { LineupData } from '@audius/common/api'
 import {
   Kind,
   type ID,
@@ -17,6 +18,7 @@ import {
 import { playbackActions, playbackSelectors } from '@audius/common/store'
 import type { PlaybackQuerySource, PlaybackTrack } from '@audius/common/store'
 import { makeStableUid } from '@audius/common/utils'
+import { EntityType } from '@audius/sdk'
 import { range } from 'lodash'
 import type {
   SectionList as RNSectionList,
@@ -27,7 +29,11 @@ import { StyleSheet, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { SectionList } from 'app/components/core'
-import { TrackTile, LineupTileSkeleton } from 'app/components/lineup-tile'
+import {
+  TrackTile,
+  CollectionTile,
+  LineupTileSkeleton
+} from 'app/components/lineup-tile'
 import { useScrollToTop } from 'app/hooks/useScrollToTop'
 
 const { makeGetCurrent } = playbackSelectors
@@ -46,7 +52,9 @@ const styles = StyleSheet.create({
 })
 
 type LoadingItem = { _loading: true }
-type Entry = { trackId: ID; uid: UID }
+type TrackEntry = { kind: 'track'; trackId: ID; uid: UID }
+type CollectionEntry = { kind: 'collection'; collectionId: ID }
+type Entry = TrackEntry | CollectionEntry
 type RenderItem = Entry | LoadingItem
 
 type Section = {
@@ -67,6 +75,12 @@ export type TrackLineupProps = {
   // Ordered list of track IDs to render. Tiles read full track data from the
   // tanquery cache (primed by whatever hook produced this list).
   trackIds: ID[]
+
+  // Optional mixed track/collection list. When provided, the lineup renders
+  // collection tiles inline for `PLAYLIST`/`ALBUM` entries and track tiles
+  // for `TRACK` entries (the For You feed uses this). When omitted the
+  // lineup behaves as a pure track lineup driven by `trackIds`.
+  lineupItems?: LineupData[]
 
   // Opaque string that tags the queue entries this lineup produces. Must
   // match the source used by the playback saga's shadow into legacy queue
@@ -119,6 +133,7 @@ export type TrackLineupProps = {
  */
 export const TrackLineup = ({
   trackIds,
+  lineupItems,
   source,
   querySource,
   isPending = false,
@@ -158,10 +173,24 @@ export const TrackLineup = ({
     [source]
   )
 
-  const visibleTrackIds = useMemo(() => {
-    const end = Math.min(trackIds.length, maxEntries)
-    return trackIds.slice(0, end)
-  }, [trackIds, maxEntries])
+  // Build a single ordered list of mixed track/collection entries. When the
+  // caller passes `lineupItems` (mixed feed) we use it verbatim; otherwise we
+  // wrap the legacy `trackIds` so the rest of the component is uniform.
+  const visibleItems: LineupData[] = useMemo(() => {
+    const source =
+      lineupItems ?? trackIds.map((id) => ({ id, type: EntityType.TRACK }))
+    const end = Math.min(source.length, maxEntries)
+    return source.slice(0, end)
+  }, [lineupItems, trackIds, maxEntries])
+
+  // Playback queue is track-only. Collection tiles drive their own internal
+  // playback via the playback slice (the mobile CollectionTile's togglePlay
+  // already targets the first track of its playlist).
+  const visibleTrackIds = useMemo(
+    () =>
+      visibleItems.filter((i) => i.type === EntityType.TRACK).map((i) => i.id),
+    [visibleItems]
+  )
 
   const tracksForPlayback: PlaybackTrack[] = useMemo(
     () =>
@@ -174,7 +203,7 @@ export const TrackLineup = ({
   )
 
   const togglePlay = useCallback(
-    ({ id }: { uid: UID; id: ID; source: PlaybackSource }) => {
+    ({ id }: { uid?: UID; id: ID; source?: PlaybackSource }) => {
       const currentTrackId = currentLegacy?.trackId ?? null
       const currentSource = currentLegacy?.source ?? null
       const isSameTile = currentTrackId === id && currentSource === source
@@ -209,8 +238,17 @@ export const TrackLineup = ({
   )
 
   const entries: Entry[] = useMemo(
-    () => visibleTrackIds.map((id) => ({ trackId: id, uid: uidFor(id) })),
-    [visibleTrackIds, uidFor]
+    () =>
+      visibleItems.map((item) =>
+        item.type === EntityType.TRACK
+          ? {
+              kind: 'track' as const,
+              trackId: item.id,
+              uid: uidFor(item.id)
+            }
+          : { kind: 'collection' as const, collectionId: item.id }
+      ),
+    [visibleItems, uidFor]
   )
 
   // Synchronous "load more was triggered" flag — set the moment the scroll
@@ -265,15 +303,24 @@ export const TrackLineup = ({
       return (
         <>
           <View style={[styles.item, itemStyles]}>
-            <TrackTile
-              id={entry.trackId}
-              uid={entry.uid}
-              index={index}
-              isTrending={isTrending}
-              togglePlay={togglePlay}
-              onPress={onPressItem}
-              showArtistPick={showArtistPick}
-            />
+            {entry.kind === 'track' ? (
+              <TrackTile
+                id={entry.trackId}
+                uid={entry.uid}
+                index={index}
+                isTrending={isTrending}
+                togglePlay={togglePlay}
+                onPress={onPressItem}
+                showArtistPick={showArtistPick}
+              />
+            ) : (
+              <CollectionTile
+                id={entry.collectionId}
+                index={index}
+                isTrending={isTrending}
+                togglePlay={togglePlay}
+              />
+            )}
           </View>
           {delineator}
         </>
@@ -329,11 +376,13 @@ export const TrackLineup = ({
         onEndReachedThreshold={LOAD_MORE_THRESHOLD}
         sections={isEmpty ? [] : sections}
         stickySectionHeadersEnabled={false}
-        keyExtractor={(item: any, index: number) =>
-          (item as LoadingItem)._loading
-            ? `skeleton-${index}`
-            : `${(item as Entry).uid}-${index}`
-        }
+        keyExtractor={(item: any, index: number) => {
+          if ((item as LoadingItem)._loading) return `skeleton-${index}`
+          const entry = item as Entry
+          return entry.kind === 'track'
+            ? `track-${entry.uid}-${index}`
+            : `collection-${entry.collectionId}-${index}`
+        }}
         renderItem={renderItem}
         scrollIndicatorInsets={{ right: Number.MIN_VALUE }}
       />

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -29,11 +29,6 @@ const messages = {
   endOfFeed: "Looks like you've reached the end of your feed..."
 }
 
-// Note: the feed API returns both tracks and collections (playlist reposts).
-// The new TrackLineup renders tracks only, so collections are filtered out by
-// `trackIds` on the hook side. This is a known limitation introduced by the
-// tanquery migration — collection feed rendering will be restored if/when
-// TrackLineup learns to render mixed feeds.
 export const FeedScreen = () => {
   const [feedTab, setFeedTab] = useFeedTab()
   const [feedFilter] = useFeedFilter()
@@ -88,6 +83,7 @@ export const FeedScreen = () => {
   const lineupProps = isForYou
     ? {
         trackIds: forYouFeed.trackIds,
+        lineupItems: forYouFeed.data,
         isPending: forYouFeed.isPending,
         isFetching: forYouFeed.isFetching,
         hasNextPage: forYouFeed.hasNextPage,

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -95,6 +95,7 @@ export const FeedScreen = () => {
       }
     : {
         trackIds: followFeed.trackIds,
+        lineupItems: followFeed.data,
         isPending: followFeed.isPending,
         isFetching: followFeed.isFetching,
         hasNextPage: followFeed.hasNextPage,

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
@@ -10,10 +10,6 @@ import { TrackLineup } from 'app/components/lineup/TrackLineup'
 
 import { EmptyProfileTile } from '../EmptyProfileTile'
 
-// Note: the reposts API returns both tracks and collections (playlist reposts).
-// The new TrackLineup renders tracks only, so collections are filtered out by
-// `trackIds` on the hook side. This is a known limitation introduced by the
-// tanquery migration.
 export const RepostsTab = () => {
   const { handle, repost_count = 0 } =
     useProfileUser({
@@ -29,6 +25,7 @@ export const RepostsTab = () => {
   const queryArgs = useMemo(() => ({ handle: handleLower }), [handleLower])
 
   const {
+    data,
     trackIds,
     isPending,
     isFetching,
@@ -49,6 +46,7 @@ export const RepostsTab = () => {
   return (
     <TrackLineup
       trackIds={trackIds}
+      lineupItems={data}
       source='PROFILE_FEED'
       querySource={querySource}
       isPending={isPending}

--- a/packages/web/src/components/lineup/TrackLineup.tsx
+++ b/packages/web/src/components/lineup/TrackLineup.tsx
@@ -1,14 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import type { LineupData } from '@audius/common/api'
+import { usePlayTrack, usePauseTrack } from '@audius/common/hooks'
 import { ID, PlaybackSource, Name } from '@audius/common/models'
 import { playbackActions, playbackSelectors } from '@audius/common/store'
-import type { PlaybackTrack, PlaybackQuerySource } from '@audius/common/store'
+import type {
+  PlaybackTrack,
+  PlaybackQuerySource,
+  QueueSource
+} from '@audius/common/store'
 import { Divider, Flex } from '@audius/harmony'
+import { EntityType } from '@audius/sdk'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { make } from 'common/store/analytics/actions'
+import { CollectionTile as DesktopCollectionTile } from 'components/track/desktop/CollectionTile'
 import { TrackTile as TrackTileDesktop } from 'components/track/desktop/TrackTile'
+import { CollectionTile as MobileCollectionTile } from 'components/track/mobile/CollectionTile'
 import { TrackTile as MobileTrackTile } from 'components/track/mobile/TrackTile'
 import { TrackTileSize, TileProps } from 'components/track/types'
 import { useIsContainerNarrow } from 'hooks/useIsContainerNarrow'
@@ -38,6 +47,12 @@ export type TrackLineupProps = {
   // Ordered list of track IDs to render. Tiles read full track data from the
   // tanquery cache (primed by whatever hook produced this list).
   trackIds: ID[]
+
+  // Optional mixed track/collection list. When provided, the lineup renders
+  // collection tiles inline for `PLAYLIST`/`ALBUM` entries and track tiles
+  // for `TRACK` entries (the For You feed uses this). When omitted the
+  // lineup behaves as a pure track lineup driven by `trackIds`.
+  lineupItems?: LineupData[]
 
   // Opaque string that tags the queue entries this lineup produces. Must
   // match the source used by the playback saga's shadow into legacy queue
@@ -90,6 +105,7 @@ export type TrackLineupProps = {
  */
 export const TrackLineup = ({
   trackIds,
+  lineupItems,
   source,
   querySource,
   isPending = false,
@@ -132,6 +148,9 @@ export const TrackLineup = ({
     isMobile || variant === LineupVariant.SECTION || isNarrow
 
   const TrackTile = isSmallTrackTile ? MobileTrackTile : TrackTileDesktop
+  const CollectionTile = isSmallTrackTile
+    ? MobileCollectionTile
+    : DesktopCollectionTile
 
   // For tile highlight: prefer new playback slice's current track when
   // present, else fall back to legacy current (non-trending flows). Also
@@ -144,13 +163,27 @@ export const TrackLineup = ({
   useSelector(getPlaybackCurrentTrackId)
   const isPlaying = useSelector(getPlayerPlaying)
 
+  // Build a single ordered list of mixed track/collection entries. When the
+  // caller passes `lineupItems` (mixed feed) we use it verbatim; otherwise we
+  // wrap the legacy `trackIds` so the rest of the component is uniform.
+  const items: LineupData[] = useMemo(
+    () => lineupItems ?? trackIds.map((id) => ({ id, type: EntityType.TRACK })),
+    [lineupItems, trackIds]
+  )
+
+  // Playback queue is track-only. Collection tiles handle their own
+  // play/pause via the playback slice (see `playTrack`/`pauseTrack` below).
+  const playbackTrackIds = useMemo(
+    () => items.filter((i) => i.type === EntityType.TRACK).map((i) => i.id),
+    [items]
+  )
   const tracksForPlayback: PlaybackTrack[] = useMemo(
     () =>
-      trackIds.map((id) => ({
+      playbackTrackIds.map((id) => ({
         trackId: id,
         source
       })),
-    [trackIds, source]
+    [playbackTrackIds, source]
   )
 
   const togglePlay = useCallback(
@@ -175,7 +208,7 @@ export const TrackLineup = ({
         )
         return
       }
-      const startIndex = trackIds.indexOf(trackId)
+      const startIndex = playbackTrackIds.indexOf(trackId)
       if (startIndex < 0) return
       dispatch(
         playbackActions.playFrom({
@@ -191,7 +224,7 @@ export const TrackLineup = ({
     [
       dispatch,
       tracksForPlayback,
-      trackIds,
+      playbackTrackIds,
       querySource,
       currentLegacy?.trackId,
       currentLegacy?.source,
@@ -200,6 +233,24 @@ export const TrackLineup = ({
       playbackSource
     ]
   )
+
+  // Collection tiles drive their own internal track playback (one of the
+  // playlist's tracks at a time) through the playback slice — same hooks
+  // the chat-unfurled CollectionTile uses.
+  const playTrack = usePlayTrack()
+  const handlePlayCollectionTrack = useCallback(
+    (trackId: ID) => {
+      playTrack({
+        id: trackId,
+        // `source` on the lineup is an opaque string that tags queue entries;
+        // it lines up with `QueueSource` values for well-known lineups
+        // (DISCOVER_FEED here). The saga treats it as a string identifier.
+        entries: [{ id: trackId, source: source as QueueSource }]
+      })
+    },
+    [playTrack, source]
+  )
+  const pauseTrack = usePauseTrack()
 
   // Tile sizing mirrors the legacy component.
   let tileSize: TrackTileSize = TrackTileSize.LARGE
@@ -220,10 +271,10 @@ export const TrackLineup = ({
       ? styles.main
       : styles.section
 
-  const visibleTrackIds = useMemo(() => {
-    const end = Math.min(trackIds.length, maxEntries)
-    return trackIds.slice(0, end)
-  }, [trackIds, maxEntries])
+  const visibleItems = useMemo(() => {
+    const end = Math.min(items.length, maxEntries)
+    return items.slice(0, end)
+  }, [items, maxEntries])
 
   // Track the scroll parent's viewport height so the load-more threshold is a
   // multiple of one full viewport. Falls back to the constant until measured.
@@ -253,13 +304,13 @@ export const TrackLineup = ({
   // tanquery's `isFetching` to round-trip back through the parent. Cleared
   // once the parent either delivers more entries or finishes fetching.
   const [isLoadMoreTriggered, setIsLoadMoreTriggered] = useState(false)
-  const prevEntriesLengthRef = useRef(visibleTrackIds.length)
+  const prevEntriesLengthRef = useRef(visibleItems.length)
   useEffect(() => {
-    if (visibleTrackIds.length !== prevEntriesLengthRef.current) {
-      prevEntriesLengthRef.current = visibleTrackIds.length
+    if (visibleItems.length !== prevEntriesLengthRef.current) {
+      prevEntriesLengthRef.current = visibleItems.length
       setIsLoadMoreTriggered(false)
     }
-  }, [visibleTrackIds.length])
+  }, [visibleItems.length])
   useEffect(() => {
     if (!isFetching) setIsLoadMoreTriggered(false)
   }, [isFetching])
@@ -333,29 +384,54 @@ export const TrackLineup = ({
 
   const tiles = useMemo(() => {
     if (isError) return []
-    return visibleTrackIds.map((trackId, index) => {
-      const trackProps = {
+    return visibleItems.map((item, index) => {
+      if (item.type === EntityType.TRACK) {
+        const trackProps = {
+          index,
+          ordered,
+          togglePlay,
+          size: tileSize,
+          statSize,
+          containerClassName,
+          id: item.id,
+          isLoading: false,
+          isTrending,
+          isFeed,
+          onClick: onClickTile,
+          showArtistPick
+        }
+        // @ts-ignore - track tile accepts extra props
+        return <TrackTile {...trackProps} key={`track-${item.id}-${index}`} />
+      }
+      const collectionProps = {
         index,
         ordered,
         togglePlay,
+        playTrack: handlePlayCollectionTrack,
+        pauseTrack,
         size: tileSize,
-        statSize,
         containerClassName,
-        id: trackId,
+        id: item.id,
         isLoading: false,
+        hasLoaded: () => {},
         isTrending,
-        isFeed,
-        onClick: onClickTile,
-        showArtistPick
+        isFeed
       }
-      // @ts-ignore - track tile accepts extra props
-      return <TrackTile {...trackProps} key={`${trackId}-${index}`} />
+      return (
+        // @ts-ignore - CollectionTile mobile variant accepts a subset of these props
+        <CollectionTile
+          {...collectionProps}
+          key={`collection-${item.id}-${index}`}
+        />
+      )
     })
   }, [
     isError,
-    visibleTrackIds,
+    visibleItems,
     ordered,
     togglePlay,
+    handlePlayCollectionTrack,
+    pauseTrack,
     tileSize,
     statSize,
     containerClassName,
@@ -363,7 +439,8 @@ export const TrackLineup = ({
     isFeed,
     onClickTile,
     showArtistPick,
-    TrackTile
+    TrackTile,
+    CollectionTile
   ])
 
   const isInitialLoad = isPending && tiles.length === 0
@@ -425,7 +502,7 @@ export const TrackLineup = ({
                   >
                     {tile}
                     {elementAdornment &&
-                      elementAdornment(visibleTrackIds[index], index)}
+                      elementAdornment(visibleItems[index].id, index)}
                   </Flex>
                   {index === 0 &&
                   tiles.length >= 1 &&

--- a/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
@@ -118,9 +118,9 @@ const FeedPageContent = ({ containerRef }: FeedPageContentProps) => {
     />
   )
 
-  // For You feed returns a mixed list of tracks and collections from the
-  // backend; pass it through as `lineupItems` so TrackLineup renders the
-  // playlist tiles inline. Following feed is currently track-only.
+  // Both feed hooks expose the mixed `LineupData[]` the API returns
+  // (tracks + collection reposts). TrackLineup branches per entry, so
+  // collections show up inline wherever the backend puts them.
   const lineupProps = isForYou
     ? {
         trackIds: forYouFeed.trackIds,
@@ -136,6 +136,7 @@ const FeedPageContent = ({ containerRef }: FeedPageContentProps) => {
       }
     : {
         trackIds: followFeed.trackIds,
+        lineupItems: followFeed.data,
         isPending: followFeed.isPending,
         isFetching: followFeed.isFetching,
         isError: followFeed.isError,

--- a/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
@@ -34,11 +34,6 @@ type FeedPageContentProps = {
   containerRef?: React.RefObject<HTMLDivElement>
 }
 
-// Note: the feed API returns both tracks and collections (playlist reposts).
-// The new TrackLineup renders tracks only, so collections are filtered out by
-// `trackIds` on the hook side. This is a known limitation introduced by the
-// tanquery migration — collection feed rendering will be restored if/when
-// TrackLineup learns to render mixed feeds.
 const FeedPageContent = ({ containerRef }: FeedPageContentProps) => {
   const titleRowRef = useRef<HTMLDivElement>(null)
   const [feedTab, setFeedTab] = useFeedTab()
@@ -123,9 +118,13 @@ const FeedPageContent = ({ containerRef }: FeedPageContentProps) => {
     />
   )
 
+  // For You feed returns a mixed list of tracks and collections from the
+  // backend; pass it through as `lineupItems` so TrackLineup renders the
+  // playlist tiles inline. Following feed is currently track-only.
   const lineupProps = isForYou
     ? {
         trackIds: forYouFeed.trackIds,
+        lineupItems: forYouFeed.data,
         isPending: forYouFeed.isPending,
         isFetching: forYouFeed.isFetching,
         isError: forYouFeed.isError,

--- a/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
@@ -43,11 +43,6 @@ type FeedPageMobileContentProps = {
   containerRef?: React.RefObject<HTMLDivElement>
 }
 
-// Note: the feed API returns both tracks and collections (playlist reposts).
-// The new TrackLineup renders tracks only, so collections are filtered out by
-// `trackIds` on the hook side. This is a known limitation introduced by the
-// tanquery migration — collection feed rendering will be restored if/when
-// TrackLineup learns to render mixed feeds.
 const FeedPageMobileContent = ({
   containerRef
 }: FeedPageMobileContentProps) => {
@@ -128,6 +123,7 @@ const FeedPageMobileContent = ({
   const lineupProps = isForYou
     ? {
         trackIds: forYouFeed.trackIds,
+        lineupItems: forYouFeed.data,
         isPending: forYouFeed.isPending,
         isFetching: forYouFeed.isFetching,
         isError: forYouFeed.isError,

--- a/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
@@ -135,6 +135,7 @@ const FeedPageMobileContent = ({
       }
     : {
         trackIds: followFeed.trackIds,
+        lineupItems: followFeed.data,
         isPending: followFeed.isPending,
         isFetching: followFeed.isFetching,
         isError: followFeed.isError,

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -172,9 +172,6 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
 
   const isDeactivated = !!profile?.is_deactivated
 
-  // --- Tanquery lineups replace legacy redux lineups --------------------------
-  // Reposts may include collections (playlist reposts); TrackLineup only renders
-  // tracks today, so collections are dropped on the hook side (trackIds filter).
   const tracksArgs = useMemo(
     () => ({ handle: handleLower ?? '', sort: tracksLineupOrder }),
     [handleLower, tracksLineupOrder]
@@ -300,6 +297,7 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
             ) : (
               <TrackLineup
                 trackIds={userRepostsQuery.trackIds}
+                lineupItems={userRepostsQuery.data}
                 source='PROFILE_FEED'
                 querySource={repostsQuerySource}
                 isPending={userRepostsQuery.isPending}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -142,9 +142,6 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
   const isLoading = status === Status.LOADING
   const isEditing = mode === 'editing'
 
-  // --- Tanquery lineups replace legacy redux lineups --------------------------
-  // Reposts may include collections (playlist reposts); TrackLineup only renders
-  // tracks today, so collections are dropped on the hook side (trackIds filter).
   const tracksArgs = useMemo(
     () => ({ handle: handleLower ?? '', sort: tracksLineupOrder }),
     [handleLower, tracksLineupOrder]
@@ -276,6 +273,7 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
             ) : (
               <TrackLineup
                 trackIds={userRepostsQuery.trackIds}
+                lineupItems={userRepostsQuery.data}
                 source='PROFILE_FEED'
                 querySource={repostsQuerySource}
                 isPending={userRepostsQuery.isPending}
@@ -347,6 +345,7 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
         ) : (
           <TrackLineup
             trackIds={userRepostsQuery.trackIds}
+            lineupItems={userRepostsQuery.data}
             source='PROFILE_FEED'
             querySource={repostsQuerySource}
             isPending={userRepostsQuery.isPending}


### PR DESCRIPTION
## Summary

The lineup infrastructure was track-only: every lineup hook returns `data: LineupData[]` that *can* contain `{ type: PLAYLIST }` / `{ type: ALBUM }` entries, but the lineup component only consumed `trackIds: ID[]`, so any collection in the response was silently dropped. This hit the For You feed most visibly (6/10 items were playlists per a live test, all invisible), but it also hid playlist reposts from the Following feed and from Profile Reposts.

This PR fixes it at the lineup level so the system handles mixed entries generically — any hook whose payload includes collections will surface them inline, with no per-feed special-casing.

## Approach

**Component (architectural fix):** `TrackLineup` (web + mobile) accepts an optional `lineupItems?: LineupData[]` prop. When provided, the lineup branches per entry — `TrackTile` for `EntityType.TRACK`, `CollectionTile` (desktop or mobile variant) for `PLAYLIST` / `ALBUM`. When omitted, behaviour is unchanged (existing track-only call sites stay on `trackIds`). The playback queue is built from track entries only; collection tiles drive their own internal track playback through the playback slice via `usePlayTrack` / `usePauseTrack` — the same hooks the chat-unfurled `CollectionTile` already uses.

**Call sites (system-wide wiring):** Every hook-driven lineup that *could* receive mixed entries now passes `lineupItems: hook.data`:
- **For You feed** (`useForYouFeed`): web desktop + mobile FeedPageContent, native FeedScreen.
- **Following feed** (`useFeed`): web desktop + mobile FeedPageContent, native FeedScreen — reposted playlists/albums now render on the Latest tab.
- **Profile Reposts** (`useProfileReposts`): web desktop + mobile ProfilePage, native RepostsTab — reposted collections now render alongside reposted tracks.

Track-only lineups (trending, profile tracks, library, remixes, etc.) are unaffected — their hooks only emit `TRACK` entries, so passing `lineupItems` would be a no-op. They stay on the legacy `trackIds` path for now. The component-level fix means any future hook that starts returning collections will surface them automatically without further changes.

## Replaces previous approach

The first version of this branch (force-pushed away) added a separate \"Playlists for you\" strip via `delineatorMap`, backed by a new `useTrendingPlaylists` hook. That was the wrong solution — the lineup endpoints were already returning the right data, the UI just wasn't rendering it. The strip and the trending-playlists hook are gone.

## Test plan

- [x] `npx tsc --noEmit` clean in `packages/common`, `packages/web`, `packages/mobile`
- [x] `eslint --quiet` clean on touched files
- [ ] **For You** tab (web + mobile + native): playlist tiles render inline at the positions the API returns them.
- [ ] **Latest** (Following) tab: reposted playlists render inline with reposted tracks.
- [ ] **Profile → Reposts** tab: reposted collections render inline.
- [ ] Click play on an inline playlist tile → plays the first track of that playlist.
- [ ] Click play on a track tile → continues to play through track entries (collections are skipped by the queue, as expected).
- [ ] Tracks-only lineups (trending, library, profile Tracks, remixes) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)