### PR TITLE
fix(mobile): stabilize collaborator field deps

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/fields/CollaboratorField.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/CollaboratorField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { useCurrentUserId, useSearchUserResults } from '@audius/common/api'
 import type { User, UserMetadata } from '@audius/common/models'
@@ -26,7 +26,7 @@ const messages = {
  */
 export const CollaboratorField = () => {
   const [{ value }, , { setValue }] = useField<UserMetadata[] | undefined>(name)
-  const collaborators = value ?? []
+  const collaborators = useMemo(() => value ?? [], [value])
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   useDebounce(() => setDebouncedQuery(query), DEBOUNCE_MS, [query])


### PR DESCRIPTION
## Summary
- memoize the mobile collaborator field fallback array so hook dependencies stay stable
- resolves the remaining `react-hooks/exhaustive-deps` warnings from the failed Mobile Verify run

## Context
Failed run: https://github.com/AudiusProject/apps/actions/runs/27653439052

The import-order failure from that run was already fixed on `main` by `a59400a913`; this PR handles the collaborator field warnings that remained on current `main`.

## Test Plan
- `/usr/local/bin/node ../../node_modules/.bin/eslint --cache --ext=js,jsx,ts,tsx src` from `packages/mobile`
- `/usr/local/bin/node ../../node_modules/.bin/tsc` from `packages/mobile`
- `git diff --check`