### PR TITLE
fix(web): serialize addTrackToPlaylist saga to stop dropping bulk-added tracks

### DIFF
--- a/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
@@ -32,7 +32,7 @@ import {
   Nullable
 } from '@audius/common/utils'
 import { Id } from '@audius/sdk'
-import { call, put, takeEvery } from 'typed-redux-saga'
+import { actionChannel, call, put, take } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
 import { ensureLoggedIn } from 'common/utils/ensureLoggedIn'
@@ -65,11 +65,20 @@ const getCurrentTimestamp = () => {
 
 /** ADD TRACK TO PLAYLIST */
 
+// Process ADD_TRACK_TO_PLAYLIST one at a time. takeEvery let concurrent
+// invocations race: each captured the cache snapshot before any had written
+// back its optimistic update, and the last saga to finish overwrote the
+// others — silently dropping their tracks on both the cache and the backend.
+// This was visible when adding tracks in quick succession (e.g. via the
+// add-tracks-by-URL modal): only the final track survived.
 export function* watchAddTrackToPlaylist() {
-  yield* takeEvery(
-    cacheCollectionsActions.ADD_TRACK_TO_PLAYLIST,
-    addTrackToPlaylistAsync
+  const channel = yield* actionChannel<AddTrackToPlaylistAction>(
+    cacheCollectionsActions.ADD_TRACK_TO_PLAYLIST
   )
+  while (true) {
+    const action = yield* take(channel)
+    yield* call(addTrackToPlaylistAsync, action)
+  }
 }
 
 function* addTrackToPlaylistAsync(action: AddTrackToPlaylistAction) {


### PR DESCRIPTION
## Summary

- `addTrackToPlaylist` saga used `takeEvery` so concurrent dispatches raced: each captured the cached playlist, mutated locally, then wrote back only after the slow `updatePlaylistArtwork` finished. With overlapping sagas, the later write overwrote the earlier one with a captured-stale playlist, dropping the earlier added track on both the cache **and** the backend (the confirmer's SDK update used the same captured playlist).
- Reported by a user as: adding tracks to a (new) playlist appears to "do nothing" — paste 5 URLs, end up with 1 track. The add-tracks-by-URL modal's 30 ms inter-dispatch delay was a workaround that didn't cover the artwork-generation window.
- Fix: switch the watcher to `actionChannel` + a serial `take` loop so each add runs to completion (cache write + confirmer queued) before the next one starts reading.

## Test plan

- [ ] Open a new (or existing) playlist on web; paste 5 track URLs into the "Add tracks by URL" modal; confirm all 5 tracks appear in the playlist and persist after refresh.
- [ ] Add 5 tracks one-by-one via the track menu's "Add to Playlist" → confirm all 5 persist.
- [ ] Add a single track via paste-URL → still works and toast appears once.
- [ ] Remove tracks from the playlist (existing flow) → still works, no regression.
- [ ] Add a track, then immediately click Apply in playlist edit mode after staging a removal → both the addition and the removal are reflected after the save settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)