### PR TITLE
ci(identity): remove Slack alert on identity-service build failure

### DIFF
--- a/.github/workflows/identity.yml
+++ b/.github/workflows/identity.yml
@@ -363,22 +363,3 @@ jobs:
             git_sha=${{ github.sha }}
           cache-from: type=gha,scope=identity-service
           cache-to: type=gha,scope=identity-service,mode=max
-
-      - name: Alert Slack on failure
-        if: failure() && env.SLACK_DAILY_DEPLOY_WEBHOOK != ''
-        env:
-          SLACK_DAILY_DEPLOY_WEBHOOK: ${{ secrets.SLACK_DAILY_DEPLOY_WEBHOOK }}
-          JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          json_content=$(cat <<EOF
-          { "blocks": [
-            { "type": "section",
-              "text": { "type": "mrkdwn",
-                        "text": "Failed to build and push identity-service. Today's release can't move forward until this is resolved. Hint: check <${JOB_URL}|here>" }
-            }
-          ]}
-          EOF
-          )
-          curl -f -X POST -H 'Content-type: application/json' \
-            --data "$json_content" \
-            "$SLACK_DAILY_DEPLOY_WEBHOOK"


### PR DESCRIPTION
## What

Removes the `Alert Slack on failure` step from the identity-service GitHub Actions workflow (`.github/workflows/identity.yml`).

## Why

On every failed identity-service Docker build/push, this step POSTed a message to the daily-deploy Slack webhook:

> Failed to build and push identity-service. Today's release can't move forward until this is resolved. Hint: check here

This was generating repeated noise in the Slack channel. Identity-service CI was migrated from CircleCI to GitHub Actions in #14390, so this workflow is the source of those posts.

## Impact

- Build failures are still fully visible in the GitHub Actions run — only the Slack notification is removed.
- The build/push step itself is untouched.
- The generic CircleCI `push-docker-image` Slack alert (still used by `discovery-provider`) is left in place.

> [!NOTE]
> The underlying identity-service build may itself be failing — this PR only silences the alert noise, it does not fix a failing build. Worth investigating separately if builds are still red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)