### PR TITLE
[codex] Add email verification frontend

### DIFF
--- a/packages/common/src/messages/settings.ts
+++ b/packages/common/src/messages/settings.ts
@@ -31,6 +31,7 @@ export const settingsMessages = {
   labelAccountCardTitle: 'Label Account',
   notificationsCardTitle: 'Configure Notifications',
   accountRecoveryCardTitle: 'Resend Recovery Email',
+  emailVerificationCardTitle: 'Email Verification',
   changeEmailCardTitle: 'Change Email',
   changePasswordCardTitle: 'Change Password',
   accountsYouManageTitle: 'Accounts You Manage',
@@ -46,6 +47,8 @@ export const settingsMessages = {
   notificationsCardDescription: 'Review your notification preferences.',
   accountRecoveryCardDescription:
     'Resend your password reset email and store it safely. This email is the only way to recover your account if you forget your password.',
+  emailVerificationCardDescription:
+    'Verify that you can receive email at the address connected to your Audius account.',
   changeEmailCardDescription:
     'Change the email you use to sign in and receive emails.',
   changePasswordCardDescription: 'Change the password to your Audius account.',
@@ -61,6 +64,11 @@ export const settingsMessages = {
   commentSettingsButtonText: 'Comment Settings',
   notificationsButtonText: 'Configure Notifications',
   accountRecoveryButtonText: 'Resend Email',
+  emailVerificationButtonText: 'Resend Verification Email',
+  emailVerificationSent: 'Verification email sent!',
+  emailVerificationAlreadyVerified: 'Your email is already verified.',
+  emailVerificationNotSent:
+    'Unable to send verification email. Please try again!',
   changeEmailButtonText: 'Change Email',
   changePasswordButtonText: 'Change Password',
   desktopAppButtonText: 'Get The App',

--- a/packages/common/src/services/auth/identity.ts
+++ b/packages/common/src/services/auth/identity.ts
@@ -25,6 +25,11 @@ type CreateStripeSessionResponse = {
   status: string
 }
 
+type ResendEmailVerificationResponse = {
+  status: true
+  alreadyVerified?: boolean
+}
+
 enum TransactionMetadataType {
   PURCHASE_SOL_AUDIO_SWAP = 'PURCHASE_SOL_AUDIO_SWAP'
 }
@@ -230,6 +235,19 @@ export class IdentityService {
       throw new Error('No email found')
     }
     return res.email
+  }
+
+  /**
+   * Resend the current user's email verification link.
+   */
+  async resendEmailVerification() {
+    const headers = await this.getAuthHeaders()
+
+    return await this._makeRequest<ResendEmailVerificationResponse>({
+      url: '/email/resend-verification',
+      method: 'post',
+      headers
+    })
   }
 
   /**

--- a/packages/common/src/utils/route.ts
+++ b/packages/common/src/utils/route.ts
@@ -55,6 +55,7 @@ export const HOME_PAGE = '/'
 export const NOT_FOUND_PAGE = '/404'
 export const SIGN_IN_PAGE = '/signin'
 export const SIGN_IN_CONFIRM_EMAIL_PAGE = '/signin/confirm-email'
+export const EMAIL_VERIFICATION_PAGE = '/verify-email'
 export const SIGN_UP_PAGE = '/signup'
 export const SIGN_ON_ALIASES = Object.freeze([
   '/login',
@@ -285,6 +286,7 @@ export const publicSiteRoutes = [
 // ordered list of routes the App attempts to match in increasing order of route selectivity
 export const orderedRoutes = [
   SIGN_IN_PAGE,
+  EMAIL_VERIFICATION_PAGE,
   SIGN_UP_PAGE,
   ...SIGN_ON_ALIASES,
   SIGN_UP_EMAIL_PAGE,

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 import {
   useCurrentAccountUser,
+  useQueryContext,
   useResendRecoveryEmail
 } from '@audius/common/api'
 import { modalsActions, useTierAndVerifiedForUser } from '@audius/common/store'
@@ -43,6 +44,14 @@ const messages = {
   recoveryButtonTitle: 'Resend Recovery Email',
   recoveryEmailSent: 'Recovery Email Sent!',
   recoveryEmailNotSent: 'Unable to send recovery email. Please try again!',
+  emailVerificationTitle: 'Email Verification',
+  emailVerificationDescription:
+    'Verify that you can receive email at the address connected to your Audius account.',
+  emailVerificationButtonTitle: 'Resend Verification Email',
+  emailVerificationSent: 'Verification email sent!',
+  emailVerificationAlreadyVerified: 'Your email is already verified.',
+  emailVerificationNotSent:
+    'Unable to send verification email. Please try again!',
   verifyTitle: 'Verification',
   verifyDescription:
     'Verify your Audius profile by completing identity verification.',
@@ -78,6 +87,9 @@ export const AccountSettingsScreen = () => {
   const styles = useStyles()
   const { toast } = useToast()
   const dispatch = useDispatch()
+  const { identityService } = useQueryContext()
+  const [isSendingVerificationEmail, setIsSendingVerificationEmail] =
+    useState(false)
   const { data: accountData } = useCurrentAccountUser({
     select: (user) => pick(user, ['user_id', 'handle', 'name'])
   })
@@ -101,6 +113,23 @@ export const AccountSettingsScreen = () => {
       onError: () => toast({ content: messages.recoveryEmailNotSent })
     })
   }, [resendRecoveryEmail, toast])
+
+  const handlePressEmailVerification = useCallback(async () => {
+    setIsSendingVerificationEmail(true)
+    try {
+      const result = await identityService.resendEmailVerification()
+      toast({
+        content: result.alreadyVerified
+          ? messages.emailVerificationAlreadyVerified
+          : messages.emailVerificationSent,
+        type: 'info'
+      })
+    } catch (e) {
+      toast({ content: messages.emailVerificationNotSent, type: 'error' })
+    } finally {
+      setIsSendingVerificationEmail(false)
+    }
+  }, [identityService, toast])
 
   const handlePressChangeEmail = useCallback(() => {
     navigation.push('ChangeEmail')
@@ -154,6 +183,14 @@ export const AccountSettingsScreen = () => {
             description={messages.recoveryDescription}
             buttonTitle={messages.recoveryButtonTitle}
             onPress={handlePressRecoveryEmail}
+          />
+          <AccountSettingsItem
+            title={messages.emailVerificationTitle}
+            titleIcon={IconEmailAddress}
+            description={messages.emailVerificationDescription}
+            buttonTitle={messages.emailVerificationButtonTitle}
+            onPress={handlePressEmailVerification}
+            disabled={isSendingVerificationEmail}
           />
           <AccountSettingsItem
             title={messages.verifyTitle}

--- a/packages/web/src/app/web-player/WebPlayer.tsx
+++ b/packages/web/src/app/web-player/WebPlayer.tsx
@@ -219,6 +219,7 @@ const ContestsPage = lazy(() =>
   }))
 )
 const SettingsPage = lazy(() => import('pages/settings-page/SettingsPage'))
+const VerifyEmailPage = lazy(() => import('pages/verify-email-page'))
 const TrackCommentsPage = lazy(() =>
   import('pages/track-page/TrackCommentsPage').then((m) => ({
     default: m.TrackCommentsPage
@@ -294,6 +295,7 @@ const {
   COIN_EXCLUSIVE_TRACKS_PAGE,
   COIN_EXCLUSIVE_TRACKS_MOBILE_ROUTE,
   CHECK_PAGE,
+  EMAIL_VERIFICATION_PAGE,
   TRENDING_PLAYLISTS_PAGE,
   TRENDING_PLAYLISTS_PAGE_LEGACY,
   DEACTIVATE_PAGE,
@@ -1055,6 +1057,10 @@ const WebPlayer = (props: WebPlayerProps) => {
                   path={LABEL_ACCOUNT_SETTINGS_PAGE}
                   element={<SettingsPage containerRef={mainContentRef} />}
                 />
+                <Route
+                  path={EMAIL_VERIFICATION_PAGE}
+                  element={<VerifyEmailPage />}
+                />
                 <Route path={CHECK_PAGE} element={<CheckPage />} />
                 {isMobile ? (
                   <>
@@ -1511,6 +1517,10 @@ const WebPlayer = (props: WebPlayerProps) => {
                 <Route
                   path={LABEL_ACCOUNT_SETTINGS_PAGE}
                   element={<SettingsPage containerRef={mainContentRef} />}
+                />
+                <Route
+                  path={EMAIL_VERIFICATION_PAGE}
+                  element={<VerifyEmailPage />}
                 />
                 <Route path={CHECK_PAGE} element={<CheckPage />} />
                 <Route

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -169,12 +169,19 @@ export const SettingsPage = () => {
     setIsNotificationSettingsModalVisible
   ] = useState(false)
   const [isEmailToastVisible, setIsEmailToastVisible] = useState(false)
+  const [isEmailVerificationToastVisible, setIsEmailVerificationToastVisible] =
+    useState(false)
+  const [isEmailVerificationLoading, setIsEmailVerificationLoading] =
+    useState(false)
   const [isChangePasswordModalVisible, setIsChangePasswordModalVisible] =
     useState(false)
   const [isChangeEmailModalVisible, setIsChangeEmailModalVisible] =
     useState(false)
   const [emailToastText, setEmailToastText] = useState(
     settingsMessages.emailSent
+  )
+  const [emailVerificationToastText, setEmailVerificationToastText] = useState(
+    settingsMessages.emailVerificationSent
   )
   const [, setIsInboxSettingsModalVisible] = useModalState('InboxSettings')
   const [, setIsCommentSettingsModalVisible] = useModalState('CommentSettings')
@@ -258,6 +265,35 @@ export const SettingsPage = () => {
     identityService,
     authService,
     dispatch
+  ])
+
+  const showEmailVerificationToast = useCallback(() => {
+    const fn = async () => {
+      setIsEmailVerificationLoading(true)
+      try {
+        const result = await identityService.resendEmailVerification()
+        setEmailVerificationToastText(
+          result.alreadyVerified
+            ? settingsMessages.emailVerificationAlreadyVerified
+            : settingsMessages.emailVerificationSent
+        )
+        setIsEmailVerificationToastVisible(true)
+      } catch (e) {
+        console.error(e)
+        setEmailVerificationToastText(settingsMessages.emailVerificationNotSent)
+        setIsEmailVerificationToastVisible(true)
+      } finally {
+        setIsEmailVerificationLoading(false)
+      }
+      setTimeout(() => {
+        setIsEmailVerificationToastVisible(false)
+      }, EMAIL_TOAST_TIMEOUT)
+    }
+    fn()
+  }, [
+    setIsEmailVerificationToastVisible,
+    setEmailVerificationToastText,
+    identityService
   ])
 
   const handleDownloadDesktopAppClicked = useCallback(() => {
@@ -603,6 +639,30 @@ export const SettingsPage = () => {
             >
               <Button onClick={showEmailToast} variant='secondary' fullWidth>
                 {settingsMessages.accountRecoveryButtonText}
+              </Button>
+            </Toast>
+          </SettingsCard>
+        ) : null}
+        {!isManagedAccount ? (
+          <SettingsCard
+            icon={<IconEmailAddress color='accent' />}
+            title={settingsMessages.emailVerificationCardTitle}
+            description={settingsMessages.emailVerificationCardDescription}
+          >
+            <Toast
+              text={emailVerificationToastText}
+              open={isEmailVerificationToastVisible}
+              className={styles.cardToast}
+              anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
+              transformOrigin={{ horizontal: 'center', vertical: 'top' }}
+            >
+              <Button
+                onClick={showEmailVerificationToast}
+                variant='secondary'
+                fullWidth
+                isLoading={isEmailVerificationLoading}
+              >
+                {settingsMessages.emailVerificationButtonText}
               </Button>
             </Toast>
           </SettingsCard>

--- a/packages/web/src/pages/settings-page/components/mobile/AccountSettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/mobile/AccountSettingsPage.tsx
@@ -45,6 +45,14 @@ const messages = {
   recoveryButtonTitle: 'Resend Recovery Email',
   recoveryEmailSent: 'Recovery Email Sent!',
   recoveryEmailNotSent: 'Unable to send recovery email. Please try again!',
+  emailVerificationTitle: 'Email Verification',
+  emailVerificationDescription:
+    'Verify that you can receive email at the address connected to your Audius account.',
+  emailVerificationButtonTitle: 'Resend Verification Email',
+  emailVerificationSent: 'Verification email sent!',
+  emailVerificationAlreadyVerified: 'Your email is already verified.',
+  emailVerificationNotSent:
+    'Unable to send verification email. Please try again!',
   verifyTitle: 'Verify Your Account',
   verifyDescription:
     'Verify your Audius profile by completing identity verification',
@@ -140,6 +148,8 @@ const AccountSettingsPage = () => {
   })
   const { userId, handle, name } = accountData ?? {}
   const [showModalSignOut, setShowModalSignOut] = useState(false)
+  const [isSendingVerificationEmail, setIsSendingVerificationEmail] =
+    useState(false)
   const { toast } = useContext(ToastContext)
   const { isVerified } = useTierAndVerifiedForUser(userId)
 
@@ -173,6 +183,22 @@ const AccountSettingsPage = () => {
     [authService, identityService, toast, record]
   )
 
+  const onClickResendVerificationEmail = useCallback(async () => {
+    setIsSendingVerificationEmail(true)
+    try {
+      const result = await identityService.resendEmailVerification()
+      toast(
+        result.alreadyVerified
+          ? messages.emailVerificationAlreadyVerified
+          : messages.emailVerificationSent
+      )
+    } catch (e) {
+      toast(messages.emailVerificationNotSent)
+    } finally {
+      setIsSendingVerificationEmail(false)
+    }
+  }, [identityService, toast])
+
   const goToChangePasswordSettingsPage = useCallback(() => {
     goToRoute(CHANGE_PASSWORD_SETTINGS_PAGE)
   }, [goToRoute])
@@ -205,6 +231,14 @@ const AccountSettingsPage = () => {
           description={messages.recoveryDescription}
           buttonTitle={messages.recoveryButtonTitle}
           onClick={onClickRecover}
+        />
+        <AccountSettingsItem
+          icon={IconEmailAddress}
+          title={messages.emailVerificationTitle}
+          description={messages.emailVerificationDescription}
+          buttonTitle={messages.emailVerificationButtonTitle}
+          onClick={onClickResendVerificationEmail}
+          disabled={isSendingVerificationEmail}
         />
         <AccountSettingsItem
           icon={IconVerified}

--- a/packages/web/src/pages/verify-email-page/VerifyEmailPage.module.css
+++ b/packages/web/src/pages/verify-email-page/VerifyEmailPage.module.css
@@ -1,0 +1,48 @@
+.wrapper {
+  display: flex;
+  min-height: 100%;
+  align-items: center;
+  justify-content: center;
+  padding: var(--harmony-unit-8);
+}
+
+.panel {
+  display: flex;
+  width: min(100%, 480px);
+  flex-direction: column;
+  align-items: center;
+  gap: var(--harmony-unit-6);
+  text-align: center;
+}
+
+.icon {
+  display: flex;
+  height: 64px;
+  width: 64px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--harmony-secondary);
+}
+
+.copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--harmony-unit-3);
+}
+
+.actions {
+  display: flex;
+  width: 100%;
+  max-width: 360px;
+  flex-direction: column;
+  gap: var(--harmony-unit-3);
+}
+
+@media (max-width: 480px) {
+  .wrapper {
+    align-items: flex-start;
+    padding: var(--harmony-unit-6);
+    padding-top: var(--harmony-unit-12);
+  }
+}

--- a/packages/web/src/pages/verify-email-page/VerifyEmailPage.tsx
+++ b/packages/web/src/pages/verify-email-page/VerifyEmailPage.tsx
@@ -1,0 +1,113 @@
+import { route } from '@audius/common/utils'
+import {
+  Button,
+  IconCheck,
+  IconEmailAddress,
+  IconError,
+  Text
+} from '@audius/harmony'
+import { Link, useSearchParams } from 'react-router'
+
+import Page from 'components/page/Page'
+
+import styles from './VerifyEmailPage.module.css'
+
+const { SETTINGS_PAGE, SIGN_IN_PAGE } = route
+
+const messages = {
+  title: 'Email Verification',
+  successTitle: 'Email Verified',
+  successDescription:
+    'Your email address has been verified. You can keep using Audius.',
+  expiredTitle: 'Verification Link Expired',
+  expiredDescription:
+    'This verification link is no longer valid. Sign in and resend the verification email from settings.',
+  invalidTitle: 'Invalid Verification Link',
+  invalidDescription:
+    'This verification link is invalid or has already been used.',
+  errorTitle: 'Verification Failed',
+  errorDescription:
+    'Something went wrong while verifying your email. Please try again from settings.',
+  settings: 'Go To Settings',
+  signIn: 'Sign In'
+}
+
+type VerificationStatus = 'success' | 'expired' | 'invalid' | 'error'
+
+const statusConfig: Record<
+  VerificationStatus,
+  {
+    title: string
+    description: string
+    Icon: typeof IconCheck
+  }
+> = {
+  success: {
+    title: messages.successTitle,
+    description: messages.successDescription,
+    Icon: IconCheck
+  },
+  expired: {
+    title: messages.expiredTitle,
+    description: messages.expiredDescription,
+    Icon: IconEmailAddress
+  },
+  invalid: {
+    title: messages.invalidTitle,
+    description: messages.invalidDescription,
+    Icon: IconError
+  },
+  error: {
+    title: messages.errorTitle,
+    description: messages.errorDescription,
+    Icon: IconError
+  }
+}
+
+const getStatus = (status: string | null): VerificationStatus => {
+  if (
+    status === 'success' ||
+    status === 'expired' ||
+    status === 'invalid' ||
+    status === 'error'
+  ) {
+    return status
+  }
+  return 'invalid'
+}
+
+export const VerifyEmailPage = () => {
+  const [searchParams] = useSearchParams()
+  const status = getStatus(searchParams.get('status'))
+  const { title, description, Icon } = statusConfig[status]
+
+  return (
+    <Page title={messages.title} description={title}>
+      <div className={styles.wrapper}>
+        <div className={styles.panel}>
+          <div className={styles.icon}>
+            <Icon color={status === 'success' ? 'staticWhite' : 'default'} />
+          </div>
+          <div className={styles.copy}>
+            <Text variant='heading' size='l'>
+              {title}
+            </Text>
+            <Text variant='body' size='l'>
+              {description}
+            </Text>
+          </div>
+          <div className={styles.actions}>
+            <Button variant='primary' fullWidth asChild>
+              <Link to={SETTINGS_PAGE}>{messages.settings}</Link>
+            </Button>
+            <Button variant='secondary' fullWidth asChild>
+              <Link to={SIGN_IN_PAGE}>{messages.signIn}</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Page>
+  )
+}
+
+export default VerifyEmailPage

--- a/packages/web/src/pages/verify-email-page/index.ts
+++ b/packages/web/src/pages/verify-email-page/index.ts
@@ -1,0 +1,2 @@
+export { default } from './VerifyEmailPage'
+export * from './VerifyEmailPage'


### PR DESCRIPTION
## Summary
- Add the `/verify-email` web route used by Identity Service email verification redirects.
- Add status-specific copy for success, expired, invalid, and error verification outcomes.
- Add email verification resend actions to desktop settings, mobile web settings, and React Native account settings.
- Add a shared `IdentityService.resendEmailVerification()` client method.

## Impact
Users who click verification links now land on a real app page, and signed-in users can resend the verification email from account settings. The new email verification card is separate from the existing profile/Persona verification flow.

## Validation
- `npm run typecheck` in `packages/web`
- `npm run typecheck` in `packages/mobile`
- `npm run lint` in `packages/web`
- `npm run stylelint -- src/pages/verify-email-page/VerifyEmailPage.module.css` in `packages/web`
- Focused ESLint on touched common, web, and mobile files
- Browser checked `http://localhost:3000/verify-email?status=success` and `status=expired`

## Notes
- Full `packages/common` typecheck/lint and full `packages/mobile` lint currently fail on unrelated pre-existing issues outside this patch.
