### PR TITLE
fix(mobile): swipe-down on comments drawer no longer closes now-playing

### DIFF
--- a/packages/mobile/src/components/comments/CommentBlock.tsx
+++ b/packages/mobile/src/components/comments/CommentBlock.tsx
@@ -25,6 +25,7 @@ import { UserLink } from '../user-link'
 import { ArtistPick } from './ArtistPick'
 import { CommentActionBar } from './CommentActionBar'
 import { CommentBadge } from './CommentBadge'
+import { useCommentDrawer } from './CommentDrawerContext'
 import { CommentText } from './CommentText'
 import { Timestamp } from './Timestamp'
 import { TimestampLink } from './TimestampLink'
@@ -42,8 +43,16 @@ export const CommentBlockInternal = (
   }
 ) => {
   const { comment, isPreview, parentCommentId, highlightedCommentId } = props
-  const { artistId, track, navigation, closeDrawer } =
-    useCurrentCommentSection()
+  const { artistId, track, navigation } = useCurrentCommentSection()
+  // Use this for in-drawer navigation (profile pic, user link, mentions)
+  // so the destination screen is visible once we navigate. The section
+  // context's `closeDrawer` would only close the comment drawer and leave
+  // the now-playing drawer covering the destination.
+  const { closeAndExitNowPlaying } = useCommentDrawer()
+  const trackIdForCloseAll = track.track_id
+  const handleNavigateAway = useCallback(() => {
+    closeAndExitNowPlaying(trackIdForCloseAll)
+  }, [closeAndExitNowPlaying, trackIdForCloseAll])
   const {
     id: commentId,
     message,
@@ -66,9 +75,9 @@ export const CommentBlockInternal = (
   })
 
   const handlePressProfilePic = useCallback(() => {
-    closeDrawer?.()
+    handleNavigateAway()
     onPressProfilePic()
-  }, [closeDrawer, onPressProfilePic])
+  }, [handleNavigateAway, onPressProfilePic])
 
   const handlePressTimestamp = useCallback(
     (e: GestureResponderEvent, timestampSeconds: number) => {
@@ -169,7 +178,7 @@ export const CommentBlockInternal = (
                     <UserLink
                       userId={userId}
                       strength='strong'
-                      onPress={closeDrawer}
+                      onPress={handleNavigateAway}
                       lineHeight='single'
                       textLinkStyle={{ lineHeight: 20 }}
                     />
@@ -207,7 +216,7 @@ export const CommentBlockInternal = (
             mentions={mentions}
             trackDuration={track.duration}
             navigation={navigation}
-            onCloseDrawer={closeDrawer}
+            onCloseDrawer={handleNavigateAway}
           >
             {message}
           </CommentText>

--- a/packages/mobile/src/components/comments/CommentDrawerContext.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawerContext.tsx
@@ -20,7 +20,19 @@ import { CommentDrawer } from './CommentDrawer'
 interface CommentDrawerContextState {
   isOpen: boolean
   open: (data: CommentDrawerData) => void
+  /**
+   * Close the comment drawer only. Use this for dismissal flows where the
+   * user is staying on the now-playing screen (swipe-down on the bottom
+   * sheet, X button, programmatic dismiss).
+   */
   close: (trackId: ID) => void
+  /**
+   * Close the comment drawer AND any open now-playing drawer behind it.
+   * Use this for in-drawer navigation actions (clicking a user link,
+   * mention, etc.) so the destination screen is actually visible once
+   * the navigation push lands.
+   */
+  closeAndExitNowPlaying: (trackId: ID) => void
 }
 
 const CommentDrawerContext = createContext<
@@ -50,10 +62,25 @@ export const CommentDrawerProvider = (props: PropsWithChildren) => {
     )
   }, [])
 
-  const close = useCallback(
+  const close = useCallback((trackId: ID) => {
+    // Closes the comment drawer only. The now-playing drawer should stay
+    // open here — the BottomSheetModal's onDismiss callback (swipe-down,
+    // backdrop tap, X button) routes through this path and historically
+    // also closed the now-playing drawer underneath, which is the bug.
+    // Navigation flows that need both drawers closed call
+    // `closeAndExitNowPlaying` instead.
+    setIsOpen(false)
+    track(
+      make({
+        eventName: Name.COMMENTS_CLOSE_COMMENT_DRAWER,
+        trackId
+      })
+    )
+  }, [])
+
+  const closeAndExitNowPlaying = useCallback(
     (trackId: ID) => {
       setIsOpen(false)
-      // This happens when you click on a UserLink inside the comments drawer
       if (isNowPlayingDrawerOpen) {
         closeNowPlayingDrawer()
       }
@@ -76,7 +103,9 @@ export const CommentDrawerProvider = (props: PropsWithChildren) => {
   }, [isOpen])
 
   return (
-    <CommentDrawerContext.Provider value={{ isOpen, open, close }}>
+    <CommentDrawerContext.Provider
+      value={{ isOpen, open, close, closeAndExitNowPlaying }}
+    >
       {children}
       {drawerData ? (
         <CommentDrawer


### PR DESCRIPTION
## The bug

Open the now-playing drawer, open the comments drawer inside it, swipe the comments drawer down — the now-playing drawer slides closed too. Only the comments drawer should dismiss.

## Why it was happening

`CommentDrawerContext.close` was unconditionally dispatching `closeNowPlayingDrawer()` whenever the now-playing drawer was open, with the existing comment hand-waving that this was for "click on a UserLink inside the comments drawer":

```ts
// CommentDrawerContext.tsx — before
const close = useCallback((trackId: ID) => {
  setIsOpen(false)
  // This happens when you click on a UserLink inside the comments drawer
  if (isNowPlayingDrawerOpen) {
    closeNowPlayingDrawer()
  }
  // …
})
```

But `close` is also exactly what `BottomSheetModal.onDismiss` routes through when the sheet is swiped down (or backdrop-tapped, or X-button-closed). So every dismiss path went through the same now-playing close.

The existing `gesturesDisabled={isCommentDrawerOpen}` on the underlying `Drawer` inside `NowPlayingDrawer.tsx` was actually doing its job — it prevents the swipe gesture from reaching the now-playing drawer's PanResponder. The bug was purely the explicit programmatic `closeNowPlayingDrawer()` call inside `close` running on every dismiss.

## Fix

Split the close behavior in `CommentDrawerContext` so dismiss flows don't drag now-playing along, and navigation flows still do:

```ts
interface CommentDrawerContextState {
  isOpen: boolean
  open: (data: CommentDrawerData) => void
  /** Close the comment drawer only. Used by swipe-down / X button. */
  close: (trackId: ID) => void
  /** Close the comment drawer AND any open now-playing drawer.
   *  Used by in-drawer navigation actions so the destination screen
   *  is visible once we navigate. */
  closeAndExitNowPlaying: (trackId: ID) => void
}
```

Then [`CommentBlock.tsx`](packages/mobile/src/components/comments/CommentBlock.tsx) routes its three navigation sites through the new method via a small `handleNavigateAway` derived from `track.track_id`:

- profile-pic tap (`handlePressProfilePic`)
- the comment's username (`<UserLink onPress=…>`)
- the `<CommentText onCloseDrawer=…>` mention-tap path

The section context's `closeDrawer` callback isn't read in `CommentBlock` anymore. The X button in `CommentDrawerHeader` and the `onDismiss` on the bottom sheet both still call `close(entityId)` → comment drawer dismisses, now-playing stays open. ✅

## Files

- [`packages/mobile/src/components/comments/CommentDrawerContext.tsx`](packages/mobile/src/components/comments/CommentDrawerContext.tsx) — split into `close` and `closeAndExitNowPlaying`
- [`packages/mobile/src/components/comments/CommentBlock.tsx`](packages/mobile/src/components/comments/CommentBlock.tsx) — route navigation handlers through `handleNavigateAway`

Net diff: +47 / −9.

## Verification

- [x] `tsc --noEmit` clean in `packages/mobile`
- [ ] Manual: open the now-playing drawer → open comments → swipe comments down. Now-playing should stay open.
- [ ] Manual: same, but tap the X in the comment drawer header. Now-playing should stay open.
- [ ] Manual: tap a commenter's profile pic or username. Both drawers should close and you should land on their profile.
- [ ] Manual: tap an `@mention` inside a comment. Both drawers should close, navigation to the user's profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)