### PR TITLE
fix(common): pass freeform genres through to SDK instead of silently falling back to Electronic

### DIFF
--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -41,13 +41,15 @@ import { transformAndCleanList } from './utils'
 const VALID_GENRES = new Set<string>(Object.values(Genre))
 const VALID_MOODS = new Set<string>(Object.values(Mood))
 
-function toSdkGenre(
-  value: string | undefined | ''
-): (typeof Genre)[keyof typeof Genre] | undefined {
+/**
+ * Pass through any non-empty genre string to the SDK. Canonical Genre enum
+ * values are returned as-is; freeform strings are also passed through
+ * unchanged so artists can enter custom genres (up to 100 chars per the
+ * schema).
+ */
+function toSdkGenre(value: string | undefined | ''): string | undefined {
   if (value === undefined || value === '') return undefined
-  return VALID_GENRES.has(value)
-    ? (value as (typeof Genre)[keyof typeof Genre])
-    : undefined
+  return value
 }
 
 function toSdkMood(


### PR DESCRIPTION
## Problem

When an artist typed a freeform genre in the track edit form, it reverted to Electronic after saving.

## Root Cause

toSdkGenre in packages/common/src/adapters/track.ts filtered out any genre string not found in the VALID_GENRES set (the canonical Genre enum), returning undefined. That undefined then fell back to DEFAULT_GENRE = Genre.Electronic before being sent to the SDK.

Before (buggy): return VALID_GENRES.has(value) ? value : undefined
Freeform strings became undefined, which then fell back to 'Electronic'.

## Fix

Pass any non-empty string through unchanged. The SDK already accepts GenreString = Genre | string and the upload schema validates up to 100 chars, so canonical genres continue working and freeform strings are now preserved.

After: return value (any non-empty string passes through)

## Testing

1. Go to release-candidate.audius.co
2. Edit a track you own
3. Type a freeform genre (e.g. Ambient Drone) in the genre field
4. Save - genre should persist as entered
