### PR TITLE
fix(suggested-tracks): row hover + full-row play click target

### DIFF
--- a/packages/web/src/components/suggested-tracks/SuggestedTracks.module.css
+++ b/packages/web/src/components/suggested-tracks/SuggestedTracks.module.css
@@ -40,6 +40,22 @@
   justify-content: space-between;
   padding: var(--harmony-unit-4);
   gap: var(--harmony-unit-3);
+  cursor: pointer;
+  transition: background-color var(--harmony-quick);
+}
+
+.suggestedTrack:hover,
+.suggestedTrack:focus-visible {
+  background-color: var(--harmony-n-50);
+}
+
+.suggestedTrack:focus {
+  outline: none;
+}
+
+.suggestedTrack:focus-visible {
+  outline: 2px solid var(--harmony-focus, var(--harmony-secondary));
+  outline-offset: -2px;
 }
 
 .trackDetails {
@@ -55,10 +71,8 @@
   border: 0.5px solid var(--harmony-n-100);
 }
 
-.artworkButton {
-  all: unset;
+.artworkWrapper {
   position: relative;
-  cursor: pointer;
   height: var(--harmony-unit-10);
   width: var(--harmony-unit-10);
   flex-shrink: 0;
@@ -74,12 +88,17 @@
   background: rgba(0, 0, 0, 0.4);
   opacity: 0;
   transition: opacity var(--harmony-quick);
+  pointer-events: none;
 }
 
-.artworkButton:hover .playOverlay,
-.artworkButton:focus-visible .playOverlay,
+.suggestedTrack:hover .playOverlay,
+.suggestedTrack:focus-visible .playOverlay,
 .playOverlay.isPlaying {
   opacity: 1;
+}
+
+.userLinkWrapper {
+  display: inline-flex;
 }
 
 .trackInfo {
@@ -139,4 +158,9 @@
 .suggestedTrackSkeleton {
   composes: suggestedTrack;
   height: 72px;
+  cursor: default;
+}
+
+.suggestedTrackSkeleton:hover {
+  background-color: transparent;
 }

--- a/packages/web/src/components/suggested-tracks/SuggestedTracks.tsx
+++ b/packages/web/src/components/suggested-tracks/SuggestedTracks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { KeyboardEvent, MouseEvent, useCallback, useMemo } from 'react'
 
 import {
   SUGGESTED_TRACK_COUNT,
@@ -79,21 +79,41 @@ const SuggestedTrackRow = (props: SuggestedTrackProps) => {
     onAddTrack(track_id)
   }, [onAddTrack, track_id])
 
+  const handleRowKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        togglePlay()
+      }
+    },
+    [togglePlay]
+  )
+
+  const handleAddClick = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation()
+      handleAddTrack()
+    },
+    [handleAddTrack]
+  )
+
   return (
-    <div className={styles.suggestedTrack}>
+    <div
+      className={styles.suggestedTrack}
+      role='button'
+      tabIndex={0}
+      aria-label={isTrackPlaying ? `Pause ${title}` : `Play ${title}`}
+      onClick={togglePlay}
+      onKeyDown={handleRowKeyDown}
+    >
       <div className={styles.trackDetails}>
-        <button
-          type='button'
-          className={styles.artworkButton}
-          onClick={togglePlay}
-          onMouseDown={(e) => e.preventDefault()}
-          aria-label={isTrackPlaying ? `Pause ${title}` : `Play ${title}`}
-        >
+        <div className={styles.artworkWrapper}>
           <Image className={styles.trackArtwork} src={image} />
           <span
             className={cn(styles.playOverlay, {
               [styles.isPlaying]: isTrackPlaying
             })}
+            aria-hidden='true'
           >
             {isTrackPlaying ? (
               <IconPause size='s' color='staticWhite' />
@@ -101,16 +121,23 @@ const SuggestedTrackRow = (props: SuggestedTrackProps) => {
               <IconPlay size='s' color='staticWhite' />
             )}
           </span>
-        </button>
+        </div>
         <div className={styles.trackInfo}>
           <p className={styles.trackName}>{title}</p>
-          {user ? <UserLink userId={user.user_id} size='s' /> : null}
+          {user ? (
+            <span
+              className={styles.userLinkWrapper}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <UserLink userId={user.user_id} size='s' />
+            </span>
+          ) : null}
         </div>
       </div>
       <Button
         variant='secondary'
         size='small'
-        onClick={handleAddTrack}
+        onClick={handleAddClick}
         onMouseDown={(e) => e.preventDefault()}
         disabled={trackIsInCollection}
       >


### PR DESCRIPTION
## Summary

Make the "Add some tracks" panel rows visibly playable:

- **Full-row hover**: row gets a neutral hover background and pointer cursor.
- **Play overlay on artwork**: now fades in on row hover *and* row focus-visible, not just artwork hover. Persistent when the track is playing.
- **Full-row click target**: clicking anywhere on the row (except the Add button or the artist link) toggles playback via the existing `useToggleTrack`. Keyboard activation with Enter/Space works because the row is `role='button' tabIndex={0}`.
- **Add button** stops propagation so it only adds, never plays.
- **Artist UserLink** stops propagation so navigating to the profile doesn't also start playback.
- Skeleton row stays inert (default cursor, no hover bg).

Before: only the 40×40 artwork was clickable; nothing told the user the row was playable. After: hovering anywhere on the row dims the artwork and surfaces the play/pause icon, and clicking anywhere starts playback.

## Test plan

- [ ] Open a playlist edit page → expand **Add some tracks** panel.
- [ ] Hover a row → row background tints (`harmony-n-50`), play icon appears centered on the artwork. Hover again with playback active → pause icon shown.
- [ ] Click the row body (not Add, not artist name) → track starts playing.
- [ ] Click the same row again while playing → pauses.
- [ ] Click the **Add** button → track added; playback does NOT start, panel does NOT scroll.
- [ ] Click the artist name → navigates to the profile; playback does NOT start.
- [ ] Tab through panel with keyboard → row gets a focus-visible outline, Enter/Space toggles play.
- [ ] Verify skeletons (before tracks load) show no hover state and use a default cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)