### PR TITLE
fix(web): hide cast device row when no Cast/AirPlay target is detected

### DIFF
--- a/packages/web/src/components/cast-button/CastButton.tsx
+++ b/packages/web/src/components/cast-button/CastButton.tsx
@@ -18,7 +18,7 @@ export const CastButton = () => {
   // tab-casts via the system picker. Track an optimistic local flag set when
   // the user successfully picks a device.
   const [pickedCast, setPickedCast] = useState(false)
-  const { supported, state, prompt } = useRemotePlayback()
+  const { supported, available, state, prompt } = useRemotePlayback()
   const isCasting =
     pickedCast || state === 'connected' || state === 'connecting'
   // Safari's `audio.remote.prompt()` opens the AirPlay picker; on Chromium
@@ -85,6 +85,7 @@ export const CastButton = () => {
         isVisible={isOpen}
         anchorRef={anchorRef}
         isCasting={isCasting}
+        castAvailable={available}
         mode={mode}
         onClose={handleClose}
         onSelectThisBrowser={handleSelectThisBrowser}

--- a/packages/web/src/components/cast-button/ConnectPopup.tsx
+++ b/packages/web/src/components/cast-button/ConnectPopup.tsx
@@ -41,6 +41,7 @@ type ConnectPopupProps = {
   isVisible: boolean
   anchorRef: MutableRefObject<HTMLElement | null>
   isCasting: boolean
+  castAvailable: boolean
   mode: 'cast' | 'airplay'
   onClose: () => void
   onSelectThisBrowser: () => void
@@ -95,6 +96,7 @@ export const ConnectPopup = ({
   isVisible,
   anchorRef,
   isCasting,
+  castAvailable,
   mode,
   onClose,
   onSelectThisBrowser,
@@ -212,16 +214,22 @@ export const ConnectPopup = ({
             active={!isCasting}
             onClick={onSelectThisBrowser}
           />
-          <Row
-            label={
-              mode === 'airplay'
-                ? messages.airplayDevices
-                : messages.googleCastDevices
-            }
-            icon={mode === 'airplay' ? IconCastAirplay : IconSpeaker}
-            active={isCasting}
-            onClick={onSelectCastDevices}
-          />
+          {/* Only offer the device row when a target is on the network (or
+              we're already casting, so the user can disconnect). Avoids the
+              confusing "Google Cast devices" option when there's nothing to
+              connect to. */}
+          {castAvailable || isCasting ? (
+            <Row
+              label={
+                mode === 'airplay'
+                  ? messages.airplayDevices
+                  : messages.googleCastDevices
+              }
+              icon={mode === 'airplay' ? IconCastAirplay : IconSpeaker}
+              active={isCasting}
+              onClick={onSelectCastDevices}
+            />
+          ) : null}
         </Flex>
       </Flex>
     </div>,

--- a/packages/web/src/components/cast-button/useRemotePlayback.ts
+++ b/packages/web/src/components/cast-button/useRemotePlayback.ts
@@ -18,6 +18,12 @@ type WebKitAudio = HTMLAudioElement & {
   webkitCurrentPlaybackTargetIsWireless?: boolean
 }
 
+// Safari's AirPlay availability event isn't in lib.dom; it carries an
+// `availability` field that is 'available' when a target is on the network.
+type AirplayAvailabilityEvent = Event & {
+  availability?: 'available' | 'not-available'
+}
+
 const getAudio = (): HTMLAudioElement | null => {
   if (typeof window === 'undefined') return null
   return audioPlayer?.audio ?? window.audio ?? null
@@ -66,6 +72,10 @@ export const useRemotePlayback = () => {
     const remote = getRemote()
     return !!remote && typeof remote.prompt === 'function'
   })
+  // Whether a wireless playback target (Cast/AirPlay device) is actually
+  // reachable on the network right now. Used to hide the device row when
+  // there's nothing to connect to.
+  const [available, setAvailable] = useState<boolean>(false)
 
   useEffect(() => {
     if (safari) {
@@ -128,6 +138,78 @@ export const useRemotePlayback = () => {
     }
   }, [safari])
 
+  // Track whether any wireless target is available on the network.
+  useEffect(() => {
+    if (safari) {
+      const attach = (): (() => void) | undefined => {
+        const audio = getAudio()
+        if (!audio) return undefined
+        const onAvailability = (e: Event) => {
+          setAvailable(
+            (e as AirplayAvailabilityEvent).availability === 'available'
+          )
+        }
+        // Safari fires this on registration with the current availability and
+        // again whenever a target appears/disappears.
+        audio.addEventListener(
+          'webkitplaybacktargetavailabilitychanged',
+          onAvailability
+        )
+        return () =>
+          audio.removeEventListener(
+            'webkitplaybacktargetavailabilitychanged',
+            onAvailability
+          )
+      }
+      // The audio element is created lazily; retry on the next tick if needed.
+      let cleanup = attach()
+      if (!cleanup) {
+        const t = setTimeout(() => {
+          cleanup = attach()
+        }, 0)
+        return () => {
+          clearTimeout(t)
+          cleanup?.()
+        }
+      }
+      return cleanup
+    }
+
+    let cancelled = false
+    let callbackId: number | null = null
+    const attach = () => {
+      const remote = getRemote()
+      if (!remote || typeof remote.watchAvailability !== 'function') {
+        // Can't query availability on this platform — assume a device may be
+        // present so we never hide a working cast flow.
+        setAvailable(true)
+        return
+      }
+      remote
+        .watchAvailability((isAvailable) => setAvailable(isAvailable))
+        .then((id) => {
+          if (cancelled) remote.cancelWatchAvailability(id)
+          else callbackId = id
+        })
+        .catch(() => {
+          // Monitoring unsupported (spec: rejects with NotSupportedError) —
+          // assume available rather than hiding the device row.
+          setAvailable(true)
+        })
+    }
+    let timer: ReturnType<typeof setTimeout> | null = null
+    if (!getRemote()) timer = setTimeout(attach, 0)
+    else attach()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+      const remote = getRemote()
+      if (remote && callbackId != null) {
+        remote.cancelWatchAvailability(callbackId)
+      }
+    }
+  }, [safari])
+
   useEffect(() => {
     dispatch(setIsCasting({ isCasting: state === 'connected' }))
   }, [state, dispatch])
@@ -151,5 +233,5 @@ export const useRemotePlayback = () => {
     }
   }, [safari])
 
-  return { state, supported, prompt }
+  return { state, supported, available, prompt }
 }


### PR DESCRIPTION
## Problem

The player's **Connect** popup always listed a **Google Cast devices** (or **AirPlay devices**) row — even when there were no wireless targets on the network. With nothing to connect to, clicking it just opened an empty system picker, which is confusing.

## Fix

Detect whether a wireless playback target is actually reachable, and only render the device row when one is (or while already casting, so the user can still disconnect). The "This web browser" option always remains.

- **Chromium (Cast):** `RemotePlayback.watchAvailability()` reports availability changes; cleaned up via `cancelWatchAvailability()`.
- **Safari (AirPlay):** the `webkitplaybacktargetavailabilitychanged` event reports `available` / `not-available`.
- If a platform can't report availability (rejects with `NotSupportedError`, or the API is missing), we assume a device may be present so the cast flow is **never** hidden on capable browsers.

The cast icon itself is unchanged — only the in-popup device row is gated.

## Changes
- `useRemotePlayback.ts` — new `available` state + availability-watching effect for both Chromium and Safari paths.
- `CastButton.tsx` — passes `castAvailable` down to the popup.
- `ConnectPopup.tsx` — conditionally renders the device row on `castAvailable || isCasting`.

## Testing
- `tsc --noEmit` and `eslint` pass on the changed files.
- Live browser verification wasn't practical: the cast button only renders in the play bar with an active track, and availability depends on real Cast/AirPlay hardware on the network (absent in a headless preview, where the row correctly stays hidden — the new default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)