### PR TITLE
chore: drop removed backend setup from postinstall script

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -63,14 +63,4 @@ else
   printf "${YELLOW}WARNING: SKIP_ANDROID_INSTALL set. Skipping Android AAR installation.${NC}\n"
 fi
 
-if [[ -z "${CI}" ]]; then
-  printf "${GREEN}Setting up audius-compose...\n${NC}"
-  ./dev-tools/setup.sh > /dev/null
-fi
-
-if [[ -z "${CI}" ]]; then
-  printf "${GREEN}Installing discovery provider dependencies...\n${NC}"
-  pip install -r packages/discovery-provider/requirements.txt > /dev/null
-fi
-
 printf "\n${GREEN}Audius monorepo ready!\n${NC}"


### PR DESCRIPTION
## What

Removes the two dead backend-setup steps from `scripts/postinstall.sh` that now break `npm i`.

## Why

The archived backend code removal in #14433 deleted `dev-tools/setup.sh` and `packages/discovery-provider/requirements.txt`, but `postinstall.sh` still invoked them:

```
./scripts/postinstall.sh: line 68: ./dev-tools/setup.sh: No such file or directory
```

Under `set -e`, the missing `dev-tools/setup.sh` aborts postinstall, so `npm i` fails. The `pip install -r packages/discovery-provider/requirements.txt` step immediately below references the same removed (now untracked) backend and is equally stale.

## Changes

- Remove the `Setting up audius-compose...` block (`./dev-tools/setup.sh`).
- Remove the `Installing discovery provider dependencies...` block (`pip install ... discovery-provider/requirements.txt`).
- Node/mobile (cocoapods, Android AAR) and patch steps are unchanged.

## Verification

```
$ bash -n scripts/postinstall.sh   # syntax OK
$ SKIP_POD_INSTALL=true bash scripts/postinstall.sh
...
Audius monorepo ready!
```

No more missing-file error; the script runs to completion.

## Note

Follow-up to the earlier preinstall cleanup (#14436). Both stem from the python/backend removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)