### PR TITLE
fix(embed): hydrate track list for slug-based playlist/album embeds

### DIFF
--- a/packages/embed/jest.config.cjs
+++ b/packages/embed/jest.config.cjs
@@ -1,0 +1,20 @@
+// Jest config scoped to the embed package's unit tests.
+// Babel presets are declared inline here (rather than a root babel.config.js)
+// so the Vite/esbuild build pipeline is unaffected.
+module.exports = {
+  testEnvironment: 'node',
+  // BedtimeClient touches `window` at import time; jest.setup provides a shim
+  // (the hoisted jsdom environment is an incompatible version in this repo).
+  setupFiles: ['<rootDir>/jest.setup.cjs'],
+  transform: {
+    '^.+\\.(js|jsx)$': [
+      'babel-jest',
+      {
+        presets: [
+          ['@babel/preset-env', { targets: { node: 'current' } }],
+          ['@babel/preset-react', { runtime: 'automatic' }]
+        ]
+      }
+    ]
+  }
+}

--- a/packages/embed/jest.setup.cjs
+++ b/packages/embed/jest.setup.cjs
@@ -1,0 +1,6 @@
+// BedtimeClient assigns `window.audiusSdk` at import time. Provide a minimal
+// `window` so the module can load under the node test environment (the hoisted
+// jsdom environment is an incompatible version in this monorepo).
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = globalThis
+}

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -10,6 +10,7 @@
     "build:prod": "env-cmd -f .env.prod turbo run build && npm run build-api && mv build build-production",
     "build-api": "webpack --config src/api/webpack.config.js -o build/api.js",
     "deploy:prod": "npx wrangler publish --env production",
+    "test": "jest",
     "lint:fix": "eslint --cache --fix --ext=js,jsx,ts,tsx src",
     "lint": "eslint --cache --ext=js,jsx,ts,tsx src",
     "lint:env": "dotenv-linter",

