### PR TITLE
[codex] fix mobile profile artist badge

### DIFF
--- a/packages/web/src/pages/profile-page/MobileServerProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/MobileServerProfilePage.tsx
@@ -78,8 +78,12 @@ export const MobileServerProfilePage = ({
               position: 'absolute',
               top: 21,
               right: 13,
-              fill: 'white',
-              boxShadow: '0 1px 4px 0 rgba(0, 0, 0, 0.3)'
+              color: 'var(--harmony-static-white)',
+              fill: 'var(--harmony-static-white)',
+              filter: 'drop-shadow(0 1px 4px rgba(0, 0, 0, 0.3))',
+              '& path': {
+                fill: 'var(--harmony-static-white)'
+              }
             }}
           />
         ) : null}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.module.css
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.module.css
@@ -49,7 +49,13 @@
   position: absolute;
   top: 21px;
   right: 13px;
+  color: var(--harmony-static-white);
+  fill: var(--harmony-static-white);
   filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.3));
+}
+
+.badgeArtist path {
+  fill: var(--harmony-static-white);
 }
 
 .artistInfo {


### PR DESCRIPTION
## Summary

Fixes the mobile web profile artist badge so it renders with the same contrast treatment as the desktop profile badge: white SVG fill and a drop-shadow affordance over the cover photo.

## Issue

On mobile web profile headers, the artist badge SVG could render with the imported icon's default/current fill, which showed up as black instead of white. On low-contrast cover photos this made the badge blend into the image and lose the visual treatment used elsewhere on profile pages.

## Root Cause

The hydrated mobile profile header applied the badge position and drop-shadow, but did not explicitly set the SVG fill/color. The desktop profile path already sets the badge fill to white and applies a drop-shadow. The mobile server-rendered profile path did force a white fill, but used `boxShadow`, which shadows the SVG box rather than the glyph shape.

## Fix

- Added explicit white `color` and `fill` styling for the mobile profile artist badge SVG.
- Added a path-level fill override so the SVG remains white even when the imported SVG carries its own path fill.
- Updated the mobile server-rendered profile badge to use the same white fill and CSS `drop-shadow(...)` treatment as the client mobile and desktop profile paths.

## Platform Inspection

- Desktop web profile already applies white fill plus `drop-shadow(...)` for the artist/label badge.
- Native mobile profile uses a separate white `badgeArtist.svg` asset and renders it over a dark cover-photo overlay, so the same black-fill issue does not apply there.
- The scoped fix is therefore limited to mobile web profile render paths.

## Validation

- `mise exec node@24.10.0 -- npm exec -w @audius/web -- eslint --no-cache --ext=js,jsx,ts,tsx src/pages/profile-page/MobileServerProfilePage.tsx`
- `mise exec node@24.10.0 -- npm exec -w @audius/web -- stylelint src/pages/profile-page/components/mobile/ProfileHeader.module.css`
- Started prod-env Vite with `mise exec node@24.10.0 -- npm run web`.
- Verified mobile-web profile rendering in Chrome via Playwright against `http://localhost:3002/skrillex` with mobile mode forced by the app's dev override.
- Computed badge styles after render: SVG fill `rgb(255, 255, 255)`, path fill `rgb(255, 255, 255)`, filter `drop-shadow(rgba(0, 0, 0, 0.3) 0px 1px 4px)`.

Notes: local rendered QA produced existing dev/prod-environment console noise from external services and browser polyfills, but the target profile route rendered and the badge style assertions passed.
