### PR TITLE
feat(genres): custom genres on mobile + relax common form/type gaps

### DIFF
--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -1,4 +1,4 @@
-import { Genre, Mood, NativeFile, MAX_DESCRIPTION_LENGTH } from '@audius/sdk'
+import { Mood, NativeFile, MAX_DESCRIPTION_LENGTH } from '@audius/sdk'
 import { z } from 'zod'
 
 import { imageBlank } from '~/assets'
@@ -54,11 +54,16 @@ const USDCPurchaseConditionsSchema = z
   })
   .strict()
 
-/** Same as SDK. */
+/**
+ * Same as SDK: arbitrary string up to 100 chars. The Genre enum is reserved
+ * for autocomplete suggestions; users may submit any value.
+ */
 const GenreSchema = z
-  .enum(Object.values(Genre) as [Genre, ...Genre[]])
+  .string()
+  .min(1, { message: messages.genreRequiredError })
+  .max(100)
   .nullable()
-  .refine((val) => val !== null, {
+  .refine((val) => val !== null && val.length > 0, {
     message: messages.genreRequiredError
   })
 

--- a/packages/common/src/utils/genres.ts
+++ b/packages/common/src/utils/genres.ts
@@ -4,6 +4,15 @@ import { Genre as SDKGenre } from '@audius/sdk'
 export { Genre } from '@audius/sdk'
 
 /**
+ * Track genre value. Any string up to 100 chars is accepted at the API/SDK
+ * layer; the {@link Genre} enum provides the canonical autocomplete values.
+ * Use this type for read-side / metadata typings so custom-genre tracks
+ * flow through without TS errors. Continue using `Genre` for write-side
+ * autocomplete sources and static lists where only known values are valid.
+ */
+export type { GenreString } from '@audius/sdk'
+
+/**
  * UI-only value for "all genres" filter (e.g. trending page).
  * Not part of SDK Genre - use for filter state only.
  */

--- a/packages/mobile/examples/upload/App.tsx
+++ b/packages/mobile/examples/upload/App.tsx
@@ -22,18 +22,10 @@ import {
 import { config } from './src/config'
 import { getSDK } from './src/sdk'
 
-const GENRES = [
-  'Electronic',
-  'Rock',
-  'Hip-Hop/Rap',
-  'Pop',
-  'R&B/Soul',
-  'Alternative',
-  'Country',
-  'Jazz',
-  'Folk',
-  'Classical'
-] as const
+// Genre is a freeform string up to 100 chars at the API/SDK layer. See
+// `Genre` from @audius/sdk for the canonical autocomplete suggestions if
+// you want to show a picker; this example uses a plain text input.
+const MAX_GENRE_LENGTH = 100
 
 type Screen = 'home' | 'signed-in'
 
@@ -46,7 +38,7 @@ export default function App() {
     useState<DocumentPicker.DocumentPickerAsset | null>(null)
   const [coverUri, setCoverUri] = useState<string | null>(null)
   const [title, setTitle] = useState('')
-  const [genre, setGenre] = useState<(typeof GENRES)[number]>('Electronic')
+  const [genre, setGenre] = useState<string>('')
   const [description, setDescription] = useState('')
   const [uploading, setUploading] = useState(false)
   const [result, setResult] = useState<string | null>(null)
@@ -131,7 +123,7 @@ export default function App() {
     setAudioFile(null)
     setCoverUri(null)
     setTitle('')
-    setGenre('Electronic')
+    setGenre('')
     setDescription('')
     setResult(null)
     setScreen('home')
@@ -302,31 +294,16 @@ export default function App() {
           />
 
           <Text style={styles.label}>Genre</Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            style={styles.genreScroll}
-          >
-            {GENRES.map((g) => (
-              <TouchableOpacity
-                key={g}
-                style={[
-                  styles.genreChip,
-                  genre === g && styles.genreChipActive
-                ]}
-                onPress={() => setGenre(g)}
-              >
-                <Text
-                  style={[
-                    styles.genreChipText,
-                    genre === g && styles.genreChipTextActive
-                  ]}
-                >
-                  {g}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </ScrollView>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g. Electronic, Phonk, Lo-Fi…"
+            placeholderTextColor="#888"
+            value={genre}
+            onChangeText={setGenre}
+            maxLength={MAX_GENRE_LENGTH}
+            autoCapitalize="words"
+            autoCorrect={false}
+          />
 
           <TextInput
             style={[styles.input, styles.textArea]}
@@ -452,17 +429,6 @@ const styles = StyleSheet.create({
   },
   textArea: { minHeight: 80, textAlignVertical: 'top' },
   label: { fontSize: 14, fontWeight: '500', marginBottom: 8, color: '#333' },
-  genreScroll: { marginBottom: 16, maxHeight: 44 },
-  genreChip: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 20,
-    backgroundColor: '#f0f0f0',
-    marginRight: 8
-  },
-  genreChipActive: { backgroundColor: '#CC0FE0' },
-  genreChipText: { fontSize: 14, color: '#333' },
-  genreChipTextActive: { color: '#fff', fontWeight: '600' },
   result: { marginTop: 16, fontSize: 13, color: '#555', lineHeight: 20 },
   debugTitle: { marginTop: 16, fontSize: 13, fontWeight: '600', color: '#333' },
   debugSession: {

--- a/packages/mobile/src/screens/edit-track-screen/screens/SelectGenreScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/SelectGenreScreen.tsx
@@ -1,26 +1,69 @@
+import { useMemo, useState } from 'react'
+
 import { GENRES, convertGenreLabelToValue } from '@audius/common/utils'
 import { useField } from 'formik'
 
+import { Flex } from '@audius/harmony-native'
 import IconGenre from 'app/assets/images/iconGenre.svg'
-import { Text } from 'app/components/core'
+import { Text, TextInput } from 'app/components/core'
 import { ListSelectionScreen } from 'app/screens/list-selection-screen'
+import { makeStyles } from 'app/styles'
+
+const MAX_GENRE_LENGTH = 100
 
 const messages = {
   screenTitle: 'Select Genre',
-  searchText: 'Select Genres'
+  searchPlaceholder: 'Search or enter a custom genre',
+  useCustom: (value: string) => `Use "${value}" as a custom genre`
 }
 
-const genres = GENRES.map((genre) => ({
+const knownGenres = GENRES.map((genre) => ({
   value: convertGenreLabelToValue(genre),
   label: genre
 }))
 
+const useStyles = makeStyles(({ spacing, typography }) => ({
+  searchInput: {
+    paddingVertical: spacing(3),
+    fontSize: typography.fontSize.large
+  }
+}))
+
 export const SelectGenreScreen = () => {
-  const [{ value }, , { setValue }] = useField('genre')
+  const [{ value }, , { setValue }] = useField<string>('genre')
+  const [input, setInput] = useState('')
+  const styles = useStyles()
+
+  const trimmed = input.trim()
+  const lower = trimmed.toLowerCase()
+
+  const filtered = useMemo(() => {
+    if (trimmed === '') return knownGenres
+    return knownGenres.filter(
+      (g) =>
+        g.label.toLowerCase().includes(lower) ||
+        g.value.toLowerCase().includes(lower)
+    )
+  }, [trimmed, lower])
+
+  const data = useMemo(() => {
+    if (trimmed === '') return knownGenres
+    const matchesKnownExactly = knownGenres.some(
+      (g) =>
+        g.label.toLowerCase() === lower || g.value.toLowerCase() === lower
+    )
+    if (matchesKnownExactly || trimmed.length > MAX_GENRE_LENGTH) {
+      return filtered
+    }
+    return [
+      { value: trimmed, label: messages.useCustom(trimmed) },
+      ...filtered
+    ]
+  }, [trimmed, lower, filtered])
 
   return (
     <ListSelectionScreen
-      data={genres}
+      data={data}
       renderItem={({ item }) => (
         <Text fontSize='large' weight='demiBold'>
           {item.label}
@@ -28,7 +71,21 @@ export const SelectGenreScreen = () => {
       )}
       screenTitle={messages.screenTitle}
       icon={IconGenre}
-      searchText={messages.searchText}
+      disableSearch
+      header={
+        <Flex>
+          <TextInput
+            value={input}
+            onChangeText={setInput}
+            placeholder={messages.searchPlaceholder}
+            maxLength={MAX_GENRE_LENGTH}
+            styles={{ input: styles.searchInput }}
+            returnKeyType='search'
+            autoCapitalize='words'
+            autoCorrect={false}
+          />
+        </Flex>
+      }
       value={value}
       onChange={setValue}
     />


### PR DESCRIPTION
Follow-up to #14424. The first genres PR shipped custom-genre support on the SDK and web edit form, but the audit afterward found three gaps that block the same UX on mobile and silently re-tighten the rule in common's form schema.

## Summary

### 1. Mobile track upload/edit picker (Tier 1 #1)
`packages/mobile/src/screens/edit-track-screen/screens/SelectGenreScreen.tsx` was a strict `ListSelectionScreen` populated from `GENRES` — users on mobile had no way to enter a custom genre. Rewritten to:
- Disable `ListSelectionScreen`'s internal search and pass a controlled `TextInput` in the `header` prop instead.
- Compute the suggestion list from the typed input: filter `GENRES` by substring match, and when the input is non-empty and doesn't match any known label/value exactly, prepend a synthetic `{ value: <input>, label: 'Use "<input>" as a custom genre' }` item at the top.
- Tap any item — known or custom — commits via the existing `onChange`/`setValue` flow.
- `maxLength={100}` caps to match the SDK/API limit.

### 2. Form schema + GenreString re-export (Tier 1 #2)
- `packages/common/src/schemas/upload/uploadFormSchema.ts:58` was still `z.enum(Object.values(Genre))` despite the SDK schema relaxing in #14424. The web `SelectGenreField` lets users type "Phonk", but this form-level validator would reject it before the submit handler ever called the SDK. Changed to `z.string().min(1).max(100)`.
- `packages/common/src/utils/genres.ts` now re-exports `GenreString` from `@audius/sdk` so downstream consumers can opt into the loose type for read-side / metadata paths.

I audited all 12 files flagged in the post-merge audit. The state/filter typings (`Search.ts`, `trending/types.ts`, `trending/actions.ts`, `lineups/useTrending.ts`, `search/useSearchResults.ts`, `quickSearch.ts`, `Analytics.ts`) are deliberately left as strict `Genre` — those represent user selections from the canonical filter UI, not received track data. Two files (`hooks/useTrackMetadata.ts` and `store/upload/types.ts`) already handled string values fine.

### 3. Mobile upload example (Tier 1 #3)
`packages/mobile/examples/upload/App.tsx` had its own inline hardcoded `GENRES` chip list. Dropped the array, replaced the horizontal chip ScrollView with a freeform `TextInput` (placeholder hints common genres). Reference example for SDK consumers no longer implies "genres must be from this list."

## Verification

- [x] `tsc --noEmit` in `packages/common` — clean
- [x] `tsc --noEmit` in `packages/web` — clean
- [x] `tsc --noEmit` in `packages/mobile` — clean
- [ ] Mobile manual test: open the edit-track flow, navigate to Select Genre, type "Phonk", tap the "Use 'Phonk'…" row, confirm the form reflects "Phonk" and the upload succeeds end-to-end.
- [ ] Mobile manual test: type a known prefix like "Tech" — confirm "Techno" and "Tech House" suggestions appear and tap committing them still works.
- [ ] Web regression: confirm the custom-genre flow shipped in #14424 still works (no functional change there; only the form schema was loosened, which could only ever accept *more* inputs).

## Still deferred (Tier 2/3 from the audit)

- Search and trending genre filters on web (`SearchFilters.tsx`, `TrendingPageContent.tsx`, `TrendingGenreSelectionPage.tsx`) and mobile (`SearchFilters.tsx`, `TrendingFilter*.tsx`) — still scoped to the canonical list. Even if loosened, the Python read-side aggregations (`index_trending.py`, `get_genre_metrics.py`) still `WHERE genre IN genre_allowlist`, so no data would back custom-genre filters until that's also addressed.
- Write-side normalization ("Hip-Hop" vs "Hip Hop" vs "hip hop" still become distinct genres).
- Mobile signup-flow `SelectGenresScreen` — preference picker, intentionally stays canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)