### PR TITLE
chore: drop python checks from preinstall script

### DIFF
--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -13,11 +13,9 @@ fi
 export NVM_DIR=$HOME/.nvm;
 source $NVM_DIR/nvm.sh;
 
-printf "${GREEN}Confirming node, python, and ruby environments...\n${NC}"
+printf "${GREEN}Confirming node and ruby environments...\n${NC}"
 {
   nvm install
-  cp .python-version-dev .python-version
-  pyenv install -s
   rbenv install -s
 } > /dev/null
 
@@ -34,14 +32,6 @@ current_ruby_version=$(ruby --version)
 
 if [[ ! $current_ruby_version =~ $required_ruby_version ]]; then
   printf "${RED}Invalid ruby version. Expected $required_ruby_version, got $current_ruby_version\n${NC}"
-  should_error=true
-fi
-
-required_python_version=$(<'.python-version')
-current_python_version=$(python --version)
-
-if [[ ! $current_python_version =~ $required_python_version ]]; then
-  printf "${RED}Invalid python version. Expected $required_python_version, got $current_python_version\n${NC}"
   should_error=true
 fi
 


### PR DESCRIPTION
## What

Removes the python tooling from `scripts/preinstall.sh`, which currently breaks `npm i`.

## Why

Python was removed from the repo, so `.python-version-dev` no longer exists. The preinstall script runs `cp .python-version-dev .python-version` under `set -e`, so the missing file aborts the whole script:

```
Confirming node, python, and ruby environments...
cp: .python-version-dev: No such file or directory
```

This blocks `npm i` for anyone on a fresh pull.

## Changes

- Drop `cp .python-version-dev .python-version` and `pyenv install -s` from the setup block.
- Drop the python version check.
- Update the status message to "Confirming node and ruby environments...".
- Node + ruby setup/validation are unchanged.

## Verification

```
$ bash ./scripts/preinstall.sh
Confirming node and ruby environments...
v24.10.0 is already installed.

Environment correctly set up!
$ echo $?
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)