### PR TITLE
fix(identity): copy loadAudiusSdk.cjs into build output

### DIFF
--- a/packages/identity-service/package.json
+++ b/packages/identity-service/package.json
@@ -16,7 +16,7 @@
     "test:debug": "./scripts/run-tests.sh -d",
     "coverage": "nyc npm run test",
     "report": "nyc report --reporter=html",
-    "copyfiles": "cp -r ./src/emails ./build/src",
+    "copyfiles": "cp -r ./src/emails ./build/src && cp ./loadAudiusSdk.cjs ./build/loadAudiusSdk.cjs",
     "build": "tsc --project tsconfig.build.json && npm run copyfiles",
     "lint": "eslint . --ext .ts,.js,.jsx,.tsx",
     "lint:fix": "eslint . --ext .ts,.js,.jsx,.tsx --fix",

--- a/packages/identity-service/package.json
+++ b/packages/identity-service/package.json
@@ -16,7 +16,7 @@
     "test:debug": "./scripts/run-tests.sh -d",
     "coverage": "nyc npm run test",
     "report": "nyc report --reporter=html",
-    "copyfiles": "cp -r ./src/emails ./build/src && cp ./loadAudiusSdk.cjs ./build/loadAudiusSdk.cjs",
+    "copyfiles": "cp -r ./src/emails ./build/src && cp -r ./src/data ./build/src && cp ./loadAudiusSdk.cjs ./build/loadAudiusSdk.cjs",
     "build": "tsc --project tsconfig.build.json && npm run copyfiles",
     "lint": "eslint . --ext .ts,.js,.jsx,.tsx",
     "lint:fix": "eslint . --ext .ts,.js,.jsx,.tsx --fix",


### PR DESCRIPTION
## Problem

The identity-service pod crashes on startup with:

```
Error: Cannot find module '/app/packages/identity-service/build/loadAudiusSdk.cjs'
Require stack:
- /app/packages/identity-service/build/src/index.js
```

## Root cause

The production container runs the compiled entrypoint `node build/src/index.js` (`scripts/start.sh`). That file requires the SDK loader via a path relative to `__dirname`:

```js
const { loadAudiusSdk } = require(
  path.join(__dirname, '..', 'loadAudiusSdk.cjs')
)
```

The `..` resolves differently depending on where the entrypoint physically lives:

- **Dev** (`ts-node-dev` runs `src/index.ts`): `__dirname` = `identity-service/src` → resolves to package-root `loadAudiusSdk.cjs` ✓
- **Prod** (`node` runs `build/src/index.js`): `__dirname` = `identity-service/build/src` → resolves to `build/loadAudiusSdk.cjs` ✗

`loadAudiusSdk.cjs` deliberately lives outside `src/` as a plain `.cjs` file (so `ts-node-dev` doesn't transpile its `import()` into `require()` and trigger `ERR_REQUIRE_ESM`). Because it isn't a `.ts` file, `tsc` never emits it into `build/`, and the `copyfiles` build step only copied `src/emails`. So `build/loadAudiusSdk.cjs` was never present in the production image → `MODULE_NOT_FOUND`.

## Fix

Extend the `copyfiles` script to also copy `loadAudiusSdk.cjs` into `build/`, so the existing relative `require('../loadAudiusSdk.cjs')` resolves correctly in both dev and prod.

## Verification

- Ran the build + `copyfiles` locally and confirmed `build/loadAudiusSdk.cjs` is produced.
- Confirmed the module loads and exports `loadAudiusSdk` (a function).

https://claude.ai/code/session_011oMzUJoMTNRaGUh7qPt1jp

---
_Generated by [Claude Code](https://claude.ai/code/session_011oMzUJoMTNRaGUh7qPt1jp)_