### PR TITLE
Fix feed pagination offset for mixed items

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useFeed.ts
@@ -60,11 +60,7 @@ export const useFeed = (
       const isFirstPage = allPages.length === 1
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       if (lastPage.length < currentPageSize) return undefined
-      return allPages.reduce(
-        (total, page) =>
-          total + page.filter((d) => d.type === EntityType.TRACK).length,
-        0
-      )
+      return allPages.reduce((total, page) => total + page.length, 0)
     },
     queryKey,
     queryFn: async ({ pageParam }) => {


### PR DESCRIPTION
## Summary
- advance Latest feed pagination by the number of mixed feed items returned, not only tracks
- align the client offset with the API contract for /v1/users/{id}/feed, which applies OFFSET over tracks + collections
- prevents overlapping/repeated pages when collections are present in the feed

## Context
Past commits introduced mixed feed rendering and then changed Latest feed pagination to count only track entries. That makes the client request page 2 with an offset that is too small whenever page 1 includes collections. Example: 6 tracks + 4 collections with limit 10 requests offset 6 instead of 10, so the next API page overlaps already-rendered items and can make pagination feel stuck.

The API history also shows separate server-side feed perf fixes (#798 for Latest feed planner cliffs, #805/#806/#817 for For You timeouts). This PR addresses the current client-side mixed-item offset mismatch.

## Testing
- git diff --check

Could not run TypeScript locally because this worktree has no node_modules and the shell has node but no npm/npx installed.