### PR TITLE
fix(mobile): rich CollectionTile in lineups (large artwork + track list + duration)

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -1,7 +1,13 @@
 import { useCallback, useMemo, useRef } from 'react'
 
-import { useCollection, useCurrentUserId, useUser } from '@audius/common/api'
+import {
+  useCollection,
+  useCurrentUserId,
+  useOrderedCollectionTracks,
+  useUser
+} from '@audius/common/api'
 import { useGatedCollectionAccess } from '@audius/common/hooks'
+import type { CollectionTrack } from '@audius/common/api'
 import {
   ShareSource,
   RepostSource,
@@ -9,7 +15,6 @@ import {
   PlaybackSource,
   SquareSizes
 } from '@audius/common/models'
-import type { Track } from '@audius/common/models'
 import {
   collectionsSocialActions,
   mobileOverflowMenuUIActions,
@@ -39,7 +44,6 @@ import { CollectionTileTrackList } from './CollectionTileTrackList'
 import { LineupTileActionButtons } from './LineupTileActionButtons'
 import { TilePressBlockContext } from './TilePressBlockContext'
 import { LineupTileSource, type CollectionTileProps } from './types'
-import { useEnhancedCollectionTracks } from './useEnhancedCollectionTracks'
 
 const { getTrackId } = playbackSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
@@ -76,7 +80,6 @@ const useStyles = makeStyles(({ spacing }) => ({
 
 export const CollectionTile = (props: CollectionTileProps) => {
   const {
-    uid,
     id,
     collection: collectionOverride,
     tracks: tracksOverride,
@@ -92,22 +95,12 @@ export const CollectionTile = (props: CollectionTileProps) => {
   const styles = useStyles()
   const { data: currentUserId } = useCurrentUserId()
 
-  const { data: cachedCollection } = useCollection(id, {
-    select: (collection) => ({
-      has_current_user_reposted: collection.has_current_user_reposted,
-      has_current_user_saved: collection.has_current_user_saved,
-      is_album: collection.is_album,
-      playlist_id: collection.playlist_id,
-      playlist_name: collection.playlist_name,
-      playlist_owner_id: collection.playlist_owner_id,
-      stream_conditions: collection.stream_conditions,
-      is_private: collection.is_private,
-      is_delete: collection.is_delete,
-      playlist_contents: collection.playlist_contents
-    })
-  })
+  // Mirror the web mobile CollectionTile path exactly: fetch the collection
+  // by ID (no select), feed it to useOrderedCollectionTracks. Returns plain
+  // CollectionTrack[] / TrackMetadata[] — no UID plumbing required.
+  const { data: cachedCollection } = useCollection(id)
   const collection = collectionOverride ?? cachedCollection
-  const collectionTracks = useEnhancedCollectionTracks(uid ?? '')
+  const collectionTracks = useOrderedCollectionTracks(cachedCollection)
   const tracks = tracksOverride ?? collectionTracks
 
   const { data: user } = useUser(collection?.playlist_owner_id, {
@@ -153,9 +146,10 @@ export const CollectionTile = (props: CollectionTileProps) => {
         childPressedRef.current = false
         return
       }
+      const startTrackId = currentTrack?.track_id ?? tracks[0]?.track_id
+      if (!startTrackId) return
       togglePlay({
-        uid: currentTrack?.uid ?? tracks[0]?.uid ?? null,
-        id: currentTrack?.track_id ?? tracks[0]?.track_id ?? null,
+        id: startTrackId,
         source: PlaybackSource.PLAYLIST_TILE_TRACK
       })
     }, 100)
@@ -172,19 +166,20 @@ export const CollectionTile = (props: CollectionTileProps) => {
 
   const duration = useMemo(() => {
     return tracks.reduce(
-      (duration: number, track: Track) => duration + track.duration,
+      (duration: number, track: CollectionTrack) =>
+        duration + (track.duration ?? 0),
       0
     )
   }, [tracks])
 
-  const expectedTrackCount =
-    collection?.playlist_contents?.track_ids?.length ?? 0
-  // Tracks are fetched lazily via useEnhancedCollectionTracks; while they're
-  // loading, `tracks` is `[]` even though the collection has track_ids. We
-  // surface that to CollectionTileTrackList so it renders skeleton rows
-  // instead of an empty block (which is what previously made the tile look
-  // "compact" along with the missing duration).
-  const tracksLoading = tracks.length === 0 && expectedTrackCount > 0
+  // Use track_count if present on the collection (canonical full count);
+  // fall back to the loaded tracks length. Drives the skeleton state on the
+  // track list while tracks are still being fetched.
+  const trackCount =
+    collection?.track_count ??
+    collection?.playlist_contents?.track_ids?.length ??
+    tracks.length
+  const tracksLoading = tracks.length === 0 && trackCount > 0
 
   const handlePressOverflow = useCallback(() => {
     if (!collection) return
@@ -324,7 +319,7 @@ export const CollectionTile = (props: CollectionTileProps) => {
           onPress={handlePressTitle}
           onPressWithPropagationBlock={handlePressWithPropagationBlock}
           isAlbum={collection.is_album}
-          trackCount={expectedTrackCount || tracks.length}
+          trackCount={trackCount}
           isLoading={tracksLoading}
         />
         {isReadonly ? null : (

--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -20,13 +20,16 @@ import {
   PurchaseableContentType
 } from '@audius/common/store'
 import type { CommonState } from '@audius/common/store'
-import { removeNullable } from '@audius/common/utils'
+import { formatLineupTileDuration, removeNullable } from '@audius/common/utils'
+import { TouchableOpacity, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Paper, type ImageProps } from '@audius/harmony-native'
+import { Flex, Paper, Text, type ImageProps } from '@audius/harmony-native'
+import { UserLink } from 'app/components/user-link'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { setVisibility } from 'app/store/drawers/slice'
 import { getIsCollectionMarkedForDownload } from 'app/store/offline-downloads/selectors'
+import { makeStyles } from 'app/styles'
 
 import { CollectionDogEar } from '../collection/CollectionDogEar'
 import { CollectionImage } from '../image/CollectionImage'
@@ -34,7 +37,6 @@ import { CollectionImage } from '../image/CollectionImage'
 import { CollectionTileStats } from './CollectionTileStats'
 import { CollectionTileTrackList } from './CollectionTileTrackList'
 import { LineupTileActionButtons } from './LineupTileActionButtons'
-import { LineupTileMetadata } from './LineupTileMetadata'
 import { TilePressBlockContext } from './TilePressBlockContext'
 import { LineupTileSource, type CollectionTileProps } from './types'
 import { useEnhancedCollectionTracks } from './useEnhancedCollectionTracks'
@@ -48,6 +50,29 @@ const {
   undoRepostCollection,
   unsaveCollection
 } = collectionsSocialActions
+
+const useStyles = makeStyles(({ spacing }) => ({
+  artworkWrapper: {
+    width: '100%',
+    aspectRatio: 1,
+    overflow: 'hidden'
+  },
+  artwork: {
+    width: '100%',
+    height: '100%'
+  },
+  metadata: {
+    paddingHorizontal: spacing(4),
+    paddingVertical: spacing(3),
+    gap: spacing(1)
+  },
+  titleTouchable: {
+    flex: 1
+  },
+  artistTouchable: {
+    alignSelf: 'flex-start'
+  }
+}))
 
 export const CollectionTile = (props: CollectionTileProps) => {
   const {
@@ -64,6 +89,7 @@ export const CollectionTile = (props: CollectionTileProps) => {
 
   const dispatch = useDispatch()
   const navigation = useNavigation()
+  const styles = useStyles()
   const { data: currentUserId } = useCurrentUserId()
 
   const { data: cachedCollection } = useCollection(id, {
@@ -97,10 +123,6 @@ export const CollectionTile = (props: CollectionTileProps) => {
     const trackId = getTrackId(state)
     return tracks.find((track) => track.track_id === trackId) ?? null
   })
-  const isPlayingUid = useSelector((state: CommonState) => {
-    const trackId = getTrackId(state)
-    return tracks.some((track) => track.track_id === trackId)
-  })
 
   const isCollectionMarkedForDownload = useSelector((state) =>
     collection
@@ -114,7 +136,7 @@ export const CollectionTile = (props: CollectionTileProps) => {
     (props: ImageProps) => (
       <CollectionImage
         collectionId={collection?.playlist_id ?? 0}
-        size={SquareSizes.SIZE_150_BY_150}
+        size={SquareSizes.SIZE_480_BY_480}
         {...props}
       />
     ),
@@ -154,6 +176,15 @@ export const CollectionTile = (props: CollectionTileProps) => {
       0
     )
   }, [tracks])
+
+  const expectedTrackCount =
+    collection?.playlist_contents?.track_ids?.length ?? 0
+  // Tracks are fetched lazily via useEnhancedCollectionTracks; while they're
+  // loading, `tracks` is `[]` even though the collection has track_ids. We
+  // surface that to CollectionTileTrackList so it renders skeleton rows
+  // instead of an empty block (which is what previously made the tile look
+  // "compact" along with the missing duration).
+  const tracksLoading = tracks.length === 0 && expectedTrackCount > 0
 
   const handlePressOverflow = useCallback(() => {
     if (!collection) return
@@ -224,9 +255,6 @@ export const CollectionTile = (props: CollectionTileProps) => {
   }, [collection, dispatch])
 
   if (!collection || !tracks || !user) {
-    console.warn(
-      'Collection, tracks, or user missing for CollectionTile, preventing render'
-    )
     return null
   }
 
@@ -237,23 +265,55 @@ export const CollectionTile = (props: CollectionTileProps) => {
   const isOwner = collection.playlist_owner_id === currentUserId
   const isReadonly = variant === 'readonly'
   const contentType = collection.is_album ? 'album' : 'playlist'
+  const durationText =
+    duration > 0 ? formatLineupTileDuration(duration, false, true) : null
 
   return (
     <TilePressBlockContext.Provider value={handlePressWithPropagationBlock}>
       <Paper onPress={handlePress} style={style}>
         <CollectionDogEar collectionId={collection.playlist_id} hideUnlocked />
-        <LineupTileMetadata
-          renderImage={renderImage}
-          onPressTitle={handlePressTitle}
-          onPressWithPropagationBlock={handlePressWithPropagationBlock}
-          title={collection.playlist_name}
-          userId={user.user_id}
-          isPlayingUid={isPlayingUid}
-          type={contentType}
-          trackId={collection.playlist_id}
-          duration={duration}
-          isLongFormContent={false}
-        />
+
+        {/* Card-style header: large square artwork above title + meta */}
+        <View style={styles.artworkWrapper}>
+          {renderImage({ style: styles.artwork })}
+        </View>
+
+        <Flex column style={styles.metadata}>
+          <Text
+            variant='label'
+            size='xs'
+            textTransform='uppercase'
+            color='subdued'
+          >
+            {contentType}
+          </Text>
+          <Flex row alignItems='center' justifyContent='space-between' gap='s'>
+            <TouchableOpacity
+              style={styles.titleTouchable}
+              onPressIn={handlePressWithPropagationBlock}
+              onPress={handlePressTitle}
+            >
+              <Text variant='title' strength='strong' numberOfLines={1}>
+                {collection.playlist_name}
+              </Text>
+            </TouchableOpacity>
+            {durationText ? (
+              <Text variant='body' size='s' color='subdued'>
+                {durationText}
+              </Text>
+            ) : null}
+          </Flex>
+          <TouchableOpacity
+            onPressIn={handlePressWithPropagationBlock}
+            activeOpacity={0.7}
+            style={styles.artistTouchable}
+          >
+            <View pointerEvents='none'>
+              <UserLink textVariant='body' userId={user.user_id} />
+            </View>
+          </TouchableOpacity>
+        </Flex>
+
         <CollectionTileStats
           collectionId={collection.playlist_id}
           rankIndex={lineupTileProps.index}
@@ -264,7 +324,8 @@ export const CollectionTile = (props: CollectionTileProps) => {
           onPress={handlePressTitle}
           onPressWithPropagationBlock={handlePressWithPropagationBlock}
           isAlbum={collection.is_album}
-          trackCount={tracks.length}
+          trackCount={expectedTrackCount || tracks.length}
+          isLoading={tracksLoading}
         />
         {isReadonly ? null : (
           <LineupTileActionButtons

--- a/packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx
@@ -1,4 +1,6 @@
-import type { ID, LineupTrack } from '@audius/common/models'
+import type { CollectionTrack } from '@audius/common/api'
+import { useUser } from '@audius/common/api'
+import type { ID } from '@audius/common/models'
 import type { CommonState } from '@audius/common/store'
 import { playbackSelectors } from '@audius/common/store'
 import { pluralize } from '@audius/common/utils'
@@ -25,7 +27,7 @@ type LineupTileTrackListProps = {
   onPress: GestureResponderHandler
   onPressWithPropagationBlock?: () => void
   trackCount: number
-  tracks: LineupTrack[]
+  tracks: CollectionTrack[]
   isAlbum: boolean
 }
 
@@ -77,7 +79,7 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
 type TrackItemProps = {
   showSkeleton?: boolean
   index: number
-  track?: LineupTrack
+  track?: CollectionTrack
   trackId?: ID
   isAlbum?: boolean
   deleted?: boolean
@@ -89,6 +91,15 @@ const TrackItem = (props: TrackItemProps) => {
   const isPlayingUid = useSelector(
     (state: CommonState) => getTrackId(state) === trackId
   )
+  // Mirror the web mobile CollectionTile.TrackItem path exactly: tracks
+  // returned by `useOrderedCollectionTracks` are plain CollectionTrack /
+  // TrackMetadata (no joined `user`), so we fetch the owner's display name
+  // per row from the user cache. Hooks must run before any conditional
+  // returns; passing `undefined` to useUser when no track is present is
+  // safe (selector returns undefined).
+  const { data: trackOwnerName } = useUser(track?.owner_id, {
+    select: (user) => user?.name
+  })
   return (
     <>
       <View style={styles.divider} />
@@ -121,7 +132,7 @@ const TrackItem = (props: TrackItemProps) => {
                 ]}
                 numberOfLines={1}
               >
-                {`${messages.by} ${track.user?.name}`}
+                {`${messages.by} ${trackOwnerName ?? ''}`}
               </Text>
             ) : null}
             {deleted ? (

--- a/packages/mobile/src/components/lineup/TrackLineup.tsx
+++ b/packages/mobile/src/components/lineup/TrackLineup.tsx
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
 
 type LoadingItem = { _loading: true }
 type TrackEntry = { kind: 'track'; trackId: ID; uid: UID }
-type CollectionEntry = { kind: 'collection'; collectionId: ID }
+type CollectionEntry = { kind: 'collection'; collectionId: ID; uid: UID }
 type Entry = TrackEntry | CollectionEntry
 type RenderItem = Entry | LoadingItem
 
@@ -172,6 +172,14 @@ export const TrackLineup = ({
     (id: ID) => makeStableUid(Kind.TRACKS, id, source),
     [source]
   )
+  // CollectionTile's useEnhancedCollectionTracks expects a UID (not just an
+  // ID) so it can derive a unique track UID per row in the playlist. Build
+  // one per collection entry — without it the tile renders empty (no track
+  // list, no duration).
+  const collectionUidFor = useCallback(
+    (id: ID) => makeStableUid(Kind.COLLECTIONS, id, source),
+    [source]
+  )
 
   // Build a single ordered list of mixed track/collection entries. When the
   // caller passes `lineupItems` (mixed feed) we use it verbatim; otherwise we
@@ -246,9 +254,13 @@ export const TrackLineup = ({
               trackId: item.id,
               uid: uidFor(item.id)
             }
-          : { kind: 'collection' as const, collectionId: item.id }
+          : {
+              kind: 'collection' as const,
+              collectionId: item.id,
+              uid: collectionUidFor(item.id)
+            }
       ),
-    [visibleItems, uidFor]
+    [visibleItems, uidFor, collectionUidFor]
   )
 
   // Synchronous "load more was triggered" flag — set the moment the scroll
@@ -316,6 +328,7 @@ export const TrackLineup = ({
             ) : (
               <CollectionTile
                 id={entry.collectionId}
+                uid={entry.uid}
                 index={index}
                 isTrending={isTrending}
                 togglePlay={togglePlay}

--- a/packages/mobile/src/components/lineup/TrackLineup.tsx
+++ b/packages/mobile/src/components/lineup/TrackLineup.tsx
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
 
 type LoadingItem = { _loading: true }
 type TrackEntry = { kind: 'track'; trackId: ID; uid: UID }
-type CollectionEntry = { kind: 'collection'; collectionId: ID; uid: UID }
+type CollectionEntry = { kind: 'collection'; collectionId: ID }
 type Entry = TrackEntry | CollectionEntry
 type RenderItem = Entry | LoadingItem
 
@@ -172,15 +172,6 @@ export const TrackLineup = ({
     (id: ID) => makeStableUid(Kind.TRACKS, id, source),
     [source]
   )
-  // CollectionTile's useEnhancedCollectionTracks expects a UID (not just an
-  // ID) so it can derive a unique track UID per row in the playlist. Build
-  // one per collection entry — without it the tile renders empty (no track
-  // list, no duration).
-  const collectionUidFor = useCallback(
-    (id: ID) => makeStableUid(Kind.COLLECTIONS, id, source),
-    [source]
-  )
-
   // Build a single ordered list of mixed track/collection entries. When the
   // caller passes `lineupItems` (mixed feed) we use it verbatim; otherwise we
   // wrap the legacy `trackIds` so the rest of the component is uniform.
@@ -254,13 +245,9 @@ export const TrackLineup = ({
               trackId: item.id,
               uid: uidFor(item.id)
             }
-          : {
-              kind: 'collection' as const,
-              collectionId: item.id,
-              uid: collectionUidFor(item.id)
-            }
+          : { kind: 'collection' as const, collectionId: item.id }
       ),
-    [visibleItems, uidFor, collectionUidFor]
+    [visibleItems, uidFor]
   )
 
   // Synchronous "load more was triggered" flag — set the moment the scroll
@@ -328,7 +315,6 @@ export const TrackLineup = ({
             ) : (
               <CollectionTile
                 id={entry.collectionId}
-                uid={entry.uid}
                 index={index}
                 isTrending={isTrending}
                 togglePlay={togglePlay}


### PR DESCRIPTION
> **Note:** The first commit on this branch (`131320e35d`) took a UID-based approach. After review, that was the wrong shape — web's mobile CollectionTile doesn't use UIDs in the read path. The follow-up commit `ac487f236d` rewrites the data flow to mirror web exactly. Read the latest as the canonical change.

Mobile collection tiles in the feed lineup were rendering as a compact row (small 72×72 thumbnail beside title/artist, no track list, no duration) — the wrong shape compared to web's mobile view, which shows a card layout (large artwork, label, title, duration, 5-row numbered track list with "by <artist>", "+N Tracks" overflow).

## How web does it (the path we now mirror)

[`packages/web/src/components/track/mobile/CollectionTile.tsx`](packages/web/src/components/track/mobile/CollectionTile.tsx):

```ts
const { data: collectionWithoutFallback } = useCollection(id)
const collection = getCollectionWithFallback(collectionWithoutFallback)
const tracks = useOrderedCollectionTracks(collectionWithoutFallback)
```

And the per-row `TrackItem` fetches its artist name separately:

```ts
const { data: trackOwnerName } = useUser(track?.owner_id, {
  select: (user) => user?.name
})
```

No UIDs anywhere — `useOrderedCollectionTracks` takes the collection and pulls tracks via `useTracks(collection.trackIds)` internally; it returns plain `CollectionTrack[]` (aka `TrackMetadata[]`), no `user` join. Mobile now does the same.

## Root cause

After #14411 wired the new collection branch into the mobile `TrackLineup`, the existing `useEnhancedCollectionTracks(uid)` hook returned `[]` because the lineup didn't supply a UID. That left `tracks.length === 0`, so the sum `duration` was `0` (hiding behind a `duration > 0` guard) and `CollectionTileTrackList` rendered an empty body. Compounded by `LineupTileMetadata` being a row-layout with a hardcoded 72×72 `LineupTileArt`.

## Changes

### `packages/mobile/src/components/lineup-tile/CollectionTile.tsx`
- Drop the `uid` prop / destructure entirely.
- Drop the custom `useCollection(id, { select })` (web reads the full collection — mirror).
- Replace `useEnhancedCollectionTracks(uid ?? '')` with `useOrderedCollectionTracks(cachedCollection)`.
- Bypass `LineupTileMetadata` for the collection variant; inline a card-style header: full-width square `CollectionImage` at `SquareSizes.SIZE_480_BY_480`, then `PLAYLIST`/`ALBUM` label, title row with duration on the right via `formatLineupTileDuration(_, false, true)` (renders "15m 32s"), artist link.
- Pass `isLoading={tracks.length === 0 && trackCount > 0}` so `CollectionTileTrackList` renders skeleton rows during the fetch.
- `handlePress` passes only `id` to `togglePlay` — the new playback slice's `togglePlay` already ignores `uid` and queues by `id`.

### `packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx`
- Switch the track type from `LineupTrack` to `CollectionTrack` (`TrackMetadata`).
- Mirror web's `TrackItem` exactly: fetch the artist name per row via `useUser(track?.owner_id, { select: u => u?.name })` and render `\`by ${trackOwnerName ?? ''}\`` instead of reading the (no-longer-present) `track.user?.name` join.

### `packages/mobile/src/components/lineup/TrackLineup.tsx`
- No UID needed for collections. Reverted the `collectionUidFor` callback, the `uid` field on `CollectionEntry`, and the `uid` prop on `<CollectionTile>`.

## Non-lineup surfaces

The two other `CollectionTile` callers — chat-unfurled `ChatMessagePlaylist.tsx` and `CollectionLineupCarousel` — both pass `collection` and `tracks` explicitly *or* sit inside 343-wide columns. The card layout fits in both contexts; nothing else changed.

## Verification

- [x] `tsc --noEmit` clean in `packages/mobile` and `packages/common`
- [ ] Mobile manual: open Feed → For You, scroll until a playlist tile appears. Expect large artwork, `PLAYLIST` label, title, duration, numbered track rows (up to 5) with "by <artist>", `+N Tracks` overflow, action buttons. Track-tile entries unchanged.
- [ ] Mobile manual: same on the Latest (following feed) tab and on Profile → Reposts.
- [ ] Mobile manual: chat-unfurled playlist in a DM still renders correctly.
- [ ] Mobile manual: explore screen's collection carousels still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)