### PR TITLE
feat(contests): prime entry-count cache from /events/entity

### DIFF
--- a/packages/common/src/api/tan-query/batchers/getEventsByEntityIdBatcher.ts
+++ b/packages/common/src/api/tan-query/batchers/getEventsByEntityIdBatcher.ts
@@ -1,9 +1,11 @@
-import { Id, OptionalId } from '@audius/sdk'
+import { Id, OptionalHashId, OptionalId } from '@audius/sdk'
 import { create, windowScheduler } from '@yornaath/batshit'
 import { memoize } from 'lodash'
 
 import { eventMetadataListFromSDK } from '~/adapters/event'
 import { ID, Event } from '~/models'
+
+import { getRemixesCountQueryKey } from '../remixes/useRemixes'
 
 import { contextCacheResolver } from './contextCacheResolver'
 import { BatchContext } from './types'
@@ -12,12 +14,30 @@ export const getEventsByEntityIdBatcher = memoize(
   (context: BatchContext) =>
     create({
       fetcher: async (entityIds: ID[]): Promise<Event[]> => {
-        const { sdk, currentUserId } = context
+        const { sdk, currentUserId, queryClient } = context
         if (!entityIds.length) return []
-        const { data } = await sdk.events.getEntityEvents({
+        const { data, related } = await sdk.events.getEntityEvents({
           entityId: entityIds.map((entityId) => Id.parse(entityId)),
           userId: OptionalId.parse(currentUserId)
         })
+
+        // Prime the dedicated `useRemixesCount` cache from the entry counts
+        // delivered alongside the event list (keyed by the contest's parent
+        // track hashid). This turns ContestCard's entry-count badge into a
+        // cache hit so surfaces that resolve contests via this endpoint (the
+        // track-page contest section, cold contest pages, web Explore's
+        // featured contests) don't fire a count-only
+        // `/tracks/{id}/remixes?limit=0` per card. Same pattern as
+        // useAllRemixContests / useUserRemixContests.
+        const entryCounts = related?.entryCounts ?? {}
+        for (const [hashedTrackId, count] of Object.entries(entryCounts)) {
+          const trackId = OptionalHashId.parse(hashedTrackId)
+          if (!trackId) continue
+          queryClient.setQueryData(
+            getRemixesCountQueryKey({ trackId, isContestEntry: true }),
+            count
+          )
+        }
 
         return eventMetadataListFromSDK(data)
       },

--- a/packages/sdk/src/sdk/api/generated/default/models/EventsResponse.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/EventsResponse.ts
@@ -19,19 +19,31 @@ import {
     EventFromJSONTyped,
     EventToJSON,
 } from './Event';
+import type { RemixContestsRelated } from './RemixContestsRelated';
+import {
+    RemixContestsRelatedFromJSON,
+    RemixContestsRelatedFromJSONTyped,
+    RemixContestsRelatedToJSON,
+} from './RemixContestsRelated';
 
 /**
- * 
+ *
  * @export
  * @interface EventsResponse
  */
 export interface EventsResponse {
     /**
-     * 
+     *
      * @type {Array<Event>}
      * @memberof EventsResponse
      */
     data?: Array<Event>;
+    /**
+     *
+     * @type {RemixContestsRelated}
+     * @memberof EventsResponse
+     */
+    related?: RemixContestsRelated;
 }
 
 /**
@@ -52,8 +64,9 @@ export function EventsResponseFromJSONTyped(json: any, ignoreDiscriminator: bool
         return json;
     }
     return {
-        
+
         'data': !exists(json, 'data') ? undefined : ((json['data'] as Array<any>).map(EventFromJSON)),
+        'related': !exists(json, 'related') ? undefined : RemixContestsRelatedFromJSON(json['related']),
     };
 }
 
@@ -65,8 +78,9 @@ export function EventsResponseToJSON(value?: EventsResponse | null): any {
         return null;
     }
     return {
-        
+
         'data': value.data === undefined ? undefined : ((value.data as Array<any>).map(EventToJSON)),
+        'related': RemixContestsRelatedToJSON(value.related),
     };
 }
 


### PR DESCRIPTION
## What

Reads the new `related.entry_counts` from `/events/entity` (see [api#916](https://github.com/AudiusProject/api/pull/916)) in `getEventsByEntityIdBatcher` and primes `getRemixesCountQueryKey({ trackId, isContestEntry: true })` — mirroring `useAllRemixContests` / `useUserRemixContests`.

## Why

`ContestCard`'s entry-count badge calls `useRemixesCount({ isContestEntry: true })`. On the grid/list surfaces (Contests page, profile tab, mobile Explore) that cache is already primed by the discovery hooks, so it's a cache hit. But surfaces that resolve a contest through the events-by-entity-id batcher had **no primed count**:

- **Web Explore featured contests** — uses `useExploreContent` (a static curated JSON of track IDs) → renders `<ContestCard>` per ID. Nothing primes the count, so each card fired its own `/tracks/{id}/remixes?only_contest_entries=true&limit=0`. **N count requests per render.**
- **Track-page contest section** and **cold/deep-linked contest pages** — 1 extra count request each.

The batcher already collapses all those cards into a **single** `/events/entity` request (`windowScheduler(10)`), so threading entry counts through it drops the per-card count requests to **zero**.

## Changes

- `getEventsByEntityIdBatcher.ts` — destructure `related`, loop `related.entryCounts`, `queryClient.setQueryData(getRemixesCountQueryKey(...), count)`. Same pattern as the discovery hooks.
- `EventsResponse.ts` (generated SDK model) — thread `related?: RemixContestsRelated` through, matching the swagger change that reuses `remix_contests_related` for `/events/entity`. Regenerated `dist` via `npm run build` (gitignored).

## Test

`tsc --noEmit` passes for both `@audius/sdk` and `@audius/common`.

> Depends on [api#916](https://github.com/AudiusProject/api/pull/916) being deployed (the endpoint must return `related.entry_counts`). Until then the batcher reads `related?.entryCounts ?? {}` and is a safe no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)