### PR TITLE
fix(identity-service): upgrade Dockerfile to node:24-alpine

### DIFF
--- a/packages/identity-service/Dockerfile.prod
+++ b/packages/identity-service/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:24-alpine AS base
 
 ARG TURBO_TEAM
 ENV TURBO_TEAM=$TURBO_TEAM


### PR DESCRIPTION
The GHA CI workflow uses Node 24.10.0, but Dockerfile.prod was still on node:18-alpine. A dependency in the workspace now requires node>=24.10.0 (npm error EBADENGINE), causing the Docker push job to fail on every main merge. Bumps the base image to node:24-alpine to match CI.