### PR TITLE
fix(feed): keep For You feed populated (no empty-state flash + live recommended endpoint)

### DIFF
--- a/.changeset/fix-for-you-feed-empty-overwrite.md
+++ b/.changeset/fix-for-you-feed-empty-overwrite.md
@@ -1,0 +1,5 @@
+---
+'@audius/common': patch
+---
+
+Fix the For You feed briefly rendering tracks and then blanking to the "follow artists" empty state. `useForYouFeed` had no `staleTime`, so the personalized query refetched on the next mount/focus right after the first paint; if that refetch settled empty (a transient backend result or a different node in the fleet) it replaced the loaded feed with an empty list, which the lineup reads as "no content." The query now uses `staleTime: Infinity` so the loaded feed stays stable for the session, and `enabled` requires a fully-resolved user id so the query no longer seeds an empty cache entry under the `undefined`-id key while the account is still loading.

--- a/.changeset/for-you-feed-recommended-fallback.md
+++ b/.changeset/for-you-feed-recommended-fallback.md
@@ -1,0 +1,5 @@
+---
+'@audius/common': patch
+---
+
+Point the For You feed at the live `GET /v1/tracks/recommended` endpoint (`sdk.tracks.getRecommendedTracks`) instead of `GET /v1/users/{id}/feed/for-you`. The dedicated for-you endpoint is not yet deployed across the validator-node fleet and 404s in production, leaving the For You tab empty. `/tracks/recommended` is the same personalized recommendation source the Explore page used before the For You feed existed and reliably returns 200 today. It has no `offset`, so pagination passes the already-seen track ids as `exclusionList`. Revert to `getUserForYouFeed()` once the new endpoint is rolled out.

--- a/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
@@ -1,15 +1,14 @@
-import { EntityType, Id } from '@audius/sdk'
+import { EntityType, OptionalId } from '@audius/sdk'
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 
-import { transformAndCleanList, userFeedItemFromSDK } from '~/adapters'
+import { transformAndCleanList, userTrackMetadataFromSDK } from '~/adapters'
 import { useQueryContext } from '~/api/tan-query/utils'
