### PR TITLE
fix(search-explore): eliminate per-card remixes-count N+1 in featured contests

### DIFF
--- a/packages/web/src/pages/search-explore-page/components/desktop/FeaturedRemixContestsSection.tsx
+++ b/packages/web/src/pages/search-explore-page/components/desktop/FeaturedRemixContestsSection.tsx
@@ -1,4 +1,4 @@
-import { useExploreContent } from '@audius/common/api'
+import { useAllRemixContests, useExploreContent } from '@audius/common/api'
 import { exploreMessages as messages } from '@audius/common/messages'
 import { route } from '@audius/common/utils'
 import { Box } from '@audius/harmony'
@@ -10,6 +10,11 @@ import { CONTEST_CARD_WIDTH } from './constants'
 import { useExploreSectionTracking } from './useExploreSectionTracking'
 
 const SKELETON_COUNT = 6
+// Big enough to cover the featured set with headroom — the All Contests
+// endpoint primes a per-track entry-count cache as a side-effect (see
+// `useAllRemixContests` queryFn). One batched fetch here replaces ~N
+// per-card count-only fetches from `useRemixesCount` inside ContestCard.
+const PRIME_BATCH_SIZE = 30
 
 export const FeaturedRemixContestsSection = () => {
   const { ref, inView } = useExploreSectionTracking('Featured Remix Contests')
@@ -17,6 +22,12 @@ export const FeaturedRemixContestsSection = () => {
   const { data, isPending, isError, isSuccess } = useExploreContent({
     enabled: inView
   })
+
+  // Side-effect: fetch+prime entry counts for the featured contests so
+  // ContestCard's `useRemixesCount` hits cache instead of firing a
+  // count-only request per card. The return value is intentionally
+  // unused — we only care about the priming inside the hook's queryFn.
+  useAllRemixContests({ pageSize: PRIME_BATCH_SIZE }, { enabled: inView })
 
   if (isError || (isSuccess && !data?.featuredRemixContests?.length)) {
     return null


### PR DESCRIPTION
## Problem

Loading the new search-explore page fires ~20 \`GET /v1/tracks/:id/remixes?limit=0&offset=0&only_contest_entries=true&only_cosigns=false\` requests — one per ContestCard in the **Featured Remix Contests** carousel.

## Root cause

\`FeaturedRemixContestsSection\` calls \`useExploreContent\`, which reads a static \`explore-content.json\` listing featured contest track IDs with **no entry-count data**. Each \`<ContestCard trackId={…} />\` then independently issues a count-only request via \`useRemixesCount({ trackId, isContestEntry: true })\` (\`packages/web/src/components/contest-card/ContestCard.tsx:255\`). N cards = N requests.

The cache-priming side-effect that other contest surfaces rely on already exists in \`packages/common/src/api/tan-query/events/useAllRemixContests.ts:93-103\` (and mirrored in \`useUserRemixContests.ts:100\`) — it walks \`related.entryCounts\` and calls \`queryClient.setQueryData(getRemixesCountQueryKey(...), count)\` for each contest, turning ContestCard's count fetch into a cache hit. But \`useExploreContent\` doesn't return entry counts, so this surface never benefited.

## Fix

Piggy-back on \`useAllRemixContests\`'s built-in prime by calling it side-effect-only in the section, gated on the same \`inView\` as \`useExploreContent\`. One batched request seeds the remixes-count cache for the top-30 active contests; ContestCards in the featured carousel then hit cache instead of firing their own count fetches.

\`\`\`tsx
useAllRemixContests({ pageSize: PRIME_BATCH_SIZE }, { enabled: inView })
\`\`\`

The return value is intentionally unused — we only care about the priming inside the hook's queryFn.

## Why not a backend fix

The cleanest solution would be to extend \`explore-content.json\` (or a new endpoint) to include entry counts per featured contest. That requires a static-content rebuild + a hook signature change, which is out of scope for this fix. The client-side prime above resolves the immediate N+1 with one extra request total, deferring the backend cleanup.

## Test plan

- [ ] Open the new search-explore page; observe the network panel. Featured Remix Contests cards should NOT each fire \`/v1/tracks/:id/remixes?only_contest_entries=true\`. One \`/v1/events/remix-contests?limit=30\` request should be visible instead.
- [ ] Confirm the entry-count badge on each ContestCard still renders correctly.
- [ ] Confirm no regressions on \`/contests\` (also uses \`useAllRemixContests\`) — the additional consumer doesn't double-fetch because TanStack Query dedupes by query key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)