### PR TITLE
feat(mobile): ping last_active_at on app foreground

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -392,6 +392,31 @@ export const audiusBackend = ({
     }
   }
 
+  async function pingActivity({
+    sdk,
+    userId
+  }: {
+    sdk: AudiusSdkWithServices
+    userId: number
+  }) {
+    try {
+      const { data, signature } = await signAPIRequest({ sdk })
+      if (!signature) return
+      const encodedUserId = encodeHashId(userId)
+      if (!encodedUserId) return
+      const base = env.API_URL.replace(/\/$/, '')
+      await fetch(`${base}/v1/users/me/ping?user_id=${encodedUserId}`, {
+        method: 'POST',
+        headers: {
+          [AuthHeaders.Message]: data,
+          [AuthHeaders.Signature]: signature
+        }
+      })
+    } catch {
+      // Fire-and-forget
+    }
+  }
+
   async function signAPIRequest({
     sdk,
     input
@@ -1181,6 +1206,7 @@ export const audiusBackend = ({
     getSignature,
     getWAudioBalance,
     identityServiceUrl,
+    pingActivity,
     registerDeviceToken,
     reportNotificationCampaignPushOpen,
     sendTokens,

--- a/packages/mobile/src/hooks/useActivityPing.ts
+++ b/packages/mobile/src/hooks/useActivityPing.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react'
+
+import { useCurrentUserId, useQueryContext } from '@audius/common/api'
+
+import { useEnterForeground } from 'app/hooks/useAppState'
+import { audiusBackendInstance } from 'app/services/audius-backend-instance'
+
+export const useActivityPing = () => {
+  const { data: currentUserId } = useCurrentUserId()
+  const { audiusSdk } = useQueryContext()
+
+  useEnterForeground(
+    useCallback(async () => {
+      if (!currentUserId) return
+      try {
+        const sdk = await audiusSdk()
+        await audiusBackendInstance.pingActivity({
+          sdk,
+          userId: currentUserId
+        })
+      } catch {
+        // Fire-and-forget
+      }
+    }, [currentUserId, audiusSdk])
+  )
+}

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -40,6 +40,8 @@ import { OAuthScreen } from '../oauth-screen/OAuthScreen'
 import { ResetPasswordModalScreen } from '../reset-password-screen'
 import { SignOnStack } from '../sign-on-screen'
 
+import { useActivityPing } from 'app/hooks/useActivityPing'
+
 import { StatusBar } from './StatusBar'
 import { useResetNotificationBadgeCount } from './useResetNotificationBadgeCount'
 
@@ -97,6 +99,7 @@ export const RootScreen = () => {
   )
 
   useResetNotificationBadgeCount()
+  useActivityPing()
 
   // Reset the player on first mount so a crash doesn't leak previous playback
   // state into the next session. PAY-1412.


### PR DESCRIPTION
## Summary
- Adds `pingActivity` function to `AudiusBackend` — fire-and-forget POST to `/v1/users/me/ping` with signature auth
- Adds `useActivityPing` hook that fires on every foreground transition when user is logged in
- Wires the hook into `RootScreen` alongside `useResetNotificationBadgeCount`

## Related PRs
- **api**: feat: add last_active_at column and /v1/users/me/ping endpoint
- **pedalboard**: notifications: query users.last_active_at for inactive user detection

## Test plan
- [ ] Open app from background, verify network request to `/v1/users/me/ping` fires
- [ ] Verify no request fires when logged out
- [ ] Verify app behavior is unaffected if ping fails (fire-and-forget)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit --project packages/mobile/tsconfig.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)