### PR TITLE
fix(mobile): standard push transition for contests screen

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -269,7 +269,15 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
 
       <Stack.Screen name='AudioScreen' component={AudioScreen} />
       <Stack.Screen name='RewardsScreen' component={RewardsScreen} />
-      <Stack.Screen name='Contests' component={ContestsScreen} />
+      <Stack.Screen
+        name='Contests'
+        component={ContestsScreen}
+        // Contests is reached from the left nav drawer, which passes
+        // `fromAppDrawer: true` and drops the screen animation to 'none'.
+        // That leaves a jarring instant pop when navigating away. Force the
+        // standard horizontal push so it transitions like the Track screen.
+        options={{ animation: 'simple_push' }}
+      />
       <Stack.Screen name='Contest' component={ContestScreen} />
       <Stack.Screen
         name='ContestFollowers'


### PR DESCRIPTION
## Summary
The Contests screen had a jarring back animation when navigating away — an instant pop instead of a smooth slide like the Track screen.

The Contests screen is reached from the left nav drawer via `LeftNavLink`, which navigates with `fromAppDrawer: true`. In [`useAppScreenOptions`](packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx), that param drops the screen `animation` to `'none'`, which kills both the enter and exit (back) transitions. The result is the weird instant pop.

This forces `animation: 'simple_push'` on the `Contests` `Stack.Screen`, overriding only the animation field while keeping all other shared screen options (gesture handling, card interpolator, header). That makes its transition identical to the Track screen, which uses the default `'simple_push'`.

## Changes
- `packages/mobile/src/screens/app-screen/AppTabScreen.tsx`: add `options={{ animation: 'simple_push' }}` to the `Contests` screen registration.

## Test plan
- [x] `tsc` typecheck passes for `@audius/mobile`
- [ ] Open Contests from the left nav drawer, navigate away (back gesture + back button) — confirm it slides like the Track screen instead of instantly popping

🤖 Generated with [Claude Code](https://claude.com/claude-code)