### PR TITLE
feat(mobile): playing icon + skip-deleted-on-tap + gray deleted index

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -29,12 +29,19 @@ import { formatLineupTileDuration, removeNullable } from '@audius/common/utils'
 import { TouchableOpacity, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Flex, Paper, Text, type ImageProps } from '@audius/harmony-native'
+import {
+  Flex,
+  IconVolumeLevel2,
+  Paper,
+  Text,
+  type ImageProps
+} from '@audius/harmony-native'
 import { UserLink } from 'app/components/user-link'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { setVisibility } from 'app/store/drawers/slice'
 import { getIsCollectionMarkedForDownload } from 'app/store/offline-downloads/selectors'
 import { makeStyles } from 'app/styles'
+import { useThemeColors } from 'app/utils/theme'
 
 import { CollectionDogEar } from '../collection/CollectionDogEar'
 import { CollectionImage } from '../image/CollectionImage'
@@ -45,7 +52,7 @@ import { LineupTileActionButtons } from './LineupTileActionButtons'
 import { TilePressBlockContext } from './TilePressBlockContext'
 import { LineupTileSource, type CollectionTileProps } from './types'
 
-const { getTrackId } = playbackSelectors
+const { getTrackId, getPlaying } = playbackSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { open: openOverflowMenu } = mobileOverflowMenuUIActions
 const {
@@ -78,7 +85,15 @@ const useStyles = makeStyles(({ spacing }) => ({
     gap: spacing(1)
   },
   titleTouchable: {
-    width: '100%'
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  titleText: {
+    flexShrink: 1
+  },
+  playingIndicator: {
+    marginLeft: 8
   },
   artistTouchable: {
     alignSelf: 'flex-start'
@@ -104,6 +119,7 @@ export const CollectionTile = (props: CollectionTileProps) => {
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const styles = useStyles()
+  const { primary } = useThemeColors()
   const { data: currentUserId } = useCurrentUserId()
 
   // Mirror the web mobile CollectionTile path exactly: fetch the collection
@@ -135,6 +151,10 @@ export const CollectionTile = (props: CollectionTileProps) => {
   // already runs its own `getTrackId(state) === trackId` selector and
   // applies `styles.active` / `palette.primary` to its title text).
   const isActive = currentTrack != null
+  // True only while audio is actively playing (not paused) AND one of this
+  // collection's tracks is the current track. Mirrors LineupTileMetadata's
+  // `isPlaying` derivation — drives the speaker icon next to the title.
+  const isPlaying = useSelector((state) => getPlaying(state) && isActive)
 
   const isCollectionMarkedForDownload = useSelector((state) =>
     collection
@@ -165,7 +185,14 @@ export const CollectionTile = (props: CollectionTileProps) => {
         childPressedRef.current = false
         return
       }
-      const startTrackId = currentTrack?.track_id ?? tracks[0]?.track_id
+      // Don't try to play a deleted-by-artist track. Pick the current
+      // track (if it's one of ours and not deleted), else the first
+      // non-deleted track in the collection. If everything is deleted,
+      // the tile tap is a no-op.
+      const startTrackId =
+        currentTrack && !currentTrack.is_delete
+          ? currentTrack.track_id
+          : tracks.find((t) => !t.is_delete)?.track_id
       if (!startTrackId) return
       togglePlay({
         id: startTrackId,
@@ -312,9 +339,21 @@ export const CollectionTile = (props: CollectionTileProps) => {
                 variant='title'
                 color={isActive ? 'active' : 'default'}
                 numberOfLines={1}
+                style={styles.titleText}
               >
                 {collection.playlist_name}
               </Text>
+              {/* Speaker icon next to the title while one of this
+                  collection's tracks is the currently-playing track and
+                  the audio engine is actively playing (not paused). Same
+                  icon + sizing TrackTile uses via LineupTileMetadata. */}
+              {isPlaying ? (
+                <IconVolumeLevel2
+                  fill={primary}
+                  size='m'
+                  style={styles.playingIndicator}
+                />
+              ) : null}
             </TouchableOpacity>
             <TouchableOpacity
               onPressIn={handlePressWithPropagationBlock}

--- a/packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx
@@ -108,7 +108,18 @@ const TrackItem = (props: TrackItemProps) => {
           <Skeleton width='100%' height={10} />
         ) : !track ? null : (
           <>
-            <Text style={[styles.text, isPlayingUid && styles.active]}>
+            {/* Index also picks up the deleted style so the whole row
+                grays out consistently — without this, the number column
+                stays the default subdued color while the title/artist
+                go further-subdued, which reads as "row partially
+                deleted" rather than the intended unavailable state. */}
+            <Text
+              style={[
+                styles.text,
+                deleted && styles.deleted,
+                isPlayingUid && styles.active
+              ]}
+            >
               {index + 1}
             </Text>
             {/*


### PR DESCRIPTION
Follow-up to #14440 — the original PR merged before this commit landed. Re-applying the three remaining behaviors on a fresh branch off main.

## 1. Speaker icon next to the title when actively playing

Mirrors what TrackTile shows via `LineupTileMetadata`: a small `IconVolumeLevel2` fills the line next to the title text while one of this collection's tracks is the currently-playing track AND the audio engine is actually playing (not paused).

```ts
const { getTrackId, getPlaying } = playbackSelectors
const isPlaying = useSelector((state) => getPlaying(state) && isActive)
```

```tsx
{isPlaying ? (
  <IconVolumeLevel2 fill={primary} size='m' style={styles.playingIndicator} />
) : null}
```

Same icon, same fill (`useThemeColors().primary`), same `size='m'`. Restructured `styles.titleTouchable` to be a row container (`flexDirection: 'row', alignItems: 'center'`) and added `styles.titleText: { flexShrink: 1 }` so a long title shrinks instead of pushing the icon off-tile.

## 2. Skip deleted-by-artist tracks on the tile-level tap

Previously `handlePress` fell back to `tracks[0]?.track_id` as the start track — if the first track was deleted, the tap dispatched playback for an unplayable track. Now:

```ts
const startTrackId =
  currentTrack && !currentTrack.is_delete
    ? currentTrack.track_id
    : tracks.find((t) => !t.is_delete)?.track_id
if (!startTrackId) return
```

Picks the current track only if it's one of ours AND not deleted, else the first non-deleted track. If every track in the collection is deleted, the tile tap is a no-op.

The per-row tap was already a no-op for playback — the list-level `Pressable` only fires `handlePressTitle` (navigate to the collection page), never a play action. The real playability concern was at the tile-level tap, which this covers.

## 3. Gray the index column on deleted rows

`CollectionTileTrackList`'s `TrackItem` already grayed the title, the `by <artist>` line, and the `[Deleted by Artist]` marker. The number column was still rendered in the regular subdued color, which read as "row partially deleted." Added `deleted && styles.deleted` to the index Text's style array so the whole row consistently grays out.

## Files

- [`packages/mobile/src/components/lineup-tile/CollectionTile.tsx`](packages/mobile/src/components/lineup-tile/CollectionTile.tsx) — icon + skip-deleted-on-tap
- [`packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx`](packages/mobile/src/components/lineup-tile/CollectionTileTrackList.tsx) — index gray-out

Net diff: +55 / −5.

## Verification

- [x] `tsc --noEmit` clean in `packages/mobile`.
- [ ] Mobile manual: play a track inside a collection in the feed lineup → speaker icon shows next to the collection title.
- [ ] Mobile manual: pause playback → speaker icon disappears (title still tinted active).
- [ ] Mobile manual: tap a collection tile whose first track is deleted → playback starts on the first non-deleted track (not on the deleted one).
- [ ] Mobile manual: collection where every track is deleted → tile tap is a no-op.
- [ ] Mobile manual: deleted row in the tracklist is fully grayed out (index, title, "by <artist>", "[Deleted by Artist]" all in the subdued color).

🤖 Generated with [Claude Code](https://claude.com/claude-code)