### PR TITLE
feat(mobile): full-screen avatar viewer on profile screen tap

### DIFF
--- a/packages/mobile/src/screens/profile-screen/AvatarViewer.tsx
+++ b/packages/mobile/src/screens/profile-screen/AvatarViewer.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect } from 'react'
+
+import type { ID } from '@audius/common/models'
+import { SquareSizes } from '@audius/common/models'
+import {
+  Image,
+  Modal,
+  StatusBar,
+  StyleSheet,
+  TouchableOpacity,
+  useWindowDimensions
+} from 'react-native'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming
+} from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import { IconClose } from '@audius/harmony-native'
+import { useProfilePicture } from 'app/components/image/UserImage'
+
+// Distance (px) the user has to drag in any direction before the viewer
+// dismisses on release. Velocity above the threshold also dismisses to
+// allow a quick flick.
+const DISMISS_DISTANCE_THRESHOLD = 120
+const DISMISS_VELOCITY_THRESHOLD = 800
+const SPRING_BACK_DURATION_MS = 200
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: '#000',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  imageWrapper: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  image: {
+    width: '100%',
+    height: '100%'
+  },
+  closeButton: {
+    position: 'absolute',
+    right: 16,
+    width: 44,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+})
+
+type AvatarViewerProps = {
+  userId: ID | null | undefined
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Full-screen avatar viewer for the profile screen. Shows the user's profile
+ * picture at the largest cached size on a black backdrop with an X button in
+ * the top-right. Any swipe gesture (up, down, left, or right) past a small
+ * distance / velocity threshold dismisses it; smaller drags spring back.
+ */
+export const AvatarViewer = ({ userId, isOpen, onClose }: AvatarViewerProps) => {
+  const insets = useSafeAreaInsets()
+  const { width: windowWidth } = useWindowDimensions()
+
+  // Use the largest cached size the image API serves so the full-screen
+  // render isn't a blurry upscale of the 150-px tile shown in the header.
+  const { source } = useProfilePicture({
+    userId,
+    size: SquareSizes.SIZE_1000_BY_1000
+  })
+
+  const translationX = useSharedValue(0)
+  const translationY = useSharedValue(0)
+
+  // Reset the translation any time the viewer opens — without this a partial
+  // drag from a previous open lingers and the next open starts off-center.
+  useEffect(() => {
+    if (isOpen) {
+      translationX.value = 0
+      translationY.value = 0
+    }
+  }, [isOpen, translationX, translationY])
+
+  const dismiss = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  const panGesture = Gesture.Pan()
+    .onUpdate((e) => {
+      'worklet'
+      translationX.value = e.translationX
+      translationY.value = e.translationY
+    })
+    .onEnd((e) => {
+      'worklet'
+      const distance = Math.sqrt(
+        e.translationX * e.translationX + e.translationY * e.translationY
+      )
+      const speed = Math.sqrt(
+        e.velocityX * e.velocityX + e.velocityY * e.velocityY
+      )
+      if (
+        distance > DISMISS_DISTANCE_THRESHOLD ||
+        speed > DISMISS_VELOCITY_THRESHOLD
+      ) {
+        runOnJS(dismiss)()
+      } else {
+        translationX.value = withTiming(0, {
+          duration: SPRING_BACK_DURATION_MS
+        })
+        translationY.value = withTiming(0, {
+          duration: SPRING_BACK_DURATION_MS
+        })
+      }
+    })
+
+  const animatedImageStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translationX.value },
+      { translateY: translationY.value }
+    ]
+  }))
+
+  return (
+    <Modal
+      visible={isOpen}
+      transparent
+      animationType='fade'
+      statusBarTranslucent
+      onRequestClose={onClose}
+    >
+      <StatusBar
+        barStyle='light-content'
+        backgroundColor='#000'
+        translucent={false}
+      />
+      <GestureDetector gesture={panGesture}>
+        <Animated.View style={styles.backdrop}>
+          <Animated.View style={[styles.imageWrapper, animatedImageStyle]}>
+            <Image
+              source={source}
+              style={[styles.image, { maxWidth: windowWidth }]}
+              resizeMode='contain'
+              accessibilityIgnoresInvertColors
+            />
+          </Animated.View>
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityLabel='Close avatar viewer'
+            accessibilityRole='button'
+            hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}
+            style={[styles.closeButton, { top: insets.top + 8 }]}
+          >
+            <IconClose color='staticWhite' size='l' />
+          </TouchableOpacity>
+        </Animated.View>
+      </GestureDetector>
+    </Modal>
+  )
+}

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ArtistProfilePicture.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ArtistProfilePicture.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useArtistCreatedFanClub } from '@audius/common/api'
 import { css } from '@emotion/native'
@@ -9,8 +9,11 @@ import { useNavigation } from 'app/hooks/useNavigation'
 import { env } from 'app/services/env'
 import { zIndex } from 'app/utils/zIndex'
 