-import { ID, UserCollectionMetadata, UserTrackMetadata } from '~/models'
+import { ID } from '~/models'
 
 import { QUERY_KEYS } from '../queryKeys'
 import { LineupData, QueryKey, QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { makeLoadNextPage } from '../utils/infiniteQueryLoadNextPage'
-import { primeCollectionData } from '../utils/primeCollectionData'
 import { primeTrackData } from '../utils/primeTrackData'
 
 export const FOR_YOU_INITIAL_PAGE_SIZE = 10
@@ -25,12 +24,21 @@ export const getForYouFeedQueryKey = (userId: ID | null | undefined) => {
 }
 
 /**
- * "For You" feed for the Feed page. Backed by the dedicated
- * `GET /v1/users/{id}/feed/for-you` endpoint — a lean 6-source pipeline
- * (in-network, trending, underground × tracks + playlists) with linear
- * ranking and a shared per-owner diversity pass. Returns a heterogenous
- * feed of tracks and playlists/albums, mirroring the chronological feed
- * shape; consumers that only render tracks can use `trackIds`.
+ * "For You" feed for the Feed page.
+ *
+ * NOTE: temporarily backed by the long-standing `GET /v1/tracks/recommended`
+ * endpoint (`sdk.tracks.getRecommendedTracks`) — the same personalized
+ * recommendation source the Explore page used before the For You feed existed.
+ * The dedicated `GET /v1/users/{id}/feed/for-you` endpoint is not yet rolled
+ * out across the validator-node fleet and 404s in production, so we fall back
+ * to the endpoint that reliably returns 200 from `api.audius.co` today. Swap
+ * back to `sdk.users.getUserForYouFeed()` once the new endpoint is deployed.
+ *
+ * `/tracks/recommended` has no `offset`, so pagination is done by passing the
+ * already-seen track ids as `exclusionList` — each page returns fresh
+ * recommendations that don't repeat earlier ones. The pageParam carries the
+ * accumulated exclusion list. Returns a tracks-only lineup; consumers that
+ * only render tracks can use `trackIds`.
  */
 export const useForYouFeed = (
   {
@@ -46,55 +54,36 @@ export const useForYouFeed = (
   const queryKey = getForYouFeedQueryKey(currentUserId)
 
   const query = useInfiniteQuery({
-    initialPageParam: 0,
+    initialPageParam: [] as ID[],
     getNextPageParam: (lastPage: LineupData[], allPages) => {
       const isFirstPage = allPages.length === 1
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       if (lastPage.length < currentPageSize) return undefined
-      return allPages.reduce((total, page) => total + page.length, 0)
+      // Accumulate every track id seen so far; the next page excludes them.
+      return allPages.flatMap((page) => page.map((item) => item.id))
     },
     queryKey,
     queryFn: async ({ pageParam }): Promise<LineupData[]> => {
       if (!currentUserId) return []
-      const isFirstPage = pageParam === 0
+      const exclusionList = pageParam
+      const isFirstPage = exclusionList.length === 0
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       const sdk = await audiusSdk()
-      const { data = [] } = await sdk.users.getUserForYouFeed({
-        id: Id.parse(currentUserId),
-        userId: Id.parse(currentUserId),
+      const { data = [] } = await sdk.tracks.getRecommendedTracks({
         limit: currentPageSize,
-        offset: pageParam
+        userId: OptionalId.parse(currentUserId),
+        exclusionList: exclusionList.length ? exclusionList : undefined
       })
 
-      const feed = transformAndCleanList(data, userFeedItemFromSDK).map(
-        ({ item }) => item
-      )
-      if (feed === null) return []
+      const tracks = primeTrackData({
+        tracks: transformAndCleanList(data, userTrackMetadataFromSDK),
+        queryClient
+      })
 
-      const { tracks, collections } = feed.reduce(
-        (acc, item) => {
-          if ('track_id' in item) {
-            acc.tracks.push(item)
-          } else {
-            acc.collections.push(item)
-          }
-          return acc
-        },
-        {
-          tracks: [] as UserTrackMetadata[],
-          collections: [] as UserCollectionMetadata[]
-        }
-      )
-
-      // Prime caches so tile renders don't have to re-fetch
-      primeTrackData({ tracks, queryClient })
-      primeCollectionData({ collections, queryClient })
-
-      return feed.map((item) =>
-        'track_id' in item
-          ? { id: item.track_id, type: EntityType.TRACK }
-          : { id: item.playlist_id, type: EntityType.PLAYLIST }
-      )
+      return tracks.map(({ track_id }) => ({
+        id: track_id,
+        type: EntityType.TRACK
+      }))
     },
     select: (data) => data?.pages.flat(),
     // Keep the loaded feed stable for the session. Without this the default

--- a/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
@@ -97,8 +97,23 @@ export const useForYouFeed = (
       )
     },
     select: (data) => data?.pages.flat(),
+    // Keep the loaded feed stable for the session. Without this the default
+    // staleTime of 0 makes the query refetch on the next mount/focus right
+    // after the first paint — and if that personalized refetch settles empty
+    // (a transient backend result, or a different node in the fleet), it
+    // replaces the just-rendered feed with `[]`, which the lineup reads as
+    // "no content" and swaps in the "follow artists" empty state. The feed
+    // renders, then blanks. Infinity (overridable via options) stops the
+    // self-inflicted refetch; pagination still works via fetchNextPage.
+    staleTime: Infinity,
     ...options,
-    enabled: options?.enabled !== false && currentUserId !== null
+    // Require a fully-resolved id (`!= null` excludes `undefined`). While the
+    // account is still loading `currentUserId` is `undefined`; enabling the
+    // query then runs the `!currentUserId` guard above and caches `[]` under
+    // the `[forYouFeed, undefined]` key. A later render that briefly reads
+    // that key would flash the empty state. Gating on a real id avoids
+    // seeding that empty cache entry entirely.
+    enabled: options?.enabled !== false && currentUserId != null
   })
 
   const data = query.data ?? []


### PR DESCRIPTION
This PR has **two commits**, both keeping the For You feed populated:

1. **Stop the feed from blanking to the follow-artists empty state** (timing/race fix)
2. **Back the feed with the live `/tracks/recommended` endpoint** (the new for-you endpoint 404s in prod)

---

## Commit 1 — stop the empty-state flash

### Summary

The **For You** feed renders real tracks for a split second and then swaps in the **"follow artists"** empty state — even for users who follow plenty of people. The data lands and renders correctly, then something overwrites it with empty.

### Root cause

The empty state is purely lineup-driven (`entries.length === 0` on mobile, `tiles.length === 0` on web) — there is **no follow-count check**, so a momentarily-empty response is indistinguishable from "follows nobody." `useForYouFeed` returns `data = query.data ?? []`, so anything that makes `query.data` empty surfaces the follow prompt.

`useForYouFeed` set **no `staleTime`**. With the react-query default of `0`, the personalized query refetches on the next mount/focus **right after the first paint**. When that refetch settles empty — a transient backend result, or a different validator node in the fleet returning no items for this user — react-query replaces the just-rendered pages with `[]`. The feed appears, then blanks. (The chronological *Latest* feed shares the same render path but its backend is deterministic, so its refetch returns the same data and it never visibly blanks — which is why only For You is affected.)

A secondary trap: `enabled` was gated on `currentUserId !== null`, which is **true while the account is still loading** (`currentUserId` is `undefined`). The query then runs its `!currentUserId` guard and caches `[]` under the `[forYouFeed, undefined]` key — a stale empty entry a later render could briefly surface.

### Fix

`packages/common/src/api/tan-query/lineups/useForYouFeed.ts`:
- **`staleTime: Infinity`** (overridable via `options`) — the loaded feed stays stable for the session instead of being re-fetched-and-clobbered. Pagination is unaffected (`fetchNextPage` ignores `staleTime`). This matches the existing pattern in `useLibraryTracks`.
- **`enabled: ... && currentUserId != null`** (excludes `undefined`) — the query no longer runs / seeds an empty cache entry while the account is resolving. `isDisabled` still keys off `=== null`, so during account load the consumer shows skeletons (not the empty state).

---

## Commit 2 — back the feed with the live `/tracks/recommended` endpoint

### Problem

The For You tab is empty in production because it calls the new `GET /v1/users/{id}/feed/for-you` endpoint (`sdk.users.getUserForYouFeed()`), which 404s on the current validator-node deployment and won't be fixed for ~a week.

### Fix

Point `useForYouFeed` at `GET /v1/tracks/recommended` (`sdk.tracks.getRecommendedTracks`) — the long-standing, personalized recommendation source the Explore page used before the For You feed existed. It reliably returns **200** from `api.audius.co` today (verified: `for-you` → 404 on the old fleet, `/tracks/recommended` → 200).

**Pagination:** `/tracks/recommended` has no `offset` parameter, but it accepts an `exclusionList`. Pagination now passes the accumulated already-seen track ids as the exclusion list, so each page returns fresh recommendations without repeats. The `pageParam` carries that list.

**Compatibility:** the hook keeps its existing return shape (a tracks-only `LineupData[]` plus derived `trackIds`), so the feed-page consumers (`FeedPageContent` web desktop/mobile, mobile `FeedScreen`) are unchanged.

This is a **temporary fallback** — revert to `getUserForYouFeed()` once the dedicated endpoint is deployed (a `NOTE` comment in the hook calls this out).

---

## Verification status

- [x] `tsc --noEmit` passes for `@audius/common`
- [x] Verified `https://api.audius.co/v1/tracks/recommended?limit=3` returns `200`
- [ ] ⚠️ **On-device verification still pending.** The empty-state flash is a sub-second race that isn't reliably reproducible through the browser preview. Recommend confirming on a mobile build signed in as a user with a real following graph: feed populates with recommended tracks, "load more" pages without duplicates, no empty-state flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)