### PR TITLE
fix: mobile wrong-track playback (queue reversal, feed offset drift, stale tile check)

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useFeed.ts
@@ -60,7 +60,11 @@ export const useFeed = (
       const isFirstPage = allPages.length === 1
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       if (lastPage.length < currentPageSize) return undefined
-      return allPages.reduce((total, page) => total + page.length, 0)
+      return allPages.reduce(
+        (total, page) =>
+          total + page.filter((d) => d.type === EntityType.TRACK).length,
+        0
+      )
     },
     queryKey,
     queryFn: async ({ pageParam }) => {

--- a/packages/common/src/store/playback/selectors.ts
+++ b/packages/common/src/store/playback/selectors.ts
@@ -68,15 +68,17 @@ export const getUpNext = createSelector(
   (queue, index) => (index < 0 ? [] : queue.slice(index + 1))
 )
 
-// Returns { trackId, source } describing the currently playing entry. Mirrors
-// the legacy `queueSelectors.makeGetCurrent`. The values here are the
-// "currently loaded" entry (lags during load), matching legacy semantics.
+// Returns { trackId, source } describing the currently selected queue entry.
+// Reads from queue[index] (updated synchronously by playFrom/playTrackAt) so
+// tile-highlight comparisons stay stable during the load gap between
+// playFrom and playSucceeded — avoiding a stale `playingIndex` causing a
+// double `playFrom` dispatch on rapid retaps.
 export const makeGetCurrent = () =>
-  createSelector(
-    [getTrackId, getPlayingIndex, getPlaybackQueue],
-    (trackId, index, queue) => ({
-      trackId,
+  createSelector([getPlaybackIndex, getPlaybackQueue], (index, queue) => {
+    const entry = index >= 0 && index < queue.length ? queue[index] : null
+    return {
+      trackId: entry?.trackId ?? null,
       index,
-      source: index >= 0 && index < queue.length ? queue[index].source : null
-    })
-  )
+      source: entry?.source ?? null
+    }
+  })

--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -341,13 +341,14 @@ const useQueueSync = (isAudioSetup: boolean) => {
         // Sort by original index so RNTP order matches redux order
         resolved.sort((a, b) => a.i - b.i)
 
-        // Tracks before startIndex get inserted at position 0 in reverse order
         const before = resolved.filter(({ i }) => i < startIndex)
         const after = resolved.filter(({ i }) => i > startIndex)
 
-        // Insert "before" tracks at position 0 (earliest first)
-        for (const { data } of before) {
-          await TrackPlayer.add(data, 0)
+        // Insert "before" tracks at position 0. Iterate from last to first so
+        // that earliest ends up at index 0 (each insert pushes prior entries
+        // right by one).
+        for (let j = before.length - 1; j >= 0; j--) {
+          await TrackPlayer.add(before[j].data, 0)
         }
 
         // Append "after" tracks at the end


### PR DESCRIPTION
## Summary

Three combined bugs caused the wrong track to play on a mobile lineup tap. All three are fixed in this PR.

### Bug 1 — Following feed pagination offset drift
`packages/common/src/api/tan-query/lineups/useFeed.ts`

The Following feed returns mixed tracks and playlists, but only tracks feed into the playable lineup. `getNextPageParam` was computing the next offset from `lastPage.length` — the raw mixed count — so each playlist in a page silently inflated the offset and the next request returned the wrong items.

**Fix:** sum the count of `EntityType.TRACK` items per page when computing the offset, so it tracks the rendered lineup rather than the raw feed.

### Bug 2 — RNTP native queue built in reverse order (primary cause)
`packages/mobile/src/components/audio/AudioPlayer.tsx`

`resetQueue` adds the tapped track first, then "prepends" each preceding track by calling `TrackPlayer.add(data, 0)` in ascending order. Each insert at index 0 pushes prior entries right, so inserting A, B, C this way ends up as `[C, B, A, tapped, …]`. When RNTP later resolves the queue it plays the wrong native slot.

**Fix:** iterate the `before` array from last to first when inserting at index 0, so the final order is ascending `[A, B, C, tapped, …]`.

### Bug 3 — Stale `playingIndex` causes a second `playFrom` on rapid retap
`packages/common/src/store/playback/selectors.ts`

`makeGetCurrent` was deriving the "current" `trackId` and `index` from `playingTrackId` / `playingIndex`, which only update on the `playSucceeded` action. Between a `playFrom` dispatch and `playSucceeded`, `isSameTile` in `TrackLineup.togglePlay` evaluates to `false` against the just-tapped tile, so a second `playFrom` (with a stale `startIndex` from the previous lineup) gets dispatched on top of the first.

**Fix:** read from `queue[index]` instead — these are set synchronously by `playFrom` / `playTrackAt`, so `isSameTile` stays stable through the load gap. The previously-lagging tile-highlight behavior was a UX nicety that this bug shows was net negative.

## Test plan

- [ ] Open Following feed, scroll past the first page boundary, confirm each subsequent page returns the next chunk of tracks (no skipped/duplicated tracks because of playlist entries in the feed).
- [ ] In any mobile lineup, tap a track in the middle of the list — verify the *tapped* track plays (not the first track) and prev/next walk the queue in the visible order.
- [ ] Rapid-tap the same tile twice — confirm only one `playFrom` is dispatched and the right track plays.
- [ ] Tap from one lineup tile, then quickly tap a different lineup's tile before the first one loads — confirm the second tile's track plays, not a stale combination.
- [ ] Verify existing playback (Trending, profile, collection pages, NowPlaying) still highlight the current track correctly after the `makeGetCurrent` semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)