### PR TITLE
ci: post release deploy updates to #eng instead of #eng-deploys

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -595,7 +595,7 @@ jobs:
         run: |
           deploying_version=$(jq -r '.version' packages/mobile/package.json)
           job_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          json_content="{ \"blocks\": [{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed co.audius.audiusmusic.releasecandidate <${job_url}|v${deploying_version}> to mobile ios\" } }]}"
+          json_content="{ \"channel\": \"#eng\", \"blocks\": [{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed co.audius.audiusmusic.releasecandidate <${job_url}|v${deploying_version}> to mobile ios\" } }]}"
           curl -f -X POST -H 'Content-type: application/json' --data "$json_content" $SLACK_WEBHOOK
 
   # Android Release Candidate: Build and upload
@@ -821,7 +821,7 @@ jobs:
         run: |
           deploying_version=$(jq -r '.version' packages/mobile/package.json)
           job_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          json_content="{ \"blocks\": [{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed releaseCandidate <${job_url}|v${deploying_version}> to mobile android\" } }]}"
+          json_content="{ \"channel\": \"#eng\", \"blocks\": [{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed releaseCandidate <${job_url}|v${deploying_version}> to mobile android\" } }]}"
           curl -f -X POST -H 'Content-type: application/json' --data "$json_content" $SLACK_WEBHOOK
 
   # iOS Production: Build and upload (requires approval)

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -862,5 +862,5 @@ jobs:
           cd packages/web
           deploying_version=$(jq -r '.version' package.json)
           job_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          json_content="{ \"blocks\": [{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed production <${job_url}|v${deploying_version}> to web \n\" } }]}"
+          json_content="{ \"channel\": \"#eng\", \"blocks\": [{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed production <${job_url}|v${deploying_version}> to web \n\" } }]}"
           curl -f -X POST -H 'Content-type: application/json' --data "$json_content" $SLACK_WEBHOOK


### PR DESCRIPTION
## Summary

Redirects the release/deploy Slack notifications in the web and mobile CI workflows from `#eng-deploys` to `#eng`.

The notifications previously had no `channel` field, so they posted to the default channel configured on the `SLACK_DAILY_DEPLOY_WEBHOOK` incoming webhook (`#eng-deploys`). This adds a `"channel": "#eng"` override to the three deploy notification payloads:

- `.github/workflows/web.yml` — web production deploy
- `.github/workflows/mobile.yml` — mobile iOS release candidate
- `.github/workflows/mobile.yml` — mobile Android release candidate

## Caveat

Channel overrides only work on Slack's **legacy/classic** incoming webhooks. Newer Slack app webhooks ignore the `channel` field and always post to the channel the webhook was bound to. If messages still land in `#eng-deploys` after this merges, the webhook is a modern one and the fix has to be made on the Slack side (repoint the secret, or switch to `chat.postMessage` with a bot token + explicit channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)