### PR TITLE
fix(mobile): match feed CollectionTile cover size + title weight to TrackTile

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -6,8 +6,8 @@ import {
   useOrderedCollectionTracks,
   useUser
 } from '@audius/common/api'
-import { useGatedCollectionAccess } from '@audius/common/hooks'
 import type { CollectionTrack } from '@audius/common/api'
+import { useGatedCollectionAccess } from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -25,16 +25,13 @@ import {
   PurchaseableContentType
 } from '@audius/common/store'
 import type { CommonState } from '@audius/common/store'
-import { formatLineupTileDuration, removeNullable } from '@audius/common/utils'
-import { TouchableOpacity, View } from 'react-native'
+import { removeNullable } from '@audius/common/utils'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Flex, Paper, Text, type ImageProps } from '@audius/harmony-native'
-import { UserLink } from 'app/components/user-link'
+import { Paper, type ImageProps } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { setVisibility } from 'app/store/drawers/slice'
 import { getIsCollectionMarkedForDownload } from 'app/store/offline-downloads/selectors'
-import { makeStyles } from 'app/styles'
 
 import { CollectionDogEar } from '../collection/CollectionDogEar'
 import { CollectionImage } from '../image/CollectionImage'
@@ -42,6 +39,7 @@ import { CollectionImage } from '../image/CollectionImage'
 import { CollectionTileStats } from './CollectionTileStats'
 import { CollectionTileTrackList } from './CollectionTileTrackList'
 import { LineupTileActionButtons } from './LineupTileActionButtons'
+import { LineupTileMetadata } from './LineupTileMetadata'
 import { TilePressBlockContext } from './TilePressBlockContext'
 import { LineupTileSource, type CollectionTileProps } from './types'
 
@@ -54,29 +52,6 @@ const {
   undoRepostCollection,
   unsaveCollection
 } = collectionsSocialActions
