### PR TITLE
ci(identity): also push :latest tag to Docker Hub

### DIFF
--- a/.github/workflows/identity.yml
+++ b/.github/workflows/identity.yml
@@ -356,7 +356,9 @@ jobs:
           context: .
           file: packages/identity-service/Dockerfile.prod
           push: true
-          tags: audius/identity-service:${{ github.sha }}
+          tags: |
+            audius/identity-service:${{ github.sha }}
+            audius/identity-service:latest
           build-args: |
             git_sha=${{ github.sha }}
           cache-from: type=gha,scope=identity-service


### PR DESCRIPTION
The auto-upgrader watches for digest changes on the configured imageTag. Every other service uses :latest, but identity-service was pinned to a SHA (c1b0e1708c) so the upgrader never detected new images after the CircleCI->GHA migration. This restores auto-deploy: GHA now pushes :latest on every main merge, and the upgrader tracks :latest.