### PR TITLE
fix(upload): make ContextualMenu Save button respond to clicks

### DIFF
--- a/packages/web/src/components/data-entry/ContextualMenu.tsx
+++ b/packages/web/src/components/data-entry/ContextualMenu.tsx
@@ -68,6 +68,15 @@ const MenuForm = (props: MenuFormProps) => {
   const { resetForm, errors, initialStatus, status, setStatus } =
     useFormikContext()
 
+  // The HTML `id`/`form` attribute association requires an id with no
+  // whitespace. Labels like "Track Privacy" contain spaces, which makes the
+  // `<Form>`/submit-button association silently fail so the Save button does
+  // nothing on click. Slugify the label into a valid id used for both ends.
+  const formId = useMemo(
+    () => label.replace(/[^\w-]+/g, '-').replace(/^-+|-+$/g, '') || 'menu-form',
+    [label]
+  )
+
   const handleCancel = useCallback(() => {
     resetForm()
     onClose()
@@ -93,7 +102,7 @@ const MenuForm = (props: MenuFormProps) => {
         <ModalTitle title={label} icon={icon} />
       </ModalHeader>
       <ModalContent>
-        <Form id={label}>{menuFields}</Form>
+        <Form id={formId}>{menuFields}</Form>
       </ModalContent>
       <ModalFooter className={styles.footer}>
         {errorMessage ? (
@@ -103,7 +112,7 @@ const MenuForm = (props: MenuFormProps) => {
             </Text>
           </Box>
         ) : null}
-        <Button variant='primary' form={label} type='submit'>
+        <Button variant='primary' form={formId} type='submit'>
           {messages.save}
         </Button>
       </ModalFooter>


### PR DESCRIPTION
## Problem

During an upload-flow test on release-candidate, the **Track Privacy** modal's **Save** button was unresponsive to normal clicks — it required a JS workaround to dismiss.

## Root cause

In [`ContextualMenu.tsx`](packages/web/src/components/data-entry/ContextualMenu.tsx), the modal `label` was used directly as both the form's `id` and the submit button's `form` attribute:

```tsx
<Form id={label}>{menuFields}</Form>
...
<Button variant='primary' form={label} type='submit'>Save</Button>
```

The Save button lives in the `ModalFooter`, outside the `<Form>`, and relies on the HTML `form` attribute to associate with the form by `id`. But labels like `"Track Privacy"`, `"Price & Audience"`, and `"Stems & Downloads"` contain whitespace, which is **invalid in an HTML `id`**. The `form`/`id` association silently fails, so a normal submit-button click never submits the form — the modal appears frozen.

This was a latent bug affecting every multi-word ContextualMenu modal; Track Privacy is one instance.

## Fix

Slugify the `label` into a whitespace-free `formId` (stripping non-word characters) and use it for both the `<Form id>` and the button's `form` attribute, so the association resolves and Save works. The human-readable `label` is still shown as the modal title.

## Verification

- `npm run verify` in `packages/web` passes (typecheck, lint, stylelint all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)