-
-const useStyles = makeStyles(({ spacing }) => ({
-  artworkWrapper: {
-    width: '100%',
-    aspectRatio: 1,
-    overflow: 'hidden'
-  },
-  artwork: {
-    width: '100%',
-    height: '100%'
-  },
-  metadata: {
-    paddingHorizontal: spacing(4),
-    paddingVertical: spacing(3),
-    gap: spacing(1)
-  },
-  titleTouchable: {
-    flex: 1
-  },
-  artistTouchable: {
-    alignSelf: 'flex-start'
-  }
-}))
 
 export const CollectionTile = (props: CollectionTileProps) => {
   const {
@@ -92,7 +67,6 @@ export const CollectionTile = (props: CollectionTileProps) => {
 
   const dispatch = useDispatch()
   const navigation = useNavigation()
-  const styles = useStyles()
   const { data: currentUserId } = useCurrentUserId()
 
   // Mirror the web mobile CollectionTile path exactly: fetch the collection
@@ -116,6 +90,10 @@ export const CollectionTile = (props: CollectionTileProps) => {
     const trackId = getTrackId(state)
     return tracks.find((track) => track.track_id === trackId) ?? null
   })
+  const isPlayingUid = useSelector((state: CommonState) => {
+    const trackId = getTrackId(state)
+    return tracks.some((track) => track.track_id === trackId)
+  })
 
   const isCollectionMarkedForDownload = useSelector((state) =>
     collection
@@ -129,7 +107,7 @@ export const CollectionTile = (props: CollectionTileProps) => {
     (props: ImageProps) => (
       <CollectionImage
         collectionId={collection?.playlist_id ?? 0}
-        size={SquareSizes.SIZE_480_BY_480}
+        size={SquareSizes.SIZE_150_BY_150}
         {...props}
       />
     ),
@@ -260,55 +238,23 @@ export const CollectionTile = (props: CollectionTileProps) => {
   const isOwner = collection.playlist_owner_id === currentUserId
   const isReadonly = variant === 'readonly'
   const contentType = collection.is_album ? 'album' : 'playlist'
-  const durationText =
-    duration > 0 ? formatLineupTileDuration(duration, false, true) : null
 
   return (
     <TilePressBlockContext.Provider value={handlePressWithPropagationBlock}>
       <Paper onPress={handlePress} style={style}>
         <CollectionDogEar collectionId={collection.playlist_id} hideUnlocked />
-
-        {/* Card-style header: large square artwork above title + meta */}
-        <View style={styles.artworkWrapper}>
-          {renderImage({ style: styles.artwork })}
-        </View>
-
-        <Flex column style={styles.metadata}>
-          <Text
-            variant='label'
-            size='xs'
-            textTransform='uppercase'
-            color='subdued'
-          >
-            {contentType}
-          </Text>
-          <Flex row alignItems='center' justifyContent='space-between' gap='s'>
-            <TouchableOpacity
-              style={styles.titleTouchable}
-              onPressIn={handlePressWithPropagationBlock}
-              onPress={handlePressTitle}
-            >
-              <Text variant='title' strength='strong' numberOfLines={1}>
-                {collection.playlist_name}
-              </Text>
-            </TouchableOpacity>
-            {durationText ? (
-              <Text variant='body' size='s' color='subdued'>
-                {durationText}
-              </Text>
-            ) : null}
-          </Flex>
-          <TouchableOpacity
-            onPressIn={handlePressWithPropagationBlock}
-            activeOpacity={0.7}
-            style={styles.artistTouchable}
-          >
-            <View pointerEvents='none'>
-              <UserLink textVariant='body' userId={user.user_id} />
-            </View>
-          </TouchableOpacity>
-        </Flex>
-
+        <LineupTileMetadata
+          renderImage={renderImage}
+          onPressTitle={handlePressTitle}
+          onPressWithPropagationBlock={handlePressWithPropagationBlock}
+          title={collection.playlist_name}
+          userId={user.user_id}
+          isPlayingUid={isPlayingUid}
+          type={contentType}
+          trackId={collection.playlist_id}
+          duration={duration}
+          isLongFormContent={false}
+        />
         <CollectionTileStats
           collectionId={collection.playlist_id}
           rankIndex={lineupTileProps.index}


### PR DESCRIPTION
## Bug

Ray reported:

> playlists render weirdly in mobile feeds. images are too big. we used to have a playlist tile that had the same sized image as the track tile. also the font is wrong it should match the same weight as the track tile too

Screenshot showed mobile Your Feed (For You / Latest) with a playlist (\"Liquid Galaxy Album\" by Zonii) where the cover art filled nearly the whole screen and the title font weight read lighter than the surrounding track-tile titles.

## Root cause

#14428 (commit `17a4971337`) replaced the feed CollectionTile's standard \`LineupTileMetadata\` header (the same one TrackTile uses) with an inline \"card-style\" header that rendered a full-width / \`aspectRatio: 1\` cover image above the metadata, and used \`Text variant='title' strength='strong'\` for the title.

## Fix

Restore \`LineupTileMetadata\` for the feed CollectionTile header so cover art renders at \`{ width: 72, height: 72 }\` (from \`lineup-tile/styles.ts\` \`image\`) and the title renders as \`Text weight='bold'\` — both matching TrackTile exactly. The rest of the tile (label, stats, track list, action buttons) is unchanged.

Behavior before -> after:

- Cover image: \`width: 100%\` + \`aspectRatio: 1\` (Collection-only style) -> \`width: 72, height: 72\` (shared \`tileStyles.image\` rule used by TrackTile via \`LineupTileArt\`).
- Cover image source size requested: \`SquareSizes.SIZE_480_BY_480\` -> \`SquareSizes.SIZE_150_BY_150\` (right-sized for a 72px render; same as TrackTile).
- Title \`Text\`: \`variant='title' strength='strong'\` -> rendered via \`LineupTileMetadata\` as \`<Text weight='bold' numberOfLines={1}>\` (same call site TrackTile uses).

## Shared-component note

\`CollectionTile\` is also used outside the mobile feed (chat-screen \`ChatMessagePlaylist\`, \`CollectionLineupCarousel\` on explore, \`PlaylistsTab\` / \`AlbumsTab\` on profile and library, \`AddToCollectionDrawer\`, \`CollectionList\`). They all rendered with the same \`LineupTileMetadata\` header for years prior to #14428 and will go back to that shape with this change. The pre-#14428 rendering is what those surfaces displayed historically; this PR restores the pre-existing baseline rather than introducing a new shape on them.

## Suspected regression

#14428 / `17a4971337` (fix(mobile): rich CollectionTile in lineups (large artwork + track list + duration)).

## Test plan

- [ ] Lint: \`cd packages/mobile && npm run lint\` — could not run in this environment (worktree is missing transitive deps: \`@react-native/typescript-config\`, \`sqlite3\` fails to native-build under Python 3.13). Ran \`npx eslint --fix\` on the changed file; remaining reported errors are the same environment-level resolve errors that occur on the pre-change file.
- [ ] Typecheck: \`tsc --noEmit\` — same environment limitation as above (\`@react-native/typescript-config\` not present).
- [ ] No snapshot tests exist for \`CollectionTile\`.
- [ ] No unit tests reference \`CollectionTile\`.
- [ ] Did NOT verify in iOS / Android simulator — this environment cannot run them. Relied on code diff vs. the pre-#14428 (working) version of the same file, which used the identical \`LineupTileMetadata\` call shape now restored.
- [ ] Manual visual verification recommended: Feed (For You and Latest tabs) shows playlist tiles with 72x72 art + bold title matching adjacent track tiles, and non-feed surfaces (DM playlist, explore carousels, profile/library tabs) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)