--- a/packages/embed/src/util/BedtimeClient.js
+++ b/packages/embed/src/util/BedtimeClient.js
@@ -112,7 +112,13 @@ export const getCollectionByPermalink = async (handle, slug, type) => {
   const res = await audiusSdk.playlists.getBulkPlaylists({
     permalink: [permalink]
   })
-  return getFormattedCollectionResponse(res.data)
+  const collection = getFormattedCollectionResponse(res.data)
+  if (!collection) return null
+  // The bulk/permalink endpoint resolves collection metadata but does not
+  // hydrate the track list (it returns an empty `tracks` array), which leaves
+  // the embed player with only a header and no playable tracks. Re-fetch the
+  // full collection by its (hash) id to get the populated track list.
+  return getCollectionWithHashId(collection.id)
 }
 
 export const getEntityEvents = async (entityId, entityType) => {

--- a/packages/embed/src/util/BedtimeClient.test.js
+++ b/packages/embed/src/util/BedtimeClient.test.js
@@ -1,0 +1,89 @@
+const mockGetBulkPlaylists = jest.fn()
+const mockGetPlaylist = jest.fn()
+const mockGetBulkTracks = jest.fn()
+
+jest.mock('@audius/sdk', () => ({
+  sdk: () => ({
+    playlists: {
+      getBulkPlaylists: (...args) => mockGetBulkPlaylists(...args),
+      getPlaylist: (...args) => mockGetPlaylist(...args)
+    },
+    tracks: {
+      getBulkTracks: (...args) => mockGetBulkTracks(...args)
+    },
+    events: {}
+  })
+}))
+
+// Avoid loading amplitude-js (and its browser globals) at import time.
+jest.mock('../analytics/analytics', () => ({
+  recordListen: jest.fn()
+}))
+
+const { getCollectionByPermalink } = require('./BedtimeClient')
+
+describe('getCollectionByPermalink', () => {
+  beforeEach(() => {
+    mockGetBulkPlaylists.mockReset()
+    mockGetPlaylist.mockReset()
+  })
+
+  it('re-fetches the full collection by id so the track list is hydrated', async () => {
+    // The bulk/permalink endpoint resolves metadata but returns an empty
+    // `tracks` array (this is what produced the header-only embed bug).
+    mockGetBulkPlaylists.mockResolvedValue({
+      data: [{ id: 'vjgoJWp', playlistName: 'Halleluyah', tracks: [] }]
+    })
+    // Fetching by (hash) id hydrates the full track list.
+    mockGetPlaylist.mockResolvedValue({
+      data: [
+        {
+          id: 'vjgoJWp',
+          playlistName: 'Halleluyah',
+          tracks: [{ id: 't1' }, { id: 't2' }]
+        }
+      ]
+    })
+
+    const collection = await getCollectionByPermalink(
+      'AcidRayn',
+      'halleluyah',
+      'playlist'
+    )
+
+    expect(mockGetBulkPlaylists).toHaveBeenCalledWith({
+      permalink: ['/AcidRayn/playlist/halleluyah']
+    })
+    // Must follow up with a by-id fetch using the resolved hash id.
+    expect(mockGetPlaylist).toHaveBeenCalledWith({ playlistId: 'vjgoJWp' })
+    expect(collection.tracks).toHaveLength(2)
+  })
+
+  it('builds the album permalink with the album path segment', async () => {
+    mockGetBulkPlaylists.mockResolvedValue({
+      data: [{ id: 'vjgoJWp', tracks: [] }]
+    })
+    mockGetPlaylist.mockResolvedValue({
+      data: [{ id: 'vjgoJWp', tracks: [{ id: 't1' }] }]
+    })
+
+    await getCollectionByPermalink('AcidRayn', 'iterations', 'album')
+
+    expect(mockGetBulkPlaylists).toHaveBeenCalledWith({
+      permalink: ['/AcidRayn/album/iterations']
+    })
+  })
+
+  it('returns null without a follow-up fetch when the permalink does not resolve', async () => {
+    mockGetBulkPlaylists.mockResolvedValue({ data: [] })
+
+    const collection = await getCollectionByPermalink(
+      'nobody',
+      'nope',
+      'playlist'
+    )
+
+    expect(collection).toBeNull()
+    expect(mockGetPlaylist).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes #14467

## Bug

Slug-based collection embeds (e.g. `/embed/album/AcidRayn/iterations-of-truth-volume-1-the-foundation`, `/embed/playlist/AcidRayn/halleluyah`) rendered only the header — artwork, title, artist — with no track list or playback controls, while hash-id embeds (e.g. `/embed/album/vjgoJWp`) worked fine.

## Root cause

The embed player resolves slug URLs through `getCollectionByPermalink`, which calls the SDK's `getBulkPlaylists({ permalink })` endpoint. That endpoint returns the collection's metadata **but with an empty `tracks` array** — only `track_count` is set. The hash-id path uses `getPlaylist({ playlistId })`, which hydrates the full track list.

Verified directly against `api.audius.co`:

| Lookup | `track_count` | `tracks.length` |
|---|---|---|
| `GET /v1/playlists?permalink=/AcidRayn/album/iterations-...` | 17 | **0** |
| `GET /v1/playlists/vjgoJWp` | 17 | 17 |
| `GET /v1/playlists?permalink=/AcidRayn/playlist/halleluyah` | 96 | **0** |
| `GET /v1/playlists/RNE1GmG` | 96 | 96 |

Because the header renders from collection metadata but `CollectionPlayerContainer` reads `collection.tracks`, the player came up empty.

## Fix

In [`getCollectionByPermalink`](packages/embed/src/util/BedtimeClient.js), after resolving the permalink to obtain the collection's hash id, re-fetch the full collection by id (`getCollectionWithHashId`) so the track list is hydrated — mirroring the hash-id code path. Returns `null` early if the permalink doesn't resolve.

This adds one extra request only on the slug path (the hash-id path is unchanged). Applies to both playlists and albums, since both resolve through the same function.

## Testing

- Confirmed the API behavior above against production with `curl`.
- Added `packages/embed/src/util/BedtimeClient.test.js` covering: track-list hydration via the follow-up by-id fetch, correct permalink construction for the `album` path segment, and the unresolved-permalink → `null` case. Verified these tests **fail on the pre-fix code** and pass after.
- `npx jest` (3/3 pass) and `eslint` clean on the touched files.

## Notes for reviewer

- The embed package had no test harness. I added a minimal `jest.config.cjs` (+ `jest.setup.cjs` window shim) and a `test` script. Config uses the `node` environment because the monorepo's hoisted `jest-environment-jsdom` is v26 (incompatible with jest 29) and ignores `testEnvironmentOptions.url`; the only DOM dependency at import is `window.audiusSdk`, which the setup shim covers. Babel presets are declared inline in the jest transform so the Vite/esbuild build is untouched.
- **Interpretation called out:** the issue framed this as a "broken slug resolver." The resolver does resolve — it just returned an under-hydrated object. The user-visible symptom (header but no tracks) matches a missing track list, which is what this fixes. If instead the intent was that slug URLs should never have needed a second request, that would be a backend change to populate `tracks` on the permalink endpoint — out of scope for the embed client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)