### PR TITLE
Remove legacy creator node SDK defaults

### DIFF
--- a/.changeset/remove-legacy-creatornodes.md
+++ b/.changeset/remove-legacy-creatornodes.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Generate the production SDK storage-node defaults from the canonical Audius storage-node hostname, removing `creatornode2.audius.co` and `creatornode3.audius.co`.

--- a/packages/sdk/src/sdk/config/production.ts
+++ b/packages/sdk/src/sdk/config/production.ts
@@ -10,16 +10,8 @@ export const productionConfig: SdkServicesConfig = {
     "apiEndpoint": "https://api.audius.co",
     "storageNodes": [
       {
-        "endpoint": "https://creatornode3.audius.co",
-        "delegateOwnerWallet": "0x0C32BE6328578E99b6F06E0e7A6B385EB8FC13d1"
-      },
-      {
         "endpoint": "https://creatornode.audius.co",
         "delegateOwnerWallet": "0xc8d0C29B6d540295e8fc8ac72456F2f4D41088c8"
-      },
-      {
-        "endpoint": "https://creatornode2.audius.co",
-        "delegateOwnerWallet": "0xf686647E3737d595C60c6DE2f5F90463542FE439"
       }
     ],
     "antiAbuseOracleNodes": {

--- a/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
+++ b/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
@@ -125,6 +125,16 @@ const CONTENT_NODE_SERVICE_TYPE =
   '0x636f6e74656e742d6e6f64650000000000000000000000000000000000000000' as const
 const VALIDATOR_SERVICE_TYPE =
   '0x76616c696461746f720000000000000000000000000000000000000000000000' as const
+const AUDIUS_STORAGE_NODE_HOSTNAME = 'creatornode.audius.co'
+
+const isAudiusStorageNodeEndpoint = (endpoint: string) => {
+  try {
+    const { hostname } = new URL(endpoint)
+    return hostname === AUDIUS_STORAGE_NODE_HOSTNAME
+  } catch {
+    return false
+  }
+}
 
 const generateServicesConfig = async (
   config: SdkServicesConfig
@@ -184,17 +194,12 @@ const generateServicesConfig = async (
   const minVersion = hexToString(versionHex, { size: 32 })
 
   config.network.minVersion = minVersion
-  // Filter to only *.audius.co storage nodes to improve upload success rates —
-  // third-party nodes have historically had lower reliability.
+  // Use the canonical Audius-operated storage node to improve upload success
+  // rates while avoiding lower-reliability third-party nodes.
   config.network.storageNodes = storageNodes
-    .filter(([_ownerWallet, endpoint]: any) => {
-      try {
-        const { hostname } = new URL(endpoint)
-        return hostname.endsWith('.audius.co')
-      } catch {
-        return false
-      }
-    })
+    .filter(([_ownerWallet, endpoint]: any) =>
+      isAudiusStorageNodeEndpoint(endpoint)
+    )
     .map(([_ownerWallet, endpoint, _blockNumber, delegateOwnerWallet]: any) => ({
       endpoint,
       delegateOwnerWallet


### PR DESCRIPTION
## Summary
- Update `generateServicesConfig.ts` so generated production SDK storage-node defaults use the canonical Audius storage-node hostname.
- Regenerate/update the emitted production SDK config so `creatornode2.audius.co` and `creatornode3.audius.co` are no longer in `packages/sdk`.
- Add a patch changeset for `@audius/sdk`.

## Validation
- `rg -n "creatornode2|creatornode3" packages/sdk` has no matches.
- `git diff --check origin/main...HEAD`

## Not run
- `npm run sdk:config -w @audius/sdk`, package typecheck, or tests; this checkout has no `node_modules`, and no npm/yarn/pnpm/corepack executable is available on PATH.