### PR TITLE
Fix signup loading after account creation

### DIFF
--- a/packages/identity-service/src/authMiddleware.js
+++ b/packages/identity-service/src/authMiddleware.js
@@ -11,6 +11,68 @@ const models = require('./models')
 const audiusLibsWrapper = require('./audiusLibsInstance')
 const { encodeHashId, decodeHashId } = require('./utils/hashIds')
 
+const SDK_USER_LOOKUP_TIMEOUT_MS = 3000
+
+const withTimeout = (promise, ms, message) => {
+  let timeoutId
+  const timeout = new Promise((_resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), ms)
+  })
+
+  return Promise.race([
+    promise,
+    timeout
+  ]).finally(() => clearTimeout(timeoutId))
+}
+
+const getUserAccountForWallet = async ({
+  req,
+  walletAddress,
+  encodedDataMessage,
+  signature
+}) => {
+  const audiusSdk = req.app.get('audiusSdk')
+  const usersApi = audiusSdk?.users ?? audiusSdk?.full?.users
+
+  if (!usersApi) {
+    throw new Error('Audius SDK users API is unavailable')
+  }
+
+  return withTimeout(
+    usersApi.getUserAccount({
+      wallet: walletAddress,
+      encodedDataMessage,
+      encodedDataSignature: signature
+    }),
+    SDK_USER_LOOKUP_TIMEOUT_MS,
+    'audiusSdk.users.getUserAccount timed out'
+  )
+}
+
+const backfillUserFromAccount = async ({
+  req,
+  user,
+  walletAddress,
+  encodedDataMessage,
+  signature
+}) => {
+  const res = await getUserAccountForWallet({
+    req,
+    walletAddress,
+    encodedDataMessage,
+    signature
+  })
+  const accountUser = res.data.user
+  const userId = decodeHashId(accountUser.id)
+  const handle = accountUser.handle
+
+  return user.update({
+    blockchainUserId: userId,
+    handle,
+    isGuest: !handle
+  })
+}
+
 /**
  * Queries for whether the wallet address has privilege to act as actingUserId
  * @param {number} managerWalletAddress
@@ -114,18 +176,12 @@ async function authMiddleware(req, res, next) {
       // ensuring that the user.handle always represents the latest state on chain
       if (!user.blockchainUserId || !user.handle) {
         try {
-          const res = await req.app.get('audiusSdk').full.users.getUserAccount({
-            wallet: walletAddress,
+          user = await backfillUserFromAccount({
+            req,
+            user,
+            walletAddress,
             encodedDataMessage,
-            encodedDataSignature: signature
-          })
-          const discprovUser = res.data.user
-          const userId = decodeHashId(discprovUser.id)
-          const handle = discprovUser.handle
-          user = await user.update({
-            blockchainUserId: userId,
-            handle,
-            isGuest: !handle
+            signature
           })
         } catch (e) {
           req.logger.error(e, 'Failed to update blockchainUserId/handle')
@@ -181,18 +237,12 @@ const parameterizedAuthMiddleware = ({ shouldRespondBadRequest }) => {
 
       if (!user.blockchainUserId || !user.handle) {
         try {
-          const res = await req.app.get('audiusSdk').full.users.getUserAccount({
-            wallet: walletAddress,
+          user = await backfillUserFromAccount({
+            req,
+            user,
+            walletAddress,
             encodedDataMessage,
-            encodedDataSignature: signature
-          })
-          const discprovUser = res.data.user
-          const userId = decodeHashId(discprovUser.id)
-          const handle = discprovUser.handle
-          user = await user.update({
-            blockchainUserId: userId,
-            handle,
-            isGuest: !handle
+            signature
           })
         } catch (e) {
           req.logger.error(e, 'Failed to update blockchainUserId/handle')

--- a/packages/identity-service/src/routes/idSignals.js
+++ b/packages/identity-service/src/routes/idSignals.js
@@ -79,6 +79,13 @@ module.exports = function (app) {
     handleResponse(async (req) => {
       const { blockchainUserId, handle } = req.user
 
+      if (!handle) {
+        req.logger.warn(
+          `idSignals | record_ip | Skipping IP record for user with id ${blockchainUserId} because handle is missing`
+        )
+        return successResponse()
+      }
+
       try {
         const userIP = getIP(req)
         req.logger.info(

--- a/packages/web/src/pages/sign-up-page/pages/LoadingAccountPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/LoadingAccountPage.tsx
@@ -1,5 +1,9 @@
 import { useEffect } from 'react'
 
+import {
+  selectIsAccountComplete,
+  useCurrentAccountUser
+} from '@audius/common/api'
 import { route } from '@audius/common/utils'
 import { Flex } from '@audius/harmony'
 import { useSelector } from 'react-redux'
@@ -26,10 +30,15 @@ export const LoadingAccountPage = () => {
   const isFastReferral = useFastReferral()
   const accountReady = useSelector(getAccountReady)
   const accountCreationStatus = useSelector(getStatus)
+  const { data: hasCompleteAccount = false } = useCurrentAccountUser({
+    select: selectIsAccountComplete
+  })
 
   const isAccountReady = isFastReferral
-    ? accountReady
-    : accountReady || accountCreationStatus === EditingStatus.SUCCESS
+    ? accountReady || hasCompleteAccount
+    : accountReady ||
+      hasCompleteAccount ||
+      accountCreationStatus === EditingStatus.SUCCESS
 
   useEffect(() => {
     if (isAccountReady) {


### PR DESCRIPTION
## Summary
- Fix the signup loading page so it finishes once the current account query reports an indexed, complete account.
- Fix identity-service auth middleware to backfill provisional users through the current SDK shape: `audiusSdk.users.getUserAccount(...)`, with a legacy `full.users` fallback and a 3s timeout.
- Keep `/record_ip` from 500ing if a request arrives before identity has a handle.

## Root cause
- The signup client writes the handle in the create-user EntityManager metadata and API can later return it from `/v1/users/account/:wallet`.
- Identity `/user` only creates the provisional row. The intended modern path is auth middleware backfilling `blockchainUserId` and `handle` from `getUserAccount`.
- Identity now loads `@audius/sdk` via `sdk(...)`, which exposes `users` at the top level. The middleware still called `audiusSdk.full.users`, so the backfill failed and identity rows stayed null.

## Testing
- `node --check packages/identity-service/src/authMiddleware.js`
- `node --check packages/identity-service/src/routes/idSignals.js`
- `git diff --check`

Note: the normal package test runner was not available in this local worktree because `npm`, `pnpm`, `yarn`, and `corepack` are absent.