### PR TITLE
Fix mobile track artist centering

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux'
 
 import { IconVolumeLevel2 } from '@audius/harmony-native'
 import { Text, FadeInView } from 'app/components/core'
-import { UserLink } from 'app/components/user-link'
+import { UserBadges } from 'app/components/user-badges'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
 import type { GestureResponderHandler } from 'app/types/gesture'
@@ -13,6 +13,8 @@ import { useThemeColors } from 'app/utils/theme'
 
 import { LineupTileArt } from './LineupTileArt'
 import { LineupTileTopRight } from './LineupTileTopRight'
+import type { ArtistNameCollaborator } from './artistNames'
+import { getTrackArtistNames } from './artistNames'
 import { useStyles as useTileStyles } from './styles'
 import type { RenderImage } from './types'
 
@@ -26,6 +28,16 @@ const useStyles = makeStyles(({ palette }) => ({
   },
   playingIndicator: {
     marginLeft: 8
+  },
+  artistText: {
+    flexShrink: 1,
+    minWidth: 0
+  },
+  artistBadges: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexShrink: 0,
+    gap: 4
   },
   coSignLabel: {
     position: 'absolute',
@@ -45,6 +57,8 @@ type Props = {
   renderImage: RenderImage
   title: string
   userId: ID
+  userName: string
+  collaborators?: ArtistNameCollaborator[] | null
   isPlayingUid: boolean
   type: 'track' | 'playlist' | 'album'
   trackId: ID
@@ -59,6 +73,8 @@ export const LineupTileMetadata = ({
   renderImage,
   title,
   userId,
+  userName,
+  collaborators,
   isPlayingUid,
   type,
   trackId,
@@ -72,6 +88,7 @@ export const LineupTileMetadata = ({
   const navigation = useNavigation()
 
   const isActive = isPlayingUid
+  const artistNames = getTrackArtistNames(userName, collaborators)
 
   const isPlaying = useSelector((state) => {
     return getPlaying(state) && isActive
@@ -139,14 +156,24 @@ export const LineupTileMetadata = ({
           onPressIn={onPressWithPropagationBlock}
           onPress={handlePressArtist}
           activeOpacity={0.7}
-          style={{ alignSelf: 'flex-start' }}
+          style={tileStyles.artist}
         >
-          <View pointerEvents='none'>
-            <UserLink
-              variant={isActive ? 'active' : 'default'}
-              textVariant='body'
-              userId={userId}
-            />
+          <Text
+            color={isActive ? 'primary' : 'neutral'}
+            numberOfLines={1}
+            ellipsizeMode='tail'
+            style={styles.artistText}
+          >
+            {artistNames}
+          </Text>
+          <View style={styles.artistBadges}>
+            <UserBadges userId={userId} />
+            {collaborators?.map((collaborator) => (
+              <UserBadges
+                key={collaborator.user_id}
+                userId={collaborator.user_id}
+              />
+            ))}
           </View>
         </TouchableOpacity>
       </FadeInView>

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -85,6 +85,7 @@ const TrackTileComponent = (props: TrackTileProps) => {
       title: track.title,
       track_id: track.track_id,
       genre: track.genre,
+      collaborators: track.collaborators,
       stream_conditions: track.stream_conditions,
 
       ddex_app: track.ddex_app,
@@ -100,6 +101,7 @@ const TrackTileComponent = (props: TrackTileProps) => {
   const { data: user } = useUser(track?.owner_id, {
     select: (user) => ({
       artist_pick_track_id: user.artist_pick_track_id,
+      name: user.name,
       user_id: user.user_id,
       is_deactivated: user.is_deactivated
     })
@@ -309,6 +311,8 @@ const TrackTileComponent = (props: TrackTileProps) => {
           onPressWithPropagationBlock={handlePressWithPropagationBlock}
           title={track.title}
           userId={user.user_id}
+          userName={user.name}
+          collaborators={track.collaborators}
           isPlayingUid={isPlayingUid}
           type='track'
           trackId={track.track_id}

--- a/packages/mobile/src/components/lineup-tile/artistNames.test.ts
+++ b/packages/mobile/src/components/lineup-tile/artistNames.test.ts
@@ -1,0 +1,22 @@
+import { getTrackArtistNames } from './artistNames'
+
+describe('getTrackArtistNames', () => {
+  it('combines owner and collaborator names', () => {
+    expect(
+      getTrackArtistNames('ray61626b', [
+        { user_id: 2, name: 'dj g8r' },
+        { user_id: 3, name: 'tim' }
+      ])
+    ).toBe('ray61626b, dj g8r, tim')
+  })
+
+  it('omits missing collaborator names', () => {
+    expect(
+      getTrackArtistNames('ray61626b', [
+        { user_id: 2, name: null },
+        { user_id: 3, name: undefined },
+        { user_id: 4, name: 'dj g8r' }
+      ])
+    ).toBe('ray61626b, dj g8r')
+  })
+})

--- a/packages/mobile/src/components/lineup-tile/artistNames.ts
+++ b/packages/mobile/src/components/lineup-tile/artistNames.ts
@@ -1,0 +1,17 @@
+import type { ID } from '@audius/common/models'
+
+export type ArtistNameCollaborator = {
+  user_id: ID
+  name?: string | null
+}
+
+export const getTrackArtistNames = (
+  userName: string,
+  collaborators?: ArtistNameCollaborator[] | null
+) => {
+  const collaboratorNames =
+    collaborators?.map((collaborator) => collaborator.name).filter(Boolean) ??
+    []
+
+  return [userName, ...collaboratorNames].join(', ')
+}

--- a/packages/mobile/src/components/lineup-tile/styles.ts
+++ b/packages/mobile/src/components/lineup-tile/styles.ts
@@ -56,6 +56,9 @@ export const useStyles = makeStyles(({ palette }) => ({
   },
   artist: {
     ...flexRowCentered(),
+    justifyContent: 'flex-start',
+    gap: spacing(1),
+    width: '100%',
     marginBottom: 'auto',
     paddingRight: spacing(10),
     minHeight: 20

--- a/packages/mobile/src/components/user-link/TrackArtists.test.tsx
+++ b/packages/mobile/src/components/user-link/TrackArtists.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from '@testing-library/react-native'
 
 import { TrackArtists } from './TrackArtists'
 
+const mockUseUsers = jest.fn()
+
+jest.mock('@audius/common/api', () => ({
+  useUsers: (...args: unknown[]) => mockUseUsers(...args)
+}))
+
 jest.mock(
   '@audius/harmony-native',
   () => {
@@ -11,7 +17,9 @@ jest.mock(
     return {
       Flex: ({ children, style }: any) =>
         React.createElement(View, { style }, children),
-      Text: ({ children }: any) => React.createElement(Text, null, children)
+      Text: ({ children }: any) => React.createElement(Text, null, children),
+      TextLink: ({ children, to }: any) =>
+        React.createElement(Text, null, `${to.params.id}:${children}`)
     }
   },
   { virtual: true }
@@ -48,12 +56,21 @@ jest.mock('../user-badges', () => {
 })
 
 describe('TrackArtists', () => {
+  beforeEach(() => {
+    mockUseUsers.mockReturnValue({
+      byId: {
+        1: { name: 'ray61626b' },
+        2: { name: 'dj g8r' }
+      }
+    })
+  })
+
   it('centers artist names and renders badges for each artist', () => {
     render(<TrackArtists userId={1} collaborators={[{ user_id: 2 }]} />)
 
-    expect(screen.getByText('1:badges-hidden')).toBeOnTheScreen()
-    expect(screen.getByText('2:badges-hidden')).toBeOnTheScreen()
-    expect(screen.queryByText(/badges-visible/)).toBeNull()
+    expect(mockUseUsers).toHaveBeenCalledWith([1, 2])
+    expect(screen.getByText('1:ray61626b')).toBeOnTheScreen()
+    expect(screen.getByText('2:dj g8r')).toBeOnTheScreen()
     expect(screen.getByText('badges:1')).toBeOnTheScreen()
     expect(screen.getByText('badges:2')).toBeOnTheScreen()
   })

--- a/packages/mobile/src/components/user-link/TrackArtists.test.tsx
+++ b/packages/mobile/src/components/user-link/TrackArtists.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react-native'
+import { render, screen, within } from '@testing-library/react-native'
 
 import { TrackArtists } from './TrackArtists'
 
@@ -15,8 +15,8 @@ jest.mock(
     const { Text, View } = require('react-native')
 
     return {
-      Flex: ({ children, style }: any) =>
-        React.createElement(View, { style }, children),
+      Flex: ({ children, style, testID }: any) =>
+        React.createElement(View, { style, testID }, children),
       Text: ({ children }: any) => React.createElement(Text, null, children),
       TextLink: ({ children, to }: any) =>
         React.createElement(Text, null, `${to.params.id}:${children}`)
@@ -65,13 +65,16 @@ describe('TrackArtists', () => {
     })
   })
 
-  it('centers artist names and renders badges for each artist', () => {
+  it('centers artist groups with each artist badge beside its name', () => {
     render(<TrackArtists userId={1} collaborators={[{ user_id: 2 }]} />)
 
+    const ownerGroup = screen.getByTestId('track-artist-1')
+    const collaboratorGroup = screen.getByTestId('track-artist-2')
+
     expect(mockUseUsers).toHaveBeenCalledWith([1, 2])
-    expect(screen.getByText('1:ray61626b')).toBeOnTheScreen()
-    expect(screen.getByText('2:dj g8r')).toBeOnTheScreen()
-    expect(screen.getByText('badges:1')).toBeOnTheScreen()
-    expect(screen.getByText('badges:2')).toBeOnTheScreen()
+    expect(within(ownerGroup).getByText('1:ray61626b')).toBeOnTheScreen()
+    expect(within(ownerGroup).getByText('badges:1')).toBeOnTheScreen()
+    expect(within(collaboratorGroup).getByText('2:dj g8r')).toBeOnTheScreen()
+    expect(within(collaboratorGroup).getByText('badges:2')).toBeOnTheScreen()
   })
 })

--- a/packages/mobile/src/components/user-link/TrackArtists.test.tsx
+++ b/packages/mobile/src/components/user-link/TrackArtists.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react-native'
+
+import { TrackArtists } from './TrackArtists'
+
+jest.mock(
+  '@audius/harmony-native',
+  () => {
+    const React = require('react')
+    const { Text, View } = require('react-native')
+
+    return {
+      Flex: ({ children, style }: any) =>
+        React.createElement(View, { style }, children),
+      Text: ({ children }: any) => React.createElement(Text, null, children)
+    }
+  },
+  { virtual: true }
+)
+
+jest.mock('./UserLink', () => {
+  const React = require('react')
+  const { Text } = require('react-native')
+
+  return {
+    UserLink: ({
+      hideBadges,
+      userId
+    }: {
+      hideBadges?: boolean
+      userId: number
+    }) =>
+      React.createElement(
+        Text,
+        null,
+        `${userId}:${hideBadges ? 'badges-hidden' : 'badges-visible'}`
+      )
+  }
+})
+
+jest.mock('../user-badges', () => {
+  const React = require('react')
+  const { Text } = require('react-native')
+
+  return {
+    UserBadges: ({ userId }: { userId: number }) =>
+      React.createElement(Text, null, `badges:${userId}`)
+  }
+})
+
+describe('TrackArtists', () => {
+  it('centers artist names and renders badges for each artist', () => {
+    render(<TrackArtists userId={1} collaborators={[{ user_id: 2 }]} />)
+
+    expect(screen.getByText('1:badges-hidden')).toBeOnTheScreen()
+    expect(screen.getByText('2:badges-hidden')).toBeOnTheScreen()
+    expect(screen.queryByText(/badges-visible/)).toBeNull()
+    expect(screen.getByText('badges:1')).toBeOnTheScreen()
+    expect(screen.getByText('badges:2')).toBeOnTheScreen()
+  })
+})

--- a/packages/mobile/src/components/user-link/TrackArtists.tsx
+++ b/packages/mobile/src/components/user-link/TrackArtists.tsx
@@ -59,8 +59,7 @@ type TrackArtistsProps = Omit<
 
 /**
  * A track's centered artist line for mobile: the owner `<UserLink>` plus
- * accepted collaborators. User badges render on their own centered row so the
- * names stay visually centered under the title.
+ * accepted collaborators, each followed by their own user badges.
  */
 export const TrackArtists = ({
   collaborators,
@@ -92,45 +91,39 @@ export const TrackArtists = ({
 
   return (
     <Flex alignItems='center' w='100%' style={[styles.artistColumn, style]}>
-      <Text
-        numberOfLines={1}
-        ellipsizeMode='tail'
-        textAlign='center'
-        style={styles.artistNames}
-      >
-        {artists.map((artist, index) => (
-          <Fragment key={artist.userId}>
-            {index > 0 ? <Text color='subdued'>, </Text> : null}
-            <TextLink
-              {...textLinkProps}
-              to={{ screen: 'Profile', params: { id: artist.userId } }}
-              numberOfLines={1}
-              style={textLinkStyle}
-            >
-              {artist.name}
-            </TextLink>
-          </Fragment>
-        ))}
-      </Text>
       <Flex
         row
         alignItems='center'
         justifyContent='center'
-        style={styles.badges}
+        w='100%'
+        style={styles.artistLine}
       >
-        <UserBadges
-          userId={userId}
-          badgeSize={badgeSize}
-          mint={mint}
-          hideFanClubBadge={hideFanClubBadge}
-        />
-        {collaborators?.map((collaborator) => (
-          <UserBadges
-            key={collaborator.user_id}
-            userId={collaborator.user_id}
-            badgeSize={badgeSize}
-            hideFanClubBadge={hideFanClubBadge}
-          />
+        {artists.map((artist, index) => (
+          <Fragment key={artist.userId}>
+            {index > 0 ? <Text color='subdued'>, </Text> : null}
+            <Flex
+              row
+              alignItems='center'
+              gap='xs'
+              style={styles.artistGroup}
+              testID={`track-artist-${artist.userId}`}
+            >
+              <TextLink
+                {...textLinkProps}
+                to={{ screen: 'Profile', params: { id: artist.userId } }}
+                numberOfLines={1}
+                style={[styles.artistName, textLinkStyle]}
+              >
+                {artist.name}
+              </TextLink>
+              <UserBadges
+                userId={artist.userId}
+                badgeSize={badgeSize}
+                mint={artist.userId === userId ? mint : undefined}
+                hideFanClubBadge={hideFanClubBadge}
+              />
+            </Flex>
+          </Fragment>
         ))}
       </Flex>
     </Flex>
@@ -142,11 +135,17 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     overflow: 'hidden'
   },
-  artistNames: {
-    width: '100%'
+  artistLine: {
+    minWidth: 0,
+    overflow: 'hidden'
   },
-  badges: {
-    gap: 4
+  artistGroup: {
+    flexShrink: 1,
+    minWidth: 0
+  },
+  artistName: {
+    flexShrink: 1,
+    minWidth: 0
   },
   artistLink: {
     flexShrink: 1,

--- a/packages/mobile/src/components/user-link/TrackArtists.tsx
+++ b/packages/mobile/src/components/user-link/TrackArtists.tsx
@@ -7,6 +7,8 @@ import type { StyleProp, ViewStyle } from 'react-native'
 
 import { Flex, Text } from '@audius/harmony-native'
 
+import { UserBadges } from '../user-badges'
+
 import { UserLink } from './UserLink'
 
 type Collaborator = { user_id: ID }
@@ -45,16 +47,19 @@ export const CollaboratorLinks = ({
   )
 }
 
-type TrackArtistsProps = Omit<ComponentProps<typeof UserLink>, 'style'> & {
+type TrackArtistsProps = Omit<
+  ComponentProps<typeof UserLink>,
+  'style' | 'hideBadges'
+> & {
   /** Accepted collaborator artists embedded on the track. */
   collaborators?: Collaborator[] | null
   style?: StyleProp<ViewStyle>
 }
 
 /**
- * A track's artist line for mobile: the owner `<UserLink>` plus accepted
- * collaborators. With the flag off (or no collaborators) it renders just the
- * owner — a safe drop-in for an existing owner `<UserLink>`.
+ * A track's centered artist line for mobile: the owner `<UserLink>` plus
+ * accepted collaborators. User badges render on their own centered row so the
+ * names stay visually centered under the title.
  */
 export const TrackArtists = ({
   collaborators,
@@ -62,23 +67,46 @@ export const TrackArtists = ({
   ...userLinkProps
 }: TrackArtistsProps) => {
   return (
-    <Flex
-      row
-      alignItems='center'
-      justifyContent='center'
-      w='100%'
-      style={[styles.artistRow, style]}
-    >
-      <UserLink {...userLinkProps} style={styles.artistLink} />
-      <CollaboratorLinks collaborators={collaborators} {...userLinkProps} />
+    <Flex alignItems='center' w='100%' style={[styles.artistColumn, style]}>
+      <Flex row alignItems='center' justifyContent='center' w='100%'>
+        <UserLink {...userLinkProps} hideBadges style={styles.artistLink} />
+        <CollaboratorLinks
+          collaborators={collaborators}
+          {...userLinkProps}
+          hideBadges
+        />
+      </Flex>
+      <Flex
+        row
+        alignItems='center'
+        justifyContent='center'
+        style={styles.badges}
+      >
+        <UserBadges
+          userId={userLinkProps.userId}
+          badgeSize={userLinkProps.badgeSize}
+          hideFanClubBadge={userLinkProps.hideFanClubBadge}
+        />
+        {collaborators?.map((collaborator) => (
+          <UserBadges
+            key={collaborator.user_id}
+            userId={collaborator.user_id}
+            badgeSize={userLinkProps.badgeSize}
+            hideFanClubBadge={userLinkProps.hideFanClubBadge}
+          />
+        ))}
+      </Flex>
     </Flex>
   )
 }
 
 const styles = StyleSheet.create({
-  artistRow: {
+  artistColumn: {
     flexShrink: 1,
     overflow: 'hidden'
+  },
+  badges: {
+    gap: 4
   },
   artistLink: {
     flexShrink: 1,

--- a/packages/mobile/src/components/user-link/TrackArtists.tsx
+++ b/packages/mobile/src/components/user-link/TrackArtists.tsx
@@ -14,6 +14,25 @@ import { UserLink } from './UserLink'
 
 type Collaborator = { user_id: ID }
 
+type ArtistBadgesProps = ComponentProps<typeof UserBadges> & {
+  isSpacer?: boolean
+}
+
+const ArtistBadges = ({ isSpacer, ...props }: ArtistBadgesProps) => (
+  <Flex
+    row
+    alignItems='center'
+    gap='xs'
+    pointerEvents={isSpacer ? 'none' : undefined}
+    accessibilityElementsHidden={isSpacer}
+    importantForAccessibility={isSpacer ? 'no-hide-descendants' : undefined}
+    style={isSpacer ? styles.badgeSpacer : undefined}
+  >
+    <Flex style={styles.badgeGapAnchor} />
+    <UserBadges {...props} />
+  </Flex>
+)
+
 type CollaboratorLinksProps = Omit<
   ComponentProps<typeof UserLink>,
   'userId'
@@ -98,13 +117,24 @@ export const TrackArtists = ({
         w='100%'
         style={styles.artistLine}
       >
+        <Flex row alignItems='center' style={styles.badgeSpacerRow}>
+          {artists.map((artist) => (
+            <ArtistBadges
+              key={artist.userId}
+              userId={artist.userId}
+              badgeSize={badgeSize}
+              mint={artist.userId === userId ? mint : undefined}
+              hideFanClubBadge={hideFanClubBadge}
+              isSpacer
+            />
+          ))}
+        </Flex>
         {artists.map((artist, index) => (
           <Fragment key={artist.userId}>
             {index > 0 ? <Text color='subdued'>, </Text> : null}
             <Flex
               row
               alignItems='center'
-              gap='xs'
               style={styles.artistGroup}
               testID={`track-artist-${artist.userId}`}
             >
@@ -116,7 +146,7 @@ export const TrackArtists = ({
               >
                 {artist.name}
               </TextLink>
-              <UserBadges
+              <ArtistBadges
                 userId={artist.userId}
                 badgeSize={badgeSize}
                 mint={artist.userId === userId ? mint : undefined}
@@ -138,6 +168,15 @@ const styles = StyleSheet.create({
   artistLine: {
     minWidth: 0,
     overflow: 'hidden'
+  },
+  badgeSpacerRow: {
+    flexShrink: 0
+  },
+  badgeSpacer: {
+    opacity: 0
+  },
+  badgeGapAnchor: {
+    width: 0
   },
   artistGroup: {
     flexShrink: 1,

--- a/packages/mobile/src/components/user-link/TrackArtists.tsx
+++ b/packages/mobile/src/components/user-link/TrackArtists.tsx
@@ -1,11 +1,12 @@
 import type { ComponentProps } from 'react'
-import { Fragment } from 'react'
+import { Fragment, useMemo } from 'react'
 
+import { useUsers } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
 import { StyleSheet } from 'react-native'
 import type { StyleProp, ViewStyle } from 'react-native'
 
-import { Flex, Text } from '@audius/harmony-native'
+import { Flex, Text, TextLink } from '@audius/harmony-native'
 
 import { UserBadges } from '../user-badges'
 
@@ -66,16 +67,51 @@ export const TrackArtists = ({
   style,
   ...userLinkProps
 }: TrackArtistsProps) => {
+  const {
+    userId,
+    badgeSize,
+    hideFanClubBadge,
+    mint,
+    textLinkStyle,
+    ...textLinkProps
+  } = userLinkProps
+  const artistIds = useMemo(
+    () => [
+      userId,
+      ...(collaborators?.map((collaborator) => collaborator.user_id) ?? [])
+    ],
+    [userId, collaborators]
+  )
+  const { byId: usersById } = useUsers(artistIds)
+  const artists = artistIds
+    .map((artistId) => ({
+      userId: artistId,
+      name: usersById[artistId]?.name
+    }))
+    .filter((artist) => artist.name)
+
   return (
     <Flex alignItems='center' w='100%' style={[styles.artistColumn, style]}>
-      <Flex row alignItems='center' justifyContent='center' w='100%'>
-        <UserLink {...userLinkProps} hideBadges style={styles.artistLink} />
-        <CollaboratorLinks
-          collaborators={collaborators}
-          {...userLinkProps}
-          hideBadges
-        />
-      </Flex>
+      <Text
+        numberOfLines={1}
+        ellipsizeMode='tail'
+        textAlign='center'
+        style={styles.artistNames}
+      >
+        {artists.map((artist, index) => (
+          <Fragment key={artist.userId}>
+            {index > 0 ? <Text color='subdued'>, </Text> : null}
+            <TextLink
+              {...textLinkProps}
+              to={{ screen: 'Profile', params: { id: artist.userId } }}
+              numberOfLines={1}
+              style={textLinkStyle}
+            >
+              {artist.name}
+            </TextLink>
+          </Fragment>
+        ))}
+      </Text>
       <Flex
         row
         alignItems='center'
@@ -83,16 +119,17 @@ export const TrackArtists = ({
         style={styles.badges}
       >
         <UserBadges
-          userId={userLinkProps.userId}
-          badgeSize={userLinkProps.badgeSize}
-          hideFanClubBadge={userLinkProps.hideFanClubBadge}
+          userId={userId}
+          badgeSize={badgeSize}
+          mint={mint}
+          hideFanClubBadge={hideFanClubBadge}
         />
         {collaborators?.map((collaborator) => (
           <UserBadges
             key={collaborator.user_id}
             userId={collaborator.user_id}
-            badgeSize={userLinkProps.badgeSize}
-            hideFanClubBadge={userLinkProps.hideFanClubBadge}
+            badgeSize={badgeSize}
+            hideFanClubBadge={hideFanClubBadge}
           />
         ))}
       </Flex>
@@ -104,6 +141,9 @@ const styles = StyleSheet.create({
   artistColumn: {
     flexShrink: 1,
     overflow: 'hidden'
+  },
+  artistNames: {
+    width: '100%'
   },
   badges: {
     gap: 4

--- a/packages/mobile/src/components/user-link/UserLink.tsx
+++ b/packages/mobile/src/components/user-link/UserLink.tsx
@@ -24,6 +24,7 @@ type UserLinkProps = Omit<TextLinkProps<ParamList>, 'to' | 'children'> & {
   badgeSize?: IconSize
   textLinkStyle?: StyleProp<TextStyle>
   disabled?: boolean
+  hideBadges?: boolean
   hideFanClubBadge?: boolean
   mint?: string
 }
@@ -35,6 +36,7 @@ export const UserLink = (props: UserLinkProps) => {
     style,
     textLinkStyle,
     disabled,
+    hideBadges,
     hideFanClubBadge,
     mint,
     ...other
@@ -89,12 +91,14 @@ export const UserLink = (props: UserLinkProps) => {
         >
           {userName}
         </TextLink>
-        <UserBadges
-          userId={userId}
-          badgeSize={badgeSize}
-          mint={mint}
-          hideFanClubBadge={hideFanClubBadge}
-        />
+        {hideBadges ? null : (
+          <UserBadges
+            userId={userId}
+            badgeSize={badgeSize}
+            mint={mint}
+            hideFanClubBadge={hideFanClubBadge}
+          />
+        )}
       </AnimatedFlex>
     </Pressable>
   )

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -621,7 +621,7 @@ export const TrackScreenDetailsTile = ({
           </Flex>
         ) : null}
         {imageElement}
-        <Flex gap='xs' alignItems='center'>
+        <Flex gap='xs' alignItems='center' w='100%'>
           <Text variant='heading' size='s' textAlign='center'>
             {title}
           </Text>

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -630,7 +630,6 @@ export const TrackScreenDetailsTile = ({
               userId={user.user_id}
               collaborators={collaborators}
               size='l'
-              badgeSize='s'
               style={{ justifyContent: 'center' }}
             />
           ) : null}


### PR DESCRIPTION
## Summary
- Keep the mobile track-page artist names visually centered under the title while still showing user badges in a separate centered badge row.
- Show accepted collaborators in mobile feed track rows as comma-separated artist names, with one-line ellipsis behavior when the row is too long.
- Preserve badges in feed rows for both the owner and accepted collaborators.
- Add focused unit tests for centered artist badge rendering plus artist-name composition.

## Test Plan
- `/usr/local/bin/node ../../node_modules/.bin/jest src/components/user-link/TrackArtists.test.tsx src/components/lineup-tile/artistNames.test.ts --moduleNameMapper='{"^react-native$":"<rootDir>/../../node_modules/react-native","^@testing-library/react-native$":"<rootDir>/node_modules/@testing-library/react-native"}'`
- `/usr/local/bin/node ../../node_modules/.bin/eslint --cache --ext=js,jsx,ts,tsx src/components/user-link/UserLink.tsx src/components/user-link/TrackArtists.tsx src/components/user-link/TrackArtists.test.tsx src/screens/track-screen/TrackScreenDetailsTile.tsx src/components/track/TrackCard.tsx src/components/lineup-tile/TrackTile.tsx src/components/lineup-tile/LineupTileMetadata.tsx src/components/lineup-tile/styles.ts src/components/lineup-tile/artistNames.ts src/components/lineup-tile/artistNames.test.ts`
- `/usr/local/bin/node ../../node_modules/.bin/tsc --noEmit`