### PR TITLE
feat(collection): inline playlist create flow + edit-mode overhaul

### DIFF
--- a/packages/web/src/app/web-player/WebPlayer.tsx
+++ b/packages/web/src/app/web-player/WebPlayer.tsx
@@ -80,7 +80,7 @@ import { getShowCookieBanner } from 'store/application/ui/cookieBanner/selectors
 import { getClient } from 'utils/clientUtil'
 import { shouldShowCookieBanner } from 'utils/gdpr'
 import 'utils/redirect'
-import { getPathname } from 'utils/route'
+import { CREATE_PLAYLIST_PAGE, getPathname } from 'utils/route'
 
 import styles from './WebPlayer.module.css'
 const { getFrostedSurfaceIntensity } = themeSelectors
@@ -124,6 +124,9 @@ const CoinRedeemPage = lazy(() =>
 )
 const CollectionPage = lazy(
   () => import('pages/collection-page/CollectionPage')
+)
+const CreatePlaylistPage = lazy(
+  () => import('pages/create-playlist-page/CreatePlaylistPage')
 )
 const CommentHistoryPage = lazy(
   () => import('pages/comment-history/CommentHistoryPage')
@@ -1159,6 +1162,10 @@ const WebPlayer = (props: WebPlayerProps) => {
                 />
                 <Route path={TRACK_ID_PAGE} element={<TrackPage />} />
                 <Route
+                  path={CREATE_PLAYLIST_PAGE}
+                  element={<CreatePlaylistPage />}
+                />
+                <Route
                   path={PLAYLIST_ID_PAGE}
                   element={<CollectionPage type='playlist' />}
                 />
@@ -1559,6 +1566,10 @@ const WebPlayer = (props: WebPlayerProps) => {
                   element={<ProfilePageRoute mainContentRef={mainContentRef} />}
                 />
                 <Route path={TRACK_ID_PAGE} element={<TrackPage />} />
+                <Route
+                  path={CREATE_PLAYLIST_PAGE}
+                  element={<CreatePlaylistPage />}
+                />
                 <Route
                   path={PLAYLIST_ID_PAGE}
                   element={<CollectionPage type='playlist' />}

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -307,7 +307,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
       gap='xl'
       direction='column'
       p='xl'
-      backgroundColor='surface1'
+      backgroundColor={isEditingThis ? 'default' : 'surface1'}
       borderTop='strong'
       borderBottom='strong'
     >

--- a/packages/web/src/components/collection/desktop/edit-mode/EditModeNavigationGuard.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/EditModeNavigationGuard.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+
+import { useBlocker } from 'react-router'
+
+import { ConfirmationModal } from 'components/confirmation-modal/ConfirmationModal'
+
+import { usePlaylistEditMode } from './PlaylistEditModeContext'
+
+const messages = {
+  header: 'Unsaved Changes',
+  description:
+    'You have unsaved changes. If you leave this page, your changes will be lost.',
+  confirm: 'Leave',
+  cancel: 'Stay'
+}
+
+/**
+ * Warns the user before navigating away (in-app route change or tab
+ * close/refresh) while there are unsaved edits in playlist edit/create mode.
+ */
+export const EditModeNavigationGuard = () => {
+  const { isEditMode, hasChanges, status } = usePlaylistEditMode()
+  // Don't block our own redirect once a save/create is underway.
+  const shouldBlock = isEditMode && hasChanges && status !== 'saving'
+
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      shouldBlock && currentLocation.pathname !== nextLocation.pathname
+  )
+
+  // Browser-level navigation (close tab, refresh, external link).
+  useEffect(() => {
+    if (!shouldBlock) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [shouldBlock])
+
+  // If the changes are saved/discarded while a navigation is blocked, release.
+  useEffect(() => {
+    if (blocker.state === 'blocked' && !shouldBlock) {
+      blocker.proceed()
+    }
+  }, [blocker, shouldBlock])
+
+  return (
+    <ConfirmationModal
+      isOpen={blocker.state === 'blocked'}
+      onClose={() => blocker.state === 'blocked' && blocker.reset()}
+      messages={messages}
+      onConfirm={() => blocker.state === 'blocked' && blocker.proceed()}
+      onCancel={() => blocker.state === 'blocked' && blocker.reset()}
+      destructive
+    />
+  )
+}

--- a/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeBar.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeBar.tsx
@@ -1,31 +1,45 @@
+import { ReactNode } from 'react'
+
 import { Button, Flex, Text, useTheme } from '@audius/harmony'
+
+import { usePortal } from 'hooks/usePortal'
+import { useMainContentRef } from 'pages/MainContentContext'
 
 import { usePlaylistEditMode } from './PlaylistEditModeContext'
 
 const messages = {
   pending: 'You have unsaved changes',
+  createPrompt: 'Finish setting up your playlist',
   conflictTitle: 'Out of date',
   conflictBody:
     'Someone else updated this playlist while you were editing it. Reload to start over.',
   apply: 'Apply',
+  create: 'Create',
   discard: 'Discard',
+  cancel: 'Cancel',
   reload: 'Reload'
 }
 
-export const PlaylistEditModeBar = () => {
+const AnchoredBar = ({ children }: { children: ReactNode }) => {
   const { color } = useTheme()
-  const { isEditMode, hasChanges, status, apply, discard, resolveConflict } =
-    usePlaylistEditMode()
+  // Portal out of the main content wrapper — its `transform` creates a
+  // containing block that breaks position:fixed relative to the viewport.
+  // Anchor to the app shell so the bar sits above the play bar and inherits
+  // the --nav-width / --play-bar-height vars.
+  const mainContentRef = useMainContentRef()
+  const Portal = usePortal({
+    container: mainContentRef.current?.parentElement ?? undefined
+  })
 
-  if (!isEditMode) return null
-
-  if (status === 'conflict') {
-    return (
+  return (
+    <Portal>
       <Flex
         css={{
-          position: 'sticky',
-          bottom: 0,
-          zIndex: 5,
+          position: 'fixed',
+          bottom: 'var(--play-bar-height)',
+          left: 'var(--nav-width)',
+          width: 'calc(100% - var(--nav-width))',
+          zIndex: 11,
           backgroundColor: color.background.surface1,
           borderTop: `1px solid ${color.border.strong}`,
           boxShadow: '0 -4px 10px rgba(0,0,0,0.08)'
@@ -35,89 +49,81 @@ export const PlaylistEditModeBar = () => {
         alignItems='center'
         justifyContent='space-between'
       >
-        <Flex direction='column' gap='xs'>
-          <Text variant='title' size='m' color='danger'>
-            {messages.conflictTitle}
-          </Text>
-          <Text variant='body' color='subdued'>
-            {messages.conflictBody}
-          </Text>
-        </Flex>
-        <Button
-          variant='primary'
-          onClick={() => {
-            resolveConflict()
-            window.location.reload()
-          }}
-        >
-          {messages.reload}
-        </Button>
+        {children}
       </Flex>
+    </Portal>
+  )
+}
+
+export const PlaylistEditModeBar = () => {
+  const {
+    isEditMode,
+    isCreate,
+    hasChanges,
+    canApply,
+    status,
+    apply,
+    discard,
+    resolveConflict
+  } = usePlaylistEditMode()
+
+  if (!isEditMode) return null
+
+  if (status === 'conflict') {
+    return (
+      <>
+        {/* Reserve space so the fixed bar never covers page content */}
+        <div css={{ height: 80 }} />
+        <AnchoredBar>
+          <Flex direction='column' gap='xs'>
+            <Text variant='title' size='m' color='danger'>
+              {messages.conflictTitle}
+            </Text>
+            <Text variant='body' color='subdued'>
+              {messages.conflictBody}
+            </Text>
+          </Flex>
+          <Button
+            variant='primary'
+            onClick={() => {
+              resolveConflict()
+              window.location.reload()
+            }}
+          >
+            {messages.reload}
+          </Button>
+        </AnchoredBar>
+      </>
     )
   }
 
-  if (!hasChanges && status !== 'saving') {
-    // Still in edit mode but no pending changes — show a slim bar with Discard
-    // (which exits edit mode).
-    return (
-      <Flex
-        css={{
-          position: 'sticky',
-          bottom: 0,
-          zIndex: 5,
-          backgroundColor: color.background.surface1,
-          borderTop: `1px solid ${color.border.strong}`
-        }}
-        p='m'
-        gap='m'
-        alignItems='center'
-        justifyContent='flex-end'
-      >
-        <Button variant='secondary' size='small' onClick={discard}>
-          {messages.discard}
-        </Button>
-        <Button variant='primary' size='small' disabled>
-          {messages.apply}
-        </Button>
-      </Flex>
-    )
-  }
+  const isSaving = status === 'saving'
 
   return (
-    <Flex
-      css={{
-        position: 'sticky',
-        bottom: 0,
-        zIndex: 5,
-        backgroundColor: color.background.surface1,
-        borderTop: `1px solid ${color.border.strong}`,
-        boxShadow: '0 -4px 10px rgba(0,0,0,0.08)'
-      }}
-      p='l'
-      gap='xl'
-      alignItems='center'
-      justifyContent='space-between'
-    >
-      <Text variant='body' strength='strong'>
-        {messages.pending}
-      </Text>
-      <Flex gap='m'>
-        <Button
-          variant='secondary'
-          onClick={discard}
-          disabled={status === 'saving'}
-        >
-          {messages.discard}
-        </Button>
-        <Button
-          variant='primary'
-          onClick={apply}
-          isLoading={status === 'saving'}
-          disabled={status === 'saving'}
-        >
-          {messages.apply}
-        </Button>
-      </Flex>
-    </Flex>
+    <>
+      <div css={{ height: 80 }} />
+      <AnchoredBar>
+        <Text variant='body' strength='strong'>
+          {isCreate
+            ? messages.createPrompt
+            : hasChanges
+              ? messages.pending
+              : ''}
+        </Text>
+        <Flex gap='m'>
+          <Button variant='secondary' onClick={discard} disabled={isSaving}>
+            {isCreate ? messages.cancel : messages.discard}
+          </Button>
+          <Button
+            variant='primary'
+            onClick={apply}
+            isLoading={isSaving}
+            disabled={isSaving || !canApply}
+          >
+            {isCreate ? messages.create : messages.apply}
+          </Button>
+        </Flex>
+      </AnchoredBar>
+    </>
   )
 }

--- a/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeContext.tsx
+++ b/packages/web/src/components/collection/desktop/edit-mode/PlaylistEditModeContext.tsx
@@ -3,6 +3,7 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState
@@ -16,6 +17,10 @@ import {
   toastActions
 } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router'
+
+import { isDraftCollection, removeDraftCollection } from './draftCollections'
+import { useCreateDraftPlaylist } from './useCreateDraftPlaylist'
 
 const { editPlaylist } = cacheCollectionsActions
 const { toast } = toastActions
@@ -39,10 +44,12 @@ type PlaylistEditModeContextValue = {
   collectionId?: ID
   isOwner: boolean
   isEditMode: boolean
+  isCreate: boolean
   status: Status
   draft: PlaylistMetadataDraft
   removedTrackIds: Set<ID>
   hasChanges: boolean
+  canApply: boolean
   canUndoRemoval: boolean
   canRedoRemoval: boolean
   enterEditMode: () => void
@@ -86,7 +93,9 @@ const messages = {
   },
   conflict:
     'Heads up — someone else changed this playlist while you were editing. Reload and try again.',
-  failed: 'Could not save changes. Please try again.'
+  failed: 'Could not save changes. Please try again.',
+  created: 'Created playlist',
+  createFailed: 'Could not create playlist. Please try again.'
 }
 
 type ProviderProps = {
@@ -101,8 +110,12 @@ export const PlaylistEditModeProvider = ({
   children
 }: ProviderProps) => {
   const dispatch = useDispatch()
+  const navigate = useNavigate()
   const { data: collection } = useCollection(collectionId)
   const { data: tracks } = useCollectionTracks(collectionId)
+  const publishDraft = useCreateDraftPlaylist()
+
+  const isCreate = isDraftCollection(collectionId)
 
   const [isEditMode, setIsEditMode] = useState(false)
   const [draft, setDraft] = useState<PlaylistMetadataDraft>({})
@@ -140,6 +153,15 @@ export const PlaylistEditModeProvider = ({
     setStatus('idle')
     setEditModeLoadedAt(null)
   }, [resetRemovals])
+
+  // For the inline create flow, the page mounts already in edit mode.
+  const autoEnteredRef = useRef(false)
+  useEffect(() => {
+    if (isCreate && !autoEnteredRef.current) {
+      autoEnteredRef.current = true
+      enterEditMode()
+    }
+  }, [isCreate, enterEditMode])
 
   const setField = useCallback<PlaylistEditModeContextValue['setField']>(
     (field, value) => {
@@ -190,7 +212,15 @@ export const PlaylistEditModeProvider = ({
   const discard = useCallback(() => {
     setDraft({})
     resetRemovals()
-  }, [resetRemovals])
+    setStatus('idle')
+    setIsEditMode(false)
+    setEditModeLoadedAt(null)
+    if (isCreate && collectionId != null) {
+      // Abandon the unsaved draft and leave the create page.
+      removeDraftCollection(collectionId)
+      navigate(-1)
+    }
+  }, [resetRemovals, isCreate, collectionId, navigate])
 
   const resolveConflict = useCallback(() => {
     setStatus('idle')
@@ -200,8 +230,18 @@ export const PlaylistEditModeProvider = ({
     setEditModeLoadedAt(null)
   }, [resetRemovals])
 
+  const stagedName =
+    draft.playlist_name !== undefined
+      ? draft.playlist_name
+      : collection?.playlist_name
+
+  const draftTrackCount = collection?.playlist_contents.track_ids.length ?? 0
+
   const hasChanges = useMemo(() => {
     if (!collection) return false
+    // In create mode the page is "dirty" the moment any content exists, so we
+    // warn before navigating away from an unsaved draft.
+    if (isCreate && draftTrackCount > 0) return true
     if (removedTrackIds.size > 0) return true
     const fields = ['playlist_name', 'description', 'is_private'] as const
     for (const f of fields) {
@@ -214,10 +254,60 @@ export const PlaylistEditModeProvider = ({
     }
     if (draft.artwork !== undefined && draft.artwork !== null) return true
     return false
-  }, [collection, draft, removedTrackIds])
+  }, [collection, draft, removedTrackIds, isCreate, draftTrackCount])
+
+  // For create, the primary action is enabled as long as the playlist has a
+  // usable name. For edit, it requires actual changes.
+  const canApply = isCreate
+    ? !!stagedName && stagedName.trim().length > 0
+    : hasChanges
 
   const apply = useCallback(() => {
     if (!collection || !collection.playlist_id) return
+
+    if (isCreate) {
+      if (!canApply) return
+      setStatus('saving')
+      const trackIds = collection.playlist_contents.track_ids
+        .filter((t) => !removedTrackIds.has(t.track))
+        .map((t) => t.track)
+      const metadata = {
+        ...(collection as unknown as EditCollectionValues),
+        playlist_name: draft.playlist_name ?? collection.playlist_name,
+        description:
+          draft.description !== undefined
+            ? draft.description
+            : collection.description,
+        is_private:
+          draft.is_private !== undefined
+            ? draft.is_private
+            : collection.is_private,
+        artwork: draft.artwork ?? undefined
+      } as EditCollectionValues
+      publishDraft.mutate(
+        { playlistId: collection.playlist_id, metadata, trackIds },
+        {
+          onSuccess: (confirmed) => {
+            removeDraftCollection(collection.playlist_id)
+            setDraft({})
+            resetRemovals()
+            setIsEditMode(false)
+            setStatus('idle')
+            setEditModeLoadedAt(null)
+            dispatch(toast({ content: messages.created }))
+            if (confirmed?.permalink) {
+              navigate(confirmed.permalink, { replace: true })
+            }
+          },
+          onError: () => {
+            setStatus('idle')
+            dispatch(toast({ content: messages.createFailed }))
+          }
+        }
+      )
+      return
+    }
+
     if (!hasChanges) {
       exitEditMode()
       return
@@ -295,12 +385,16 @@ export const PlaylistEditModeProvider = ({
       })
     )
   }, [
+    canApply,
     collection,
     dispatch,
     draft,
     editModeLoadedAt,
     exitEditMode,
     hasChanges,
+    isCreate,
+    navigate,
+    publishDraft,
     removedTrackIds,
     resetRemovals,
     tracks
@@ -314,10 +408,12 @@ export const PlaylistEditModeProvider = ({
       collectionId,
       isOwner,
       isEditMode,
+      isCreate,
       status,
       draft,
       removedTrackIds,
       hasChanges,
+      canApply,
       canUndoRemoval,
       canRedoRemoval,
       enterEditMode,
@@ -332,6 +428,7 @@ export const PlaylistEditModeProvider = ({
     }),
     [
       apply,
+      canApply,
       canRedoRemoval,
       canUndoRemoval,
       collectionId,
@@ -340,6 +437,7 @@ export const PlaylistEditModeProvider = ({
       enterEditMode,
       exitEditMode,
       hasChanges,
+      isCreate,
       isEditMode,
       isOwner,
       redoRemoval,
@@ -369,10 +467,12 @@ export const usePlaylistEditMode = (): PlaylistEditModeContextValue => {
       collectionId: undefined,
       isOwner: false,
       isEditMode: false,
+      isCreate: false,
       status: 'idle',
       draft: {},
       removedTrackIds: new Set(),
       hasChanges: false,
+      canApply: false,
       canUndoRemoval: false,
       canRedoRemoval: false,
       enterEditMode: () => {},

--- a/packages/web/src/components/collection/desktop/edit-mode/draftCollectionCache.ts
+++ b/packages/web/src/components/collection/desktop/edit-mode/draftCollectionCache.ts
@@ -1,0 +1,47 @@
+import { getCollectionQueryKey } from '@audius/common/api'
+import { ID, Kind } from '@audius/common/models'
+import { Uid } from '@audius/common/utils'
+import { QueryClient } from '@tanstack/react-query'
+
+type DraftCollection = {
+  trackIds?: ID[]
+  track_count?: number
+  playlist_contents: {
+    track_ids: { track: ID; time: number; uid?: string }[]
+  }
+}
+
+/**
+ * Appends a track to a locally-drafted collection in the query cache. Used by
+ * the inline create flow so "add" affordances mutate the draft instead of
+ * writing to the backend. Mutates both `trackIds` and `playlist_contents` so
+ * the lineup and dependent queries stay consistent.
+ */
+export const addTrackToDraftCollection = (
+  queryClient: QueryClient,
+  collectionId: ID,
+  trackId: ID
+) => {
+  queryClient.setQueryData<DraftCollection>(
+    getCollectionQueryKey(collectionId),
+    (prev) => {
+      if (!prev) return prev
+      if (prev.trackIds?.includes(trackId)) return prev
+      const time = Math.round(Date.now() / 1000)
+      const uid = new Uid(Kind.TRACKS, trackId, 'collection').toString()
+      const nextTrackIds = [...(prev.trackIds ?? []), trackId]
+      return {
+        ...prev,
+        trackIds: nextTrackIds,
+        track_count: nextTrackIds.length,
+        playlist_contents: {
+          ...prev.playlist_contents,
+          track_ids: [
+            ...prev.playlist_contents.track_ids,
+            { track: trackId, time, uid }
+          ]
+        }
+      }
+    }
+  )
+}

--- a/packages/web/src/components/collection/desktop/edit-mode/draftCollections.ts
+++ b/packages/web/src/components/collection/desktop/edit-mode/draftCollections.ts
@@ -1,0 +1,19 @@
+import { ID } from '@audius/common/models'
+
+// Tracks collection ids that exist only as unsaved local drafts (the inline
+// "create playlist" flow). A draft is primed into the query cache with a
+// generated id but is not persisted to the backend until the user hits Apply.
+// The edit-mode provider reads this to auto-enter edit mode and to treat Apply
+// as a create rather than an edit.
+const draftCollectionIds = new Set<ID>()
+
+export const addDraftCollection = (id: ID) => {
+  draftCollectionIds.add(id)
+}
+
+export const removeDraftCollection = (id: ID) => {
+  draftCollectionIds.delete(id)
+}
+
+export const isDraftCollection = (id: ID | null | undefined): boolean =>
+  id != null && draftCollectionIds.has(id)

--- a/packages/web/src/components/collection/desktop/edit-mode/useCreateDraftPlaylist.ts
+++ b/packages/web/src/components/collection/desktop/edit-mode/useCreateDraftPlaylist.ts
@@ -1,0 +1,109 @@
+import {
+  fileToSdk,
+  playlistMetadataForCreateWithSDK,
+  userCollectionMetadataFromSDK
+} from '@audius/common/adapters'
+import {
+  getCollectionQueryKey,
+  primeCollectionData,
+  useCurrentAccountUser,
+  useCurrentUserId,
+  useQueryContext
+} from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { accountActions, EditCollectionValues } from '@audius/common/store'
+import { Id, OptionalId } from '@audius/sdk'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useDispatch } from 'react-redux'
+
+const { addAccountPlaylist } = accountActions
+
+type CreateDraftPlaylistParams = {
+  playlistId: ID
+  metadata: EditCollectionValues
+  trackIds: ID[]
+}
+
+/**
+ * Persists a locally-drafted playlist (see the inline create flow) to the
+ * backend in one shot: uploads artwork, writes metadata + ordered tracks, then
+ * primes the confirmed playlist into the cache and adds it to the account.
+ * Returns the confirmed collection so the caller can navigate to its permalink.
+ */
+export const useCreateDraftPlaylist = () => {
+  const { audiusSdk } = useQueryContext()
+  const queryClient = useQueryClient()
+  const dispatch = useDispatch()
+  const { data: currentUserId } = useCurrentUserId()
+  const { data: accountUser } = useCurrentAccountUser()
+
+  return useMutation({
+    mutationFn: async ({
+      playlistId,
+      metadata,
+      trackIds
+    }: CreateDraftPlaylistParams) => {
+      const sdk = await audiusSdk()
+      if (!currentUserId) throw new Error('Not logged in')
+
+      const coverArtFile =
+        metadata.artwork && 'file' in metadata.artwork
+          ? (metadata.artwork.file as File)
+          : undefined
+
+      const now = Math.round(Date.now() / 1000) // seconds
+      const sdkMetadata = playlistMetadataForCreateWithSDK(metadata as any)
+      sdkMetadata.playlistId = Id.parse(playlistId)
+      sdkMetadata.playlistContents = trackIds.map((trackId) => ({
+        trackId: Id.parse(trackId),
+        timestamp: now,
+        metadataTimestamp: now
+      }))
+
+      await sdk.playlists.createPlaylist({
+        userId: Id.parse(currentUserId),
+        imageFile: coverArtFile
+          ? fileToSdk(coverArtFile, 'cover_art')
+          : undefined,
+        metadata: sdkMetadata
+      })
+
+      const { data: playlist } = await sdk.playlists.getPlaylist({
+        userId: OptionalId.parse(currentUserId),
+        playlistId: Id.parse(playlistId)
+      })
+
+      const confirmed = playlist?.[0]
+        ? userCollectionMetadataFromSDK(playlist[0])
+        : null
+      if (!confirmed) {
+        throw new Error(`Could not load created playlist for id ${playlistId}`)
+      }
+
+      primeCollectionData({
+        collections: [confirmed],
+        queryClient,
+        forceReplace: true
+      })
+
+      if (accountUser) {
+        dispatch(
+          addAccountPlaylist({
+            id: confirmed.playlist_id,
+            name: confirmed.playlist_name,
+            is_album: false,
+            user: { id: accountUser.user_id, handle: accountUser.handle },
+            permalink: confirmed.permalink
+          })
+        )
+      }
+
+      return confirmed
+    },
+    onSuccess: (_, { playlistId }) => {
+      queryClient.invalidateQueries({
+        queryKey: getCollectionQueryKey(playlistId)
+      })
+    }
+  })
+}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -28,6 +28,7 @@ import {
   IconTrash,
   PopupMenuItem,
   Text,
+  Tooltip,
   useTheme
 } from '@audius/harmony'
 import { pick } from 'lodash'
@@ -62,7 +63,8 @@ const messages = {
   edit: 'Edit',
   share: 'Share',
   delete: 'Delete',
-  unfavorite: 'Unfavorite'
+  unfavorite: 'Unfavorite',
+  favorited: 'Favorited'
 }
 
 const acceptedKinds: DragDropKind[] = [
@@ -272,14 +274,27 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
               css={{ position: 'relative' }}
               justifyContent='space-between'
             >
-              <Text
-                variant='body'
-                size='s'
-                css={{ maxWidth: '160px' }}
-                ellipses
+              <Flex
+                alignItems='center'
+                gap='xs'
+                css={{ minWidth: 0, flex: 1 }}
               >
-                {name}
-              </Text>
+                <Text
+                  variant='body'
+                  size='s'
+                  css={{ maxWidth: '160px' }}
+                  ellipses
+                >
+                  {name}
+                </Text>
+                {!isOwned ? (
+                  <Tooltip text={messages.favorited} placement='top'>
+                    <Flex alignItems='center' css={{ flexShrink: 0 }}>
+                      <IconHeart size='2xs' color='subdued' />
+                    </Flex>
+                  </Tooltip>
+                ) : null}
+              </Flex>
               <NavItemKebabButton
                 visible={isHovering && !isDraggingOver}
                 aria-label={

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -274,11 +274,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
               css={{ position: 'relative' }}
               justifyContent='space-between'
             >
-              <Flex
-                alignItems='center'
-                gap='xs'
-                css={{ minWidth: 0, flex: 1 }}
-              >
+              <Flex alignItems='center' gap='xs' css={{ minWidth: 0, flex: 1 }}>
                 <Text
                   variant='body'
                   size='s'

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CreatePlaylistLibraryItemButton.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CreatePlaylistLibraryItemButton.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo, useState } from 'react'
 import { useCurrentAccount, useUpdatePlaylistLibrary } from '@audius/common/api'
 import {
   playlistLibraryHelpers,
-  useCreatePlaylistModal,
   useDuplicatePlaylistModal
 } from '@audius/common/store'
 import {
@@ -15,8 +14,10 @@ import {
   PopupMenu,
   PopupMenuItem
 } from '@audius/harmony'
+import { useNavigate } from 'react-router'
 
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
+import { CREATE_PLAYLIST_PAGE } from 'utils/route'
 
 const { addFolderToLibrary, constructPlaylistFolder } = playlistLibraryHelpers
 
@@ -35,14 +36,14 @@ export const CreatePlaylistLibraryItemButton = () => {
     select: (account) => account?.playlistLibrary
   })
   const { mutate: updatePlaylistLibrary } = useUpdatePlaylistLibrary()
-  const { onOpen: openCreatePlaylistModal } = useCreatePlaylistModal()
   const { onOpen: openDuplicatePlaylistModal } = useDuplicatePlaylistModal()
+  const navigate = useNavigate()
   const [isActive, setIsActive] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
 
   const handleSubmitPlaylist = useCallback(() => {
-    openCreatePlaylistModal({ isAlbum: false })
-  }, [openCreatePlaylistModal])
+    navigate(CREATE_PLAYLIST_PAGE)
+  }, [navigate])
 
   const handleDuplicatePlaylist = useCallback(() => {
     openDuplicatePlaylistModal({ isAlbum: false })

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/EmptyLibraryNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/EmptyLibraryNavLink.tsx
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
 
-import { useCreatePlaylistModal } from '@audius/common/store'
+import { useNavigate } from 'react-router'
+
+import { CREATE_PLAYLIST_PAGE } from 'utils/route'
 
 import { LeftNavLink } from '../LeftNavLink'
 
@@ -9,11 +11,11 @@ const messages = {
 }
 
 export const EmptyLibraryNavLink = () => {
-  const { onOpen: openCreatePlaylistModal } = useCreatePlaylistModal()
+  const navigate = useNavigate()
 
   const handleCreatePlaylist = useCallback(() => {
-    openCreatePlaylistModal({ isAlbum: false })
-  }, [openCreatePlaylistModal])
+    navigate(CREATE_PLAYLIST_PAGE)
+  }, [navigate])
 
   return (
     <LeftNavLink disabled onClick={handleCreatePlaylist}>

--- a/packages/web/src/components/suggested-tracks/SuggestedTracks.module.css
+++ b/packages/web/src/components/suggested-tracks/SuggestedTracks.module.css
@@ -55,6 +55,33 @@
   border: 0.5px solid var(--harmony-n-100);
 }
 
+.artworkButton {
+  all: unset;
+  position: relative;
+  cursor: pointer;
+  height: var(--harmony-unit-10);
+  width: var(--harmony-unit-10);
+  flex-shrink: 0;
+}
+
+.playOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transition: opacity var(--harmony-quick);
+}
+
+.artworkButton:hover .playOverlay,
+.artworkButton:focus-visible .playOverlay,
+.playOverlay.isPlaying {
+  opacity: 1;
+}
+
 .trackInfo {
   display: flex;
   flex-direction: column;

--- a/packages/web/src/components/suggested-tracks/SuggestedTracks.tsx
+++ b/packages/web/src/components/suggested-tracks/SuggestedTracks.tsx
@@ -6,19 +6,27 @@ import {
   useSuggestedPlaylistTracks,
   useUser
 } from '@audius/common/api'
+import { useToggleTrack } from '@audius/common/hooks'
 import { SquareSizes, ID, Track } from '@audius/common/models'
+import { QueueSource, Queueable } from '@audius/common/store'
 import {
   Button,
   Divider,
   IconCaretDown,
+  IconPause,
+  IconPlay,
   IconRefresh,
   Paper,
   useTheme,
   Image
 } from '@audius/harmony'
 import { animated, useSpring } from '@react-spring/web'
+import { useQueryClient } from '@tanstack/react-query'
+import cn from 'classnames'
 import { useToggle } from 'react-use'
 
+import { addTrackToDraftCollection } from 'components/collection/desktop/edit-mode/draftCollectionCache'
+import { isDraftCollection } from 'components/collection/desktop/edit-mode/draftCollections'
 import { UserLink } from 'components/link/UserLink'
 import Skeleton from 'components/skeleton/Skeleton'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
@@ -39,17 +47,24 @@ const messages = {
 type SuggestedTrackProps = {
   collectionId: ID
   track: Track
+  queueEntries: Queueable[]
   onAddTrack: (trackId: ID) => void
 }
 
 const SuggestedTrackRow = (props: SuggestedTrackProps) => {
-  const { collectionId, track, onAddTrack } = props
+  const { collectionId, track, queueEntries, onAddTrack } = props
   const { track_id, title, owner_id } = track
   const { data: user } = useUser(owner_id)
   const { data: collection } = useCollection(collectionId)
   const { imageUrl: image } = useTrackCoverArt({
     trackId: track_id,
     size: SquareSizes.SIZE_150_BY_150
+  })
+
+  const { togglePlay, isTrackPlaying } = useToggleTrack({
+    id: track_id,
+    source: QueueSource.RECOMMENDED_TRACKS,
+    entries: queueEntries
   })
 
   const trackIsInCollection = useMemo(
@@ -67,7 +82,26 @@ const SuggestedTrackRow = (props: SuggestedTrackProps) => {
   return (
     <div className={styles.suggestedTrack}>
       <div className={styles.trackDetails}>
-        <Image className={styles.trackArtwork} src={image} />
+        <button
+          type='button'
+          className={styles.artworkButton}
+          onClick={togglePlay}
+          onMouseDown={(e) => e.preventDefault()}
+          aria-label={isTrackPlaying ? `Pause ${title}` : `Play ${title}`}
+        >
+          <Image className={styles.trackArtwork} src={image} />
+          <span
+            className={cn(styles.playOverlay, {
+              [styles.isPlaying]: isTrackPlaying
+            })}
+          >
+            {isTrackPlaying ? (
+              <IconPause size='s' color='staticWhite' />
+            ) : (
+              <IconPlay size='s' color='staticWhite' />
+            )}
+          </span>
+        </button>
         <div className={styles.trackInfo}>
           <p className={styles.trackName}>{title}</p>
           {user ? <UserLink userId={user.user_id} size='s' /> : null}
@@ -107,6 +141,7 @@ type SuggestedTracksProps = {
 export const SuggestedTracks = (props: SuggestedTracksProps) => {
   const { collectionId } = props
   const mainContentRef = useMainContentRef()
+  const queryClient = useQueryClient()
   const {
     suggestedTracks,
     onRefresh,
@@ -114,13 +149,19 @@ export const SuggestedTracks = (props: SuggestedTracksProps) => {
   } = useSuggestedPlaylistTracks(collectionId)
   const [isExpanded, toggleIsExpanded] = useToggle(false)
   const { motion } = useTheme()
+  const isDraft = isDraftCollection(collectionId)
 
   // Preserve scroll position when adding track - prevents scroll-to-top on
   // optimistic update (e.g. from focus loss when Add button becomes disabled)
   const onAddTrack = useCallback(
     (trackId: ID) => {
       const scrollTop = mainContentRef?.current?.scrollTop ?? 0
-      originalOnAddTrack(trackId)
+      if (isDraft) {
+        // Unsaved create flow: mutate the local draft, not the backend.
+        addTrackToDraftCollection(queryClient, collectionId, trackId)
+      } else {
+        originalOnAddTrack(trackId)
+      }
       // Restore scroll after React has committed the update
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
@@ -130,7 +171,18 @@ export const SuggestedTracks = (props: SuggestedTracksProps) => {
         })
       })
     },
-    [originalOnAddTrack, mainContentRef]
+    [originalOnAddTrack, mainContentRef, isDraft, queryClient, collectionId]
+  )
+
+  const queueEntries = useMemo<Queueable[]>(
+    () =>
+      suggestedTracks
+        .filter((track): track is Track => !!track?.track_id)
+        .map((track) => ({
+          id: track.track_id,
+          source: QueueSource.RECOMMENDED_TRACKS
+        })),
+    [suggestedTracks]
   )
 
   const contentHeight = 66 + SUGGESTED_TRACK_COUNT * 74
@@ -167,6 +219,7 @@ export const SuggestedTracks = (props: SuggestedTracksProps) => {
                 <SuggestedTrackRow
                   track={suggestedTracks[i]}
                   collectionId={collectionId}
+                  queueEntries={queueEntries}
                   onAddTrack={onAddTrack}
                 />
               ) : (

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -22,6 +22,7 @@ import { Id } from '@audius/sdk'
 
 import { CollectionDogEar } from 'components/collection'
 import { CollectionHeader } from 'components/collection/desktop/CollectionHeader'
+import { EditModeNavigationGuard } from 'components/collection/desktop/edit-mode/EditModeNavigationGuard'
 import { PlaylistEditModeBar } from 'components/collection/desktop/edit-mode/PlaylistEditModeBar'
 import { PlaylistEditModeProvider } from 'components/collection/desktop/edit-mode/PlaylistEditModeContext'
 import { EditAwareTracksTable } from 'components/collection/desktop/edit-mode/tracks/EditAwareTracksTable'
@@ -398,6 +399,7 @@ const CollectionPage = ({ type }: CollectionPageProps) => {
             </Flex>
           ) : null}
           <PlaylistEditModeBar />
+          <EditModeNavigationGuard />
         </Page>
       </TrackSelectionProvider>
     </PlaylistEditModeProvider>

--- a/packages/web/src/pages/create-playlist-page/CreatePlaylistPage.tsx
+++ b/packages/web/src/pages/create-playlist-page/CreatePlaylistPage.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+
+import {
+  primeCollectionData,
+  useCurrentAccountUser,
+  useQueryContext
+} from '@audius/common/api'
+import { CollectionMetadata } from '@audius/common/models'
+import { newCollectionMetadata } from '@audius/common/schemas'
+import { route } from '@audius/common/utils'
+import { Flex, LoadingSpinner } from '@audius/harmony'
+import { useQueryClient } from '@tanstack/react-query'
+import { Navigate } from 'react-router'
+
+import {
+  addDraftCollection,
+  isDraftCollection
+} from 'components/collection/desktop/edit-mode/draftCollections'
+import { useRequiresAccount } from 'hooks/useRequiresAccount'
+
+const { collectionPage, PLAYLIST_ID_PAGE } = route
+
+const messages = {
+  defaultName: 'My Playlist'
+}
+
+/**
+ * Entry point for the inline "create playlist" flow. Generates a playlist id,
+ * primes an unsaved draft collection into the query cache (nothing is written
+ * to the backend), registers it as a draft, then redirects to the standard
+ * collection page which renders the draft in edit/create mode.
+ */
+export const CreatePlaylistPage = () => {
+  useRequiresAccount()
+  const { audiusSdk } = useQueryContext()
+  const queryClient = useQueryClient()
+  const { data: accountUser } = useCurrentAccountUser()
+
+  const [draftId, setDraftId] = useState<number | null>(null)
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    if (startedRef.current || !accountUser) return
+    startedRef.current = true
+
+    const createDraft = async () => {
+      const sdk = await audiusSdk()
+      const id = await sdk.playlists.generatePlaylistId()
+      if (!id) return
+
+      const { user_id, handle } = accountUser
+      const permalink = collectionPage(
+        handle,
+        messages.defaultName,
+        id,
+        undefined,
+        false
+      )
+
+      const draft = newCollectionMetadata({
+        playlist_id: id,
+        playlist_owner_id: user_id,
+        playlist_name: messages.defaultName,
+        description: '',
+        is_private: true,
+        is_album: false,
+        playlist_contents: { track_ids: [] },
+        track_count: 0,
+        save_count: 0,
+        repost_count: 0,
+        has_current_user_saved: false,
+        has_current_user_reposted: false,
+        is_delete: false,
+        permalink
+      }) as CollectionMetadata
+
+      // forceReplace writes the draft into the cache; entityCacheOptions
+      // (staleTime/gcTime Infinity) keep it from being refetched/clobbered.
+      primeCollectionData({
+        collections: [draft],
+        queryClient,
+        forceReplace: true
+      })
+
+      addDraftCollection(id)
+      setDraftId(id)
+    }
+
+    createDraft()
+  }, [accountUser, audiusSdk, queryClient])
+
+  if (draftId != null && isDraftCollection(draftId)) {
+    return (
+      <Navigate to={PLAYLIST_ID_PAGE.replace(':id', String(draftId))} replace />
+    )
+  }
+
+  return (
+    <Flex w='100%' justifyContent='center' alignItems='center' p='3xl'>
+      <LoadingSpinner css={{ width: 48, height: 48 }} />
+    </Flex>
+  )
+}
+
+export default CreatePlaylistPage

--- a/packages/web/src/pages/create-playlist-page/CreatePlaylistPage.tsx
+++ b/packages/web/src/pages/create-playlist-page/CreatePlaylistPage.tsx
@@ -9,6 +9,7 @@ import { CollectionMetadata } from '@audius/common/models'
 import { newCollectionMetadata } from '@audius/common/schemas'
 import { route } from '@audius/common/utils'
 import { Flex, LoadingSpinner } from '@audius/harmony'
+import { Id } from '@audius/sdk'
 import { useQueryClient } from '@tanstack/react-query'
 import { Navigate } from 'react-router'
 
@@ -91,7 +92,10 @@ export const CreatePlaylistPage = () => {
 
   if (draftId != null && isDraftCollection(draftId)) {
     return (
-      <Navigate to={PLAYLIST_ID_PAGE.replace(':id', String(draftId))} replace />
+      <Navigate
+        to={PLAYLIST_ID_PAGE.replace(':id', Id.parse(draftId))}
+        replace
+      />
     )
   }
 

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -10,6 +10,9 @@ import { encodeUrlName } from './urlUtils'
 // Local route functions to avoid importing from @audius/common/src/utils/route which pulls in formatUtil/dayjs
 const SIGN_UP_PAGE = '/signup'
 
+// Inline "create playlist" flow entry point.
+export const CREATE_PLAYLIST_PAGE = '/create/playlist'
+
 export const profilePage = (handle: string | null | undefined) => {
   return `/${encodeUrlName(handle ?? '')}`
 }


### PR DESCRIPTION
## Summary
- Replaces the create-playlist **modal** with an inline `/create/playlist` flow that reuses the existing collection edit UI. The draft lives only in the TanStack Query cache — nothing is written to the backend until **Apply**, which publishes metadata + ordered tracks in one shot via the SDK and redirects to the new playlist's permalink.
- Suggested-tracks "Add" mutates the cached draft directly while in create mode (no backend writes); suggested tracks are now playable with a play overlay.
- Bundles the rest of the playlist-edit overhaul: fixed discard, fixed description-field background contrast, anchored the unsaved-changes bar to the bottom, added an unsaved-changes navigation guard (in-app + tab close), and added an owned-vs-favorited heart indicator in the left nav.

## Implementation notes
- New `/create/playlist` route generates a playlist id, primes a private draft into the cache (`forceReplace`; `entityCacheOptions` staleTime/gcTime Infinity keep it from being refetched), then redirects to the standard collection page which auto-enters create-edit mode.
- Publish logic kept in `packages/web` (a tan-query mutation hook) rather than `packages/common` to avoid a publishable-package changeset.
- Desktop create triggers (`CreatePlaylistLibraryItemButton`, `EmptyLibraryNavLink`) now navigate to the route instead of opening the modal. Mobile triggers are left on the modal — this is a desktop inline feature.

## Test plan
- [ ] From the left nav "+", create a playlist → lands on `/create/playlist` → redirects into inline create-edit mode
- [ ] Set name/description/visibility (private) and artwork in the inline editor
- [ ] Add tracks from the "Add some tracks" panel; verify they appear and are playable
- [ ] Apply → spinner → redirect to the new playlist permalink; playlist shows in left nav
- [ ] Cancel/discard abandons the draft and navigates back; nothing persisted
- [ ] Navigating away mid-draft triggers the unsaved-changes warning
- [ ] Editing an existing playlist: discard works, description contrast is correct, unsaved bar is anchored

🤖 Generated with [Claude Code](https://claude.com/claude-code)