+import { AvatarViewer } from '../AvatarViewer'
+
 const messages = {
-  fanClubBadge: 'Fan club badge'
+  fanClubBadge: 'Fan club badge',
+  viewAvatar: 'View profile picture'
 }
 
 export type ArtistProfilePictureProps = {
@@ -35,9 +38,20 @@ export const ArtistProfilePicture = ({ userId }: ArtistProfilePictureProps) => {
     }
   }, [navigation, ownedCoin?.ticker])
 
+  const [isViewerOpen, setIsViewerOpen] = useState(false)
+  const handleOpenViewer = useCallback(() => setIsViewerOpen(true), [])
+  const handleCloseViewer = useCallback(() => setIsViewerOpen(false), [])
+
   return (
     <>
-      <ProfilePicture userId={userId} size='xl' />
+      <TouchableOpacity
+        onPress={handleOpenViewer}
+        activeOpacity={0.85}
+        accessibilityLabel={messages.viewAvatar}
+        accessibilityRole='imagebutton'
+      >
+        <ProfilePicture userId={userId} size='xl' />
+      </TouchableOpacity>
       {shouldShowFanClubBadge && (
         <TouchableOpacity
           onPress={handleCoinPress}
@@ -52,6 +66,11 @@ export const ArtistProfilePicture = ({ userId }: ArtistProfilePictureProps) => {
           <TokenIcon logoURI={ownedCoin?.logoUri} size='l' />
         </TouchableOpacity>
       )}
+      <AvatarViewer
+        userId={userId}
+        isOpen={isViewerOpen}
+        onClose={handleCloseViewer}
+      />
     </>
   )
 }


### PR DESCRIPTION
Tapping the avatar on a profile page now opens a full-window viewer of the user's profile picture at the largest cached image size.

## What's new

### `packages/mobile/src/screens/profile-screen/AvatarViewer.tsx` (new)

Self-contained viewer component — no nav stack changes, no provider.

- **React Native `<Modal>`** with `transparent` + `animationType="fade"` handles the open/close fade-in/out automatically. `statusBarTranslucent` keeps the image flush to the top edge under the notch.
- **Image** rendered with `resizeMode="contain"` so the square avatar fits the rectangular window with letterboxing instead of cropping. Width capped at `useWindowDimensions().width`.
- **Highest-resolution source:** `useProfilePicture({ userId, size: SquareSizes.SIZE_1000_BY_1000 })`. The header uses `SIZE_150_BY_150` for the small tile; the viewer uses 1000 so it isn't a blurry upscale.
- **Close button:** `IconClose` in the top-right at `insets.top + 8` with a generous `hitSlop`. Accessible role + label.
- **Swipe to dismiss:** `Gesture.Pan()` from `react-native-gesture-handler`. The image follows the finger in any direction via Reanimated `useSharedValue`/`useAnimatedStyle`. On release:
  - Drag distance > `120 px` OR velocity > `800 px/s` → `runOnJS(onClose)()` (the Modal fade-out handles the rest)
  - Otherwise → spring back to center with `withTiming(0, { duration: 200 })` on both axes
- **Reset on open:** translation shared values reset to 0 in a `useEffect` keyed on `isOpen`, so a partial-then-cancelled drag from a previous open doesn't carry over.
- Black `#000` backdrop; `StatusBar` set to `light-content` + black while mounted.

### `packages/mobile/src/screens/profile-screen/ProfileHeader/ArtistProfilePicture.tsx`

- Wraps the existing `<ProfilePicture>` in a `<TouchableOpacity>` with `activeOpacity={0.85}` to signal tappability (no visual change beyond a brief fade on press).
- Local `isViewerOpen` state with `useState`.
- Renders `<AvatarViewer userId={userId} isOpen={isViewerOpen} onClose={…}>` as a sibling.

The fan-club badge overlay keeps its own tap target — it sits at `zIndex: PROFILE_PAGE_PROFILE_PICTURE + 1` over the avatar, so badge taps still route to `CoinDetailsScreen` (the avatar tap doesn't fire under it).

## Verification

- [x] `tsc --noEmit` clean in `packages/mobile`.
- [ ] Manual: tap an avatar on any profile screen → black full-screen viewer fades in, image at the largest cached resolution.
- [ ] Manual: tap the X in the top-right → viewer fades out.
- [ ] Manual: short drag in any direction (< ~100 px, slow) → image springs back, viewer stays open.
- [ ] Manual: longer drag or quick flick in any of the four directions → viewer dismisses.
- [ ] Manual: tap the fan-club badge (where present) → still navigates to `CoinDetailsScreen` without opening the viewer.
- [ ] Manual: Android hardware back → viewer dismisses (handled by Modal's `onRequestClose`).

## Out of scope

- Pinch-to-zoom — the spec listed dismiss-via-any-swipe; zoom can be a separate enhancement (would conflict with the dismiss gesture without a more elaborate gesture composition).
- Avatar viewer from other screens (lineup tiles, comments, etc.) — only wired into the profile screen header per the request. The `AvatarViewer` component itself is general-purpose if we want to add more entry points later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)