### PR TITLE
fix(collection): stop double-toast on add-to-playlist (mobile + web)

### DIFF
--- a/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
+++ b/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
@@ -134,7 +134,11 @@ export const AddToCollectionDrawer = () => {
               )
             } else {
               toast({ content: messages.addedToast })
-              dispatch(addTrackToPlaylist(trackId, item.playlist_id))
+              dispatch(
+                addTrackToPlaylist(trackId, item.playlist_id, {
+                  silent: true
+                })
+              )
             }
             onClose()
           }}

--- a/packages/mobile/src/components/duplicate-add-confirmation-drawer/DuplicateAddConfirmationDrawer.tsx
+++ b/packages/mobile/src/components/duplicate-add-confirmation-drawer/DuplicateAddConfirmationDrawer.tsx
@@ -71,7 +71,7 @@ export const DuplicateAddConfirmationDrawer = () => {
   const handleAdd = useCallback(() => {
     if (playlistId && trackId) {
       toast({ content: messages.addedToast })
-      dispatch(addTrackToPlaylist(trackId, playlistId))
+      dispatch(addTrackToPlaylist(trackId, playlistId, { silent: true }))
     }
     onClose()
   }, [playlistId, trackId, onClose, toast, messages.addedToast, dispatch])

--- a/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
+++ b/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
@@ -121,7 +121,9 @@ const AddToCollectionModal = NiceModal.create(() => {
         })
       )
     } else {
-      dispatch(addTrackToPlaylist(trackId, playlist.playlist_id))
+      dispatch(
+        addTrackToPlaylist(trackId, playlist.playlist_id, { silent: true })
+      )
       if (trackTitle) {
         toast({
           content: messages.addedToast,

--- a/packages/web/src/components/duplicate-add-confirmation-modal/DuplicateAddConfirmationModal.tsx
+++ b/packages/web/src/components/duplicate-add-confirmation-modal/DuplicateAddConfirmationModal.tsx
@@ -61,7 +61,7 @@ export const DuplicateAddConfirmationModal = NiceModal.create(() => {
 
   const handleAdd = useCallback(() => {
     if (trackId && playlistId) {
-      dispatch(addTrackToPlaylist(trackId, playlistId))
+      dispatch(addTrackToPlaylist(trackId, playlistId, { silent: true }))
       if (accountHandle) {
         toast(
           <ToastLinkContent


### PR DESCRIPTION
## Summary

Adding a track via the Add-to-Collection drawer (mobile) or modal (web), or via the Duplicate-Add confirmation drawer/modal, showed **two** toasts in a row.

Root cause: the `addTrackToPlaylist` saga ends with `if (!action.silent) put(toast(...))` — the `silent` gate added in #14393 lets callers suppress the saga's default toast when they want to show their own. Four callers ignored the gate: they dispatched `addTrackToPlaylist` without `silent` *and* fired their own UI toast (some richer than the saga's, e.g. the duplicate-add-confirmation modal's toast with a "View" link). Both the UI toasts and the saga's toast funnel through the same Redux toast slice — `ToastContext.toast` and `useToast().toast` both ultimately dispatch the same `toast` action — so there is no implicit dedup. Mobile users saw two toasts; desktop users got the same bug but the two were timed close enough that they often didn't notice.

The fix is a one-line `{ silent: true }` in each of the four call sites so the saga keeps quiet and the caller's richer toast wins. Other callers (track menu, sidebar drag-drop, suggested-tracks "Add") don't fire their own toast and keep getting the saga's default — unchanged.

## Files

- `packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx`
- `packages/mobile/src/components/duplicate-add-confirmation-drawer/DuplicateAddConfirmationDrawer.tsx`
- `packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx`
- `packages/web/src/components/duplicate-add-confirmation-modal/DuplicateAddConfirmationModal.tsx`

## Test plan

- [ ] Mobile: Open a track menu → Add to playlist → pick a playlist → exactly one toast appears.
- [ ] Mobile: Add a track that's already in the playlist → confirm "Add Anyway" → exactly one toast appears.
- [ ] Web: Same two flows via desktop modal → exactly one toast appears, and the toast still includes the "View" link where it did before.
- [ ] Web: Drag a track from the sidebar onto a playlist library entry → still get the saga's default "Added track to playlist" toast (no regression).
- [ ] Web: Click "+" on a suggested track on the playlist page → still get the saga's default toast.
- [ ] Web: Paste-URL bulk add → no per-track toasts, only the modal's summary toast (no regression — already used `silent: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)