### PR TITLE
fix(embed): clip playlist card overflow to viewport

### DIFF
--- a/packages/embed/src/components/app.jsx
+++ b/packages/embed/src/components/app.jsx
@@ -364,7 +364,10 @@ const App = (props) => {
             ref={playerContainerRef}
             style={{
               flex: 1,
-              width: isCard ? 'auto' : '100%',
+              width: '100%',
+              minWidth: 0,
+              minHeight: 0,
+              overflow: 'hidden',
               display: isCard ? 'flex' : 'block',
               justifyContent: isCard ? 'center' : undefined,
               alignItems: isCard ? 'center' : undefined

--- a/packages/embed/src/components/collection/CollectionPlayerCard.jsx
+++ b/packages/embed/src/components/collection/CollectionPlayerCard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-import { full } from '@audius/sdk'
+import { instanceOfPurchaseGate } from '@audius/sdk'
 import cn from 'classnames'
 import SimpleBar from 'simplebar-react'
 
@@ -20,8 +20,6 @@ import BedtimeScrubber from '../scrubber/BedtimeScrubber'
 import Titles from '../titles/Titles'
 
 import styles from './CollectionPlayerCard.module.css'
-
-const { instanceOfPurchaseGate } = full
 
 const CollectionListRow = ({
   playingState,

--- a/packages/embed/src/components/collection/CollectionPlayerContainer.jsx
+++ b/packages/embed/src/components/collection/CollectionPlayerContainer.jsx
@@ -1,6 +1,6 @@
 import { useState, useContext, useCallback, useEffect } from 'react'
 
-import { full } from '@audius/sdk'
+import { instanceOfPurchaseGate } from '@audius/sdk'
 
 import usePlayback from '../../hooks/usePlayback'
 import { useRecordListens } from '../../hooks/useRecordListens'
@@ -14,8 +14,6 @@ import { PlayingState } from '../playbutton/PlayButton'
 
 import CollectionHelmet from './CollectionHelmet'
 import CollectionPlayerCard from './CollectionPlayerCard'
-
-const { instanceOfPurchaseGate } = full
 
 const LISTEN_INTERVAL_SECONDS = 1
 

--- a/packages/embed/src/components/pausedpopover/ListenOnAudiusCTA.jsx
+++ b/packages/embed/src/components/pausedpopover/ListenOnAudiusCTA.jsx
@@ -1,10 +1,8 @@
 import { USDC } from '@audius/fixed-decimal'
 import { Button, Text } from '@audius/harmony'
-import { full } from '@audius/sdk'
+import { instanceOfPurchaseGate } from '@audius/sdk'
 
 import { getCopyableLink } from '../../util/shareUtil'
-
-const { instanceOfPurchaseGate } = full
 
 const messages = {
   listen: 'Listen on Audius',

--- a/packages/embed/src/components/pausedpopover/PrimaryLabel.jsx
+++ b/packages/embed/src/components/pausedpopover/PrimaryLabel.jsx
@@ -1,7 +1,5 @@
 import { Text } from '@audius/harmony'
-import { full } from '@audius/sdk'
-
-const { instanceOfPurchaseGate } = full
+import { instanceOfPurchaseGate } from '@audius/sdk'
 
 const messages = {
   more: 'Looking for more like this?',

--- a/packages/embed/src/components/track/TrackPlayerCard.jsx
+++ b/packages/embed/src/components/track/TrackPlayerCard.jsx
@@ -1,6 +1,6 @@
 import { useState, useContext, useEffect } from 'react'
 
-import { full } from '@audius/sdk'
+import { instanceOfPurchaseGate } from '@audius/sdk'
 
 import IconTrophy from '../../assets/img/iconTrophy.svg'
 import { isMobileWebTwitter } from '../../util/isMobileWebTwitter'
@@ -14,8 +14,6 @@ import BedtimeScrubber from '../scrubber/BedtimeScrubber'
 import Titles from '../titles/Titles'
 
 import styles from './TrackPlayerCard.module.css'
-
-const { instanceOfPurchaseGate } = full
 
 const TrackPlayerCard = ({
   title,

--- a/packages/embed/src/components/track/TrackPlayerCompact.jsx
+++ b/packages/embed/src/components/track/TrackPlayerCompact.jsx
@@ -1,4 +1,4 @@
-import { full } from '@audius/sdk'
+import { instanceOfPurchaseGate } from '@audius/sdk'
 
 import IconTrophy from '../../assets/img/iconTrophy.svg'
 import Artwork from '../artwork/Artwork'
@@ -11,8 +11,6 @@ import BedtimeScrubber from '../scrubber/BedtimeScrubber'
 import Titles from '../titles/Titles'
 
 import styles from './TrackPlayerCompact.module.css'
-
-const { instanceOfPurchaseGate } = full
 
 const TrackPlayerCompact = ({
   title,

--- a/packages/embed/src/components/track/TrackPlayerContainer.jsx
+++ b/packages/embed/src/components/track/TrackPlayerContainer.jsx
@@ -1,6 +1,6 @@
 import { useState, useContext, useCallback, useEffect, useMemo } from 'react'
 
-import { full } from '@audius/sdk'
+import { instanceOfPurchaseGate } from '@audius/sdk'
 
 import usePlayback from '../../hooks/usePlayback'
 import { useRecordListens } from '../../hooks/useRecordListens'
@@ -19,8 +19,6 @@ import TrackHelmet from './TrackHelmet'
 import TrackPlayerCard from './TrackPlayerCard'
 import TrackPlayerCompact from './TrackPlayerCompact'
 import TrackPlayerTiny from './TrackPlayerTiny'
-
-const { instanceOfPurchaseGate } = full
 
 const LISTEN_INTERVAL_SECONDS = 1
 

--- a/packages/embed/src/components/track/TrackPlayerTiny.jsx
+++ b/packages/embed/src/components/track/TrackPlayerTiny.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { full } from '@audius/sdk'
+import { instanceOfPurchaseGate } from '@audius/sdk'
 import cn from 'classnames'
 
 import AudiusLogoGlyph from '../../assets/img/audiusLogoGlyph.svg'
@@ -10,8 +10,6 @@ import { Preview } from '../preview/Preview'
 import BedtimeScrubber from '../scrubber/BedtimeScrubber'
 
 import styles from './TrackPlayerTiny.module.css'
-
-const { instanceOfPurchaseGate } = full
 
 const MARQUEE_SPACING = 40
 const SHOULD_ANIMATE_WIDTH_THRESHOLD = 15


### PR DESCRIPTION
Fixes [#14431](https://github.com/AudiusProject/apps/issues/14431)

## Summary

Playlist embeds were rendering off-screen — Card flavor looked like a stuck loading spinner and Compact flavor showed only the header. Albums hid the same bug because they typically have few tracks.

## What was wrong

The embed Card sizes itself from its parent's `clientHeight × 0.833` (aspect ratio). The wrapping `playerContainerRef` div was a `flex: 1, width: auto` flex item with no `min-*: 0`, so it grew to its content's natural height. For a 96-track playlist that's ~4760px, which made the Card ~3965×4760px — entirely off the visible 480×480 iframe.

Albums with ~10 tracks landed at a viable size (~566×680px) and looked roughly fine, masking the bug. The regression goes back to [#13496](https://github.com/AudiusProject/apps/pull/13496), which introduced the wrapping div as part of the react-router v7 upgrade.

## Fix

In [packages/embed/src/components/app.jsx:365-374](packages/embed/src/components/app.jsx#L365-L374), lock the player-container box to the iframe so the Card can't drag it open:

- `width: '100%'` — drop the `isCard ? 'auto'` branch that fed back into Card sizing
- `minWidth: 0, minHeight: 0` — let the flex item shrink below its content size
- `overflow: 'hidden'` — clip any Card content that still exceeds the viewport

This PR also fixes seven `import { full } from '@audius/sdk'` callsites whose `full` namespace was dropped by [#13730](https://github.com/AudiusProject/apps/pull/13730). Those imports left the embed unbuildable from current source — the prod bundle has been a stale pre-#13730 build for months. The default (non-full) endpoints return the same fields the embed reads, so they swap to the named `instanceOfPurchaseGate` export.

## Verification

With the SDK imports fixed, the embed dev server now builds. Verified against the local dev server at 480×480 viewport:

| Embed | Card dims | Notes |
|---|---|---|
| `/playlist/RNE1GmG?flavor=card` (96 tracks, the issue's repro) | 400×480 | Renders correctly with scrollable track list |
| `/album/54qOm4X?flavor=card` (11 tracks, regression check) | 400×480 | Renders correctly |
| `/track/KKK8bEr?flavor=card` (regression check) | 400×480 | Renders correctly |

Also cross-checked against live production (with the equivalent CSS injected via Playwright) — same results.

No automated tests added; embed has no layout test infrastructure.

## For the reviewer

- **Compact + collection** was always a structural mismatch — `CollectionPlayerCard` is the only collection player, so compact (120px tall) renders the same card layout, just clipped. This PR makes it visibly clipped instead of pushed off-screen, but designing a real compact collection view is out of scope.
- **Once this lands, the prod embed bundle should be rebuilt** — it's been running a stale pre-#13730 build since the `full` removal made source uncompilable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)