### PR TITLE
fix(feed): prevent For You feed from blanking on tab switch or window focus

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
+++ b/packages/common/src/api/tan-query/lineups/useForYouFeed.ts
@@ -97,8 +97,9 @@ export const useForYouFeed = (
       )
     },
     select: (data) => data?.pages.flat(),
+    staleTime: Infinity,
     ...options,
-    enabled: options?.enabled !== false && currentUserId !== null
+    enabled: options?.enabled !== false && currentUserId != null
   })
 
   const data = query.data ?? []
@@ -109,7 +110,7 @@ export const useForYouFeed = (
   // When the query is disabled, react-query keeps isPending/isLoading true
   // (data is undefined). Surface them as false so consumers can render an
   // empty state instead of an indefinite loading state.
-  const isDisabled = currentUserId === null || options?.enabled === false
+  const isDisabled = currentUserId == null || options?.enabled === false
 
   return {
     data,


### PR DESCRIPTION
## Summary

Fixes the For You feed going blank when the user swipes back to the For You tab or when the window regains focus. Two bugs:

1. **`staleTime` defaulted to 0** — every time the query became "observed" again (tab switch, window focus), React Query triggered a background refetch. During that refetch the feed briefly returned `[]`, blanking the UI. Fixed by setting `staleTime: Infinity` so cached pages are always considered fresh. Pagination via `fetchNextPage` is unaffected by `staleTime`.

2. **`currentUserId !== null` allowed `undefined` through** — `useCurrentUserId` returns `undefined` while auth is still resolving, not `null`. The strict `!== null` check let the query fire immediately with no user ID, caching an empty `[]` result. Changed to `!= null` (loose equality) so both `null` and `undefined` correctly disable the query until auth resolves.

These are the same two fixes PR #14470 applied to `useFeed`. Commit `3d65667e35` had this fix on a diverged branch that never merged. PR #14473 (PagerView swipe) made the stale-refetch path reliably reproducible since it enabled smooth swiping between feed tabs.

## Test plan

- [ ] Open the app, navigate to For You feed, verify it loads
- [ ] Swipe to Following tab and back to For You — feed should remain populated, not flash blank
- [ ] Background and foreground the app — For You feed should not blank
- [ ] Pull to refresh still works
- [ ] Log out and back in — feed reloads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)