### PR TITLE
fix(search): show freeform genre as a selected filter chip

### DIFF
--- a/packages/mobile/src/screens/search-screen/SearchFilters.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchFilters.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 
 import type { Genre } from '@audius/common/utils'
 import {
@@ -48,12 +48,25 @@ export const GenreFilter = () => {
     setGenre(value)
   }
 
+  const options = useMemo(() => {
+    // Freeform/custom genres (e.g. "Hyperpop Fusion") aren't in the predefined
+    // GENRES list. Without a matching option the FilterButton can't resolve a
+    // label and the active chip falls back to the generic "Genre" text, leaving
+    // no indication of what's actually being filtered. Add the current genre as
+    // an option so it renders as a selected chip.
+    if (genre && !genreOptions.some((option) => option.value === genre)) {
+      return [{ label: genre, value: genre }, ...genreOptions]
+    }
+
+    return genreOptions
+  }, [genre])
+
   return (
     <FilterButton
       label={messages.genre}
       value={genre}
       onChange={handleGenreChange}
-      options={genreOptions}
+      options={options}
       size='small'
     />
   )

--- a/packages/web/src/pages/search-page/SearchFilters.tsx
+++ b/packages/web/src/pages/search-page/SearchFilters.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useState } from 'react'
+import { ReactElement, useCallback, useMemo, useState } from 'react'
 
 import {
   GENRES,
@@ -55,6 +55,24 @@ const GenreFilter = () => {
     updateGenreParams(value)
   }
 
+  const options = useMemo(() => {
+    const genreOptions = GENRES.map((genre) => ({
+      label: genre,
+      value: convertGenreLabelToValue(genre)
+    }))
+
+    // Freeform/custom genres (e.g. "Hyperpop Fusion") aren't in the predefined
+    // GENRES list. Without a matching option the FilterButton can't resolve a
+    // label and the active chip falls back to the generic "Genre" text, leaving
+    // no indication of what's actually being filtered. Add the current genre as
+    // an option so it renders as a selected chip.
+    if (genre && !genreOptions.some((option) => option.value === genre)) {
+      return [{ label: genre, value: genre }, ...genreOptions]
+    }
+
+    return genreOptions
+  }, [genre])
+
   return (
     <FilterButton
       label={messages.genre}
@@ -65,10 +83,7 @@ const GenreFilter = () => {
       }}
       value={genre}
       onChange={handleGenreChange}
-      options={GENRES.map((genre) => ({
-        label: genre,
-        value: convertGenreLabelToValue(genre)
-      }))}
+      options={options}
       showFilterInput
       filterInputProps={{ label: messages.genreFilterLabel }}
     />


### PR DESCRIPTION
## Problem

Clicking a freeform/custom genre (e.g. **"Hyperpop Fusion"**) on a track page navigates to search, but the genre doesn't appear as a selected filter chip — leaving no indication of what's being filtered and making it unclear whether the search is filtering by that genre at all.

## Root cause

The genre **is** read from the URL and **is** passed to the search API ([`useSearchResults.ts:177`](packages/common/src/api/tan-query/search/useSearchResults.ts) — `genre: filters.genre ? [filters.genre] : undefined`), so server-side filtering already works.

The bug is purely in the filter UI. The harmony `FilterButton` resolves its active label by matching the URL genre value against its `options`, which are built from the ~51 hardcoded `GENRES`:

```ts
const selectedOption = options?.find((option) => option.value === value)
const selectedLabel = selectedOption?.label ?? selectedOption?.value
// ...
{selectedLabel ? renderLabel(selectedLabel) : label}
```

A freeform genre matches no option → `selectedLabel` is `undefined` → the chip falls back to the generic `"Genre"` label.

## Fix

In the `GenreFilter` on both web and mobile, when the active genre isn't in the predefined `GENRES` list, add it as an option so the `FilterButton` can resolve a label and render it as a selected chip.

- `packages/web/src/pages/search-page/SearchFilters.tsx`
- `packages/mobile/src/screens/search-screen/SearchFilters.tsx`

No change needed on the API side — the genre was already passed through correctly.

## Testing

- `eslint` clean on both changed files
- `tsc --noEmit` passes for both `packages/web` and `packages/mobile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)