### PR TITLE
fix(common): pass freeform genres through to SDK instead of reverting to Electronic

### DIFF
--- a/.changeset/fix-freeform-genre-adapter.md
+++ b/.changeset/fix-freeform-genre-adapter.md
@@ -1,0 +1,5 @@
+---
+'@audius/common': patch
+---
+
+Fix freeform/custom track genres silently reverting to Electronic on save. `toSdkGenre` in the track adapter filtered out any value not in the canonical `Genre` enum and returned `undefined`, which then fell back to `DEFAULT_GENRE` (Electronic) before reaching the SDK. Now any non-empty genre string is passed through unchanged (the SDK upload schema already caps it at 100 chars), so custom genres entered by artists are preserved end-to-end.

--- a/packages/common/src/adapters/track.test.ts
+++ b/packages/common/src/adapters/track.test.ts
@@ -30,4 +30,26 @@ describe('trackMetadataForUploadToSdk', () => {
 
     expect(result.allowedApiKeys).toBeNull()
   })
+
+  it('passes a freeform/custom genre through to the SDK unchanged', () => {
+    const result = trackMetadataForUploadToSdk(
+      makeMetadata({ genre: 'Ambient Drone' })
+    )
+
+    expect(result.genre).toBe('Ambient Drone')
+  })
+
+  it('preserves a canonical genre', () => {
+    const result = trackMetadataForUploadToSdk(
+      makeMetadata({ genre: Genre.HipHopRap })
+    )
+
+    expect(result.genre).toBe(Genre.HipHopRap)
+  })
+
+  it('falls back to Electronic only when genre is empty', () => {
+    const result = trackMetadataForUploadToSdk(makeMetadata({ genre: '' }))
+
+    expect(result.genre).toBe(Genre.Electronic)
+  })
 })

--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -38,16 +38,19 @@ import { repostFromSDK } from './repost'
 import { userMetadataFromSDK } from './user'
 import { transformAndCleanList } from './utils'
 
-const VALID_GENRES = new Set<string>(Object.values(Genre))
 const VALID_MOODS = new Set<string>(Object.values(Mood))
 
-function toSdkGenre(
-  value: string | undefined | ''
-): (typeof Genre)[keyof typeof Genre] | undefined {
+/**
+ * Pass through any non-empty genre string to the SDK. Canonical Genre enum
+ * values are returned as-is; freeform strings are also passed through
+ * unchanged so artists can enter custom genres (the SDK upload schema caps
+ * them at 100 chars). Previously this filtered out any value not in the
+ * canonical Genre enum, which caused custom genres to silently fall back to
+ * Electronic.
+ */
+function toSdkGenre(value: string | undefined | ''): string | undefined {
   if (value === undefined || value === '') return undefined
-  return VALID_GENRES.has(value)
-    ? (value as (typeof Genre)[keyof typeof Genre])
-    : undefined
+  return value
 }
 
 function toSdkMood(


### PR DESCRIPTION
## Problem

When an artist enters a freeform/custom genre on the track edit/upload form, it silently reverts to **Electronic** after saving.

## Root cause

`toSdkGenre` in `packages/common/src/adapters/track.ts` filtered out any value not in the canonical `Genre` enum and returned `undefined`. That `undefined` then fell back to `DEFAULT_GENRE = Genre.Electronic` before being sent to the SDK:

```ts
// before
return VALID_GENRES.has(value) ? value : undefined   // custom genre → undefined → Electronic
```

This is the last missing piece of the freeform-genres feature. The backend already accepts any non-empty genre string up to 100 chars:
- Go API — `feat(tracks): allow custom genres; cap at 100 chars` (#879)
- ETL indexer — OpenAudio/go-openaudio#351
- SDK upload schema + `SelectGenreField` rewrite — #14424 (merged)

…but the web write-path adapter still corrupted custom genres to Electronic, so the feature wasn't actually live end-to-end on web.

## Fix

Pass any non-empty genre string through unchanged. The empty case still falls back to Electronic (genre is required). Removes the now-unused `VALID_GENRES` set and adds regression tests.

## Note

Re-applies the fix from #14465, which was **closed inadvertently** after the backend half merged — there was no superseding PR and `main` still had the bug.

## Validation
- `tsc --noEmit` — no new errors (one pre-existing unrelated `Event.ts` error remains on `main`)
- `eslint` — clean
- `vitest src/adapters/track.test.ts` — 5/5 pass (added 3 regression tests: freeform passthrough, canonical preserved, empty → Electronic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)