### PR TITLE
fix(mobile): queue the track-page lineup from the hero Play button

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -7,7 +7,9 @@ import {
   useStems,
   useCurrentUserId,
   useFanClub,
-  useTrackDownloadCount
+  useTrackDownloadCount,
+  useTrackPageLineup,
+  getTrackPageLineupQueryKey
 } from '@audius/common/api'
 import { useCurrentTrack, useGatedContentAccess } from '@audius/common/hooks'
 import {
@@ -29,7 +31,7 @@ import type {
   User,
   TokenGatedConditions
 } from '@audius/common/models'
-import type { CommonState } from '@audius/common/store'
+import type { CommonState, PlaybackTrack } from '@audius/common/store'
 import {
   playbackSelectors,
   reachabilitySelectors,
@@ -319,6 +321,18 @@ export const TrackScreenDetailsTile = ({
 
   const currentQueueItem = useSelector(getCurrentQueueItem)
   const currentTrack = useCurrentTrack()
+
+  // Subscribe to the same lineup that renders below the track so the hero
+  // play button can hand the related tracks (More By + You Might Also Like
+  // / Remixes) to the player as a queue. The query is shared with
+  // TrackScreenLineup via the tanquery cache, so this does not re-fetch.
+  // `enabled: isReachable` keeps the fetch off when offline — matching the
+  // visibility gate on TrackScreenLineup in TrackScreen.tsx.
+  const { trackIds: lineupTrackIds } = useTrackPageLineup(
+    { trackId },
+    { enabled: !!isReachable }
+  )
+
   const play = useCallback(
     ({ isPreview = false } = {}) => {
       if (isLineupLoading) return
@@ -334,18 +348,35 @@ export const TrackScreenDetailsTile = ({
         dispatch(playbackActions.play())
         recordPlay(trackId)
       } else {
-        // Matches legacy track page lineup prefix.
-        const playbackSource = 'TRACK_TRACKS'
+        // Hero gets the legacy 'TRACK_TRACKS' source so its uid (built in
+        // TrackScreen via makeStableUid(..., 'TRACK_TRACKS')) still matches.
+        // The related tracks below render through TrackLineup with
+        // 'TRACK_PAGE_MORE_BY' — use the same source for those queue entries
+        // so the lineup tile highlights track auto-advance.
+        const heroSource = 'TRACK_TRACKS'
+        const relatedSource = 'TRACK_PAGE_MORE_BY'
+        const hasLineup =
+          !isPreview &&
+          lineupTrackIds.length > 1 &&
+          lineupTrackIds[0] === trackId
+        const tracks: PlaybackTrack[] = hasLineup
+          ? [
+              { trackId, source: heroSource },
+              ...lineupTrackIds.slice(1).map((id) => ({
+                trackId: id,
+                source: relatedSource
+              }))
+            ]
+          : [{ trackId, source: heroSource }]
         dispatch(
           playbackActions.playFrom({
-            tracks: [
-              {
-                trackId,
-                source: playbackSource
-              }
-            ],
+            tracks,
             startIndex: 0,
-            querySource: null
+            querySource: hasLineup
+              ? {
+                  queryKey: [...getTrackPageLineupQueryKey(trackId)] as unknown[]
+                }
+              : null
           })
         )
         recordPlay(trackId, true, true)
@@ -359,6 +390,7 @@ export const TrackScreenDetailsTile = ({
       currentQueueItem.trackId,
       currentTrack,
       trackId,
+      lineupTrackIds,
       dispatch
     ]
   )


### PR DESCRIPTION
## The bug

When you press the big **Play** button at the top of a track-detail screen on mobile, it should queue up the related-tracks lineup that the same screen renders below — Remixes / More By `<artist>` / You Might Also Like — so playback continues past the hero track. Today it doesn't: the queue is exactly one item and playback stops at the end of the hero.

Every other lineup-driven screen on mobile (feed, profile tracks/reposts, library) does this correctly because its play interactions go through `TrackLineup`, which builds a multi-track `playFrom` queue with a `querySource`. The track screen's hero **Play** button bypasses `TrackLineup` entirely and dispatches its own `playFrom`.

## Before

`packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx`:

```ts
dispatch(
  playbackActions.playFrom({
    tracks: [{ trackId, source: 'TRACK_TRACKS' }],
    startIndex: 0,
    querySource: null
  })
)
```

## After

Subscribe to the same `useTrackPageLineup` hook that `TrackScreenLineup` already uses to render the sections below the track, and build the queue from `trackIds`:

```ts
const { trackIds: lineupTrackIds } = useTrackPageLineup(
  { trackId },
  { enabled: !!isReachable }   // mirror the gate on <TrackScreenLineup> in TrackScreen.tsx
)

// inside play():
const hasLineup =
  !isPreview &&
  lineupTrackIds.length > 1 &&
  lineupTrackIds[0] === trackId

const tracks: PlaybackTrack[] = hasLineup
  ? [
      { trackId, source: 'TRACK_TRACKS' },
      ...lineupTrackIds.slice(1).map((id) => ({
        trackId: id,
        source: 'TRACK_PAGE_MORE_BY'
      }))
    ]
  : [{ trackId, source: 'TRACK_TRACKS' }]

dispatch(
  playbackActions.playFrom({
    tracks,
    startIndex: 0,
    querySource: hasLineup
      ? { queryKey: [...getTrackPageLineupQueryKey(trackId)] }
      : null
  })
)
```

### Why these specific source strings

- **Hero stays `'TRACK_TRACKS'`** so its uid (`makeStableUid(Kind.TRACKS, track_id, 'TRACK_TRACKS')` from `TrackScreen.tsx`) still matches the queue entry, and the hero's own play-button state continues to derive correctly from the playback selectors.
- **Related tracks use `'TRACK_PAGE_MORE_BY'`** because that is the source `TrackScreenLineup` already hands `TrackLineup` for all four sections (`renderRemixParentSection`, `renderRemixesSection`, `renderMoreBySection`, `renderRecommendedSection`). When auto-advance reaches a related track, the corresponding tile down the page highlights as currently-playing.

### Why `useTrackPageLineup` here doesn't double-fetch

tanquery shares query data by key. `TrackScreenLineup` already subscribes via `useTrackPageLineup({ trackId })`; adding a second subscription in `TrackScreenDetailsTile` for the same `trackId` hits the same cache entry. The `enabled: !!isReachable` matches the truthiness check `{isReachable ? <TrackScreenLineup>...` in `TrackScreen.tsx` so we don't fire the network fetch when offline.

### Edge cases

| Case | Behavior |
|---|---|
| **Preview button** (`isPreview === true`) | Falls back to single-track queue. Preview is intentionally a one-track, no-auto-advance gesture. |
| **Fast tap before lineup loads** | `lineupTrackIds.length <= 1` → falls back to single-track queue (today's behavior). |
| **Offline** | `enabled: !!isReachable` keeps the hook from firing → `lineupTrackIds` stays empty → single-track queue (today's behavior). The lineup section also doesn't render below in this state, so there's nothing to queue anyway. |
| **`lineupTrackIds[0]` somehow isn't the hero** | Defensive bail-out → single-track queue. Shouldn't happen — `useTrackPageLineup` always pushes the hero at index 0 and sets `indices.mainTrackIndex = 0` — but the guard costs nothing. |

## Verification

- [x] `tsc --noEmit` clean in `packages/mobile`.
- [ ] Manual: open a track, press Play → hero plays. Let it end → next track plays from More By or You Might Also Like, and the matching tile down the page highlights as playing.
- [ ] Manual: tap a track tile in the More By / You Might Also Like sections → still plays from that point in the same queue (unchanged from before).
- [ ] Manual: tap **Preview** on a gated track → plays the preview only, no auto-advance (unchanged from before).
- [ ] Manual: airplane-mode → tap Play → still plays the hero track as a single-track queue, no error, no extra fetch (lineup section is also hidden by `isReachable`).
- [ ] Manual: NowPlayingDrawer → Up Next list shows the related tracks queued after the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)