### PR TITLE
chore: drop stray uid from new playback-system queues

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -316,8 +316,7 @@ export const CollectionScreenDetailsTile = ({
         .map((uid) => Uid.fromString(uid).id as ID)
         .map((id) => ({
           trackId: id,
-          source: collectionPlaybackSource,
-          uid: makeStableUid(Kind.TRACKS, id, collectionPlaybackSource)
+          source: collectionPlaybackSource
         })),
     [trackUids, collectionPlaybackSource]
   )
@@ -584,8 +583,7 @@ const CollectionTrackList = ({
         .map((uid) => Uid.fromString(uid).id as ID)
         .map((id) => ({
           trackId: id,
-          source: trackListPlaybackSource,
-          uid: makeStableUid(Kind.TRACKS, id, trackListPlaybackSource)
+          source: trackListPlaybackSource
         })),
     [uids, trackListPlaybackSource]
   )

--- a/packages/mobile/src/screens/library-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/library-screen/TracksTab.tsx
@@ -223,8 +223,7 @@ export const TracksTab = () => {
     () =>
       filteredTrackIds.map((id) => ({
         trackId: id,
-        source: playbackSource,
-        uid: makeStableUid(Kind.TRACKS, id, playbackSource)
+        source: playbackSource
       })),
     [filteredTrackIds]
   )

--- a/packages/web/src/components/tracks-table/TrackTableLineup.tsx
+++ b/packages/web/src/components/tracks-table/TrackTableLineup.tsx
@@ -74,8 +74,7 @@ export const TrackTableLineup = ({
     () =>
       trackIds.map((id) => ({
         trackId: id,
-        source,
-        uid: makeStableUid(Kind.TRACKS, id, source)
+        source
       })),
     [trackIds, source]
   )

--- a/packages/web/src/pages/collection-page/useCollectionPage.ts
+++ b/packages/web/src/pages/collection-page/useCollectionPage.ts
@@ -520,12 +520,7 @@ export const useCollectionPage = (
     () =>
       tracks.entries.map((entry) => ({
         trackId: entry.track_id,
-        source: collectionPlaybackSource,
-        uid: makeStableUid(
-          Kind.TRACKS,
-          entry.track_id,
-          collectionPlaybackSource
-        )
+        source: collectionPlaybackSource
       })),
     [tracks.entries, collectionPlaybackSource]
   )

--- a/packages/web/src/pages/history-page/components/desktop/HistoryPage.tsx
+++ b/packages/web/src/pages/history-page/components/desktop/HistoryPage.tsx
@@ -1,10 +1,9 @@
 import { ChangeEvent, useCallback, useMemo, useState } from 'react'
 
 import { useCurrentUserId, useTrackHistory } from '@audius/common/api'
-import { Name, PlaybackSource, Kind, ID } from '@audius/common/models'
+import { Name, PlaybackSource, ID } from '@audius/common/models'
 import { playbackActions, playbackSelectors } from '@audius/common/store'
 import type { PlaybackTrack } from '@audius/common/store'
-import { makeStableUid } from '@audius/common/utils'
 import {
   Button,
   IconListeningHistory,
@@ -101,8 +100,7 @@ export const HistoryPage = ({ title, description }: HistoryPageProps) => {
     () =>
       trackIds.map((id) => ({
         trackId: id,
-        source: HISTORY_SOURCE,
-        uid: makeStableUid(Kind.TRACKS, id, HISTORY_SOURCE)
+        source: HISTORY_SOURCE
       })),
     [trackIds]
   )

--- a/packages/web/src/pages/library-page/hooks/useLibraryPage.ts
+++ b/packages/web/src/pages/library-page/hooks/useLibraryPage.ts
@@ -16,7 +16,6 @@ import {
   FavoriteSource,
   PlaybackSource,
   ID,
-  Kind,
   UID,
   LineupTrack,
   Status
@@ -362,12 +361,7 @@ export const useLibraryPage = () => {
     () =>
       tracks.entries.map((entry: any) => ({
         trackId: entry.track_id ?? entry.id,
-        source: playbackSource,
-        uid: makeStableUid(
-          Kind.TRACKS,
-          entry.track_id ?? entry.id,
-          playbackSource
-        )
+        source: playbackSource
       })),
     [tracks.entries]
   )


### PR DESCRIPTION
## What

Removes vestigial `uid` properties from the new playback system's queue builders, across web and mobile.

## Why

The new playback system (`playbackActions.playFrom` + the `PlaybackTrack` queue in `packages/common/src/store/playback`) identifies tracks by **queue index** and `(trackId, source)`. `PlaybackTrack` has **no `uid` field**, and nothing reads `.uid` off the queue (verified across the common slice/selectors, the web playback saga, and the mobile playback path — zero `.uid` reads).

Despite that, several `PlaybackTrack[]` builders still constructed each entry with a dead `uid: makeStableUid(...)` excess property. This removes them so the queue construction matches the system's actual contract.

## Changes

`PlaybackTrack[]` builders cleaned:
- **mobile**: `CollectionScreenDetailsTile` (collection + track-list queues), `TracksTab` (saved-tracks queue)
- **web**: `TrackTableLineup`, `useLibraryPage`, `HistoryPage` (desktop), `useCollectionPage`

Left untouched (these `uid`s are still read for active-track highlighting): lineup entry objects, table row uids, and the `currentPlayingUid`/`useCollectionTrackUids` comparison keys. Removed now-unused `Kind`/`makeStableUid` imports where the cleanup left them dangling.

## Verification

- `tsc --noEmit` clean in both `packages/web` and `packages/mobile` (0 errors).
- Final sweep confirms no `PlaybackTrack[]` builder carries `uid` anymore.

## Context

Follow-up to the collection-tile playback fix ([#14435](https://github.com/AudiusProject/apps/pull/14435)), which already dropped `uid` from the mobile feed-lineup queue. This cleans up the remaining call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)