### PR TITLE
fix(mobile): prevent crash when posting a comment

### DIFF
--- a/packages/common/src/api/tan-query/comments/usePostComment.ts
+++ b/packages/common/src/api/tan-query/comments/usePostComment.ts
@@ -73,7 +73,9 @@ export const usePostComment = () => {
         trackTimestampS,
         reactCount: 0,
         replyCount: 0,
-        replies: undefined,
+        // Match the server-hydrated shape (`commentFromSDK` always returns an
+        // array) so the optimistic comment renders identically to a real one.
+        replies: [],
         createdAt: new Date().toISOString(),
         updatedAt: undefined
       }

--- a/packages/mobile/src/components/comments/CommentThread.tsx
+++ b/packages/mobile/src/components/comments/CommentThread.tsx
@@ -40,13 +40,22 @@ export const CommentThread = (props: CommentThreadProps) => {
   const { motion, spacing } = useTheme()
   const { entityId } = useCurrentCommentSection()
   const { data: rootCommentData } = useComment(commentId)
-  const rootComment = rootCommentData as Comment // We can safely assume that this is a parent comment
+  const rootComment = rootCommentData as Comment | null | undefined // May be null/undefined or a `{}` placeholder while the individual comment cache is (re)hydrating
+
+  // Guard before any `rootComment.id` access. The individual comment cache can
+  // briefly be undefined/null or an empty `{}` placeholder (written by
+  // `useComments`' queryFn) while it (re)hydrates — e.g. when a post mutation
+  // toggles the list query off via `useIsMutating` and the optimistic id is
+  // momentarily present without its primed comment data. Dereferencing
+  // `rootComment.id` in that window throws and crashes the app.
+  const hasRootComment = !!rootComment && 'id' in rootComment
 
   const isReplyHighlighted =
-    highlightedComment?.parentCommentId === rootComment.id
+    hasRootComment && highlightedComment?.parentCommentId === rootComment.id
   const highlightedCommentId =
-    isReplyHighlighted || highlightedComment?.id === rootComment.id
-      ? highlightedComment.id
+    hasRootComment &&
+    (isReplyHighlighted || highlightedComment?.id === rootComment.id)
+      ? highlightedComment?.id
       : null
 
   const [hiddenReplies, setHiddenReplies] = useState<{
@@ -105,6 +114,7 @@ export const CommentThread = (props: CommentThreadProps) => {
   )
 
   useEffect(() => {
+    if (!hasRootComment) return
     if (hiddenReplies[rootComment.id]) {
       repliesContainerHeight.value = withTiming(0, motion.expressive)
     } else if (rootComment.replies?.length) {
@@ -116,6 +126,7 @@ export const CommentThread = (props: CommentThreadProps) => {
       }
     }
   }, [
+    hasRootComment,
     hiddenReplies,
     rootComment,
     motion.expressive,
@@ -123,7 +134,7 @@ export const CommentThread = (props: CommentThreadProps) => {
     repliesContainerHeight
   ])
 
-  if (!rootComment || !('id' in rootComment)) return null
+  if (!hasRootComment) return null
 
   const { replyCount = 0 } = rootComment
 


### PR DESCRIPTION
## Problem

On mobile, posting the **first comment on a track** (no prior comments) crashes the app with a `TypeError` the moment **Send** is pressed.

## Root cause (the crash)

`CommentThread` dereferences `rootComment.id` (and `highlightedComment.id`) near the top of the component — [`CommentThread.tsx:46`](packages/mobile/src/components/comments/CommentThread.tsx) — roughly 80 lines **before** the existing guard `if (!rootComment || !('id' in rootComment)) return null`.

`rootComment` comes from `useComment(commentId)`, which reads the shared `[comment, id]` query cache. During a post:

1. `mutate()` flips `useIsMutating()` to `1`, disabling the comment-list infinite query (`enabled: isMutating === 0`, [`useTrackComments.ts`](packages/common/src/api/tan-query/comments/useTrackComments.ts)).
2. `onMutate` is `async` and `await`s `generateCommentId()` before priming the optimistic comment, so the optimistic id can be present in the list while its individual comment cache is still empty — or holding the `{}` placeholder that `useComments`' queryFn writes to the same key ([`useComments.ts:30`](packages/common/src/api/tan-query/comments/useComments.ts)).
3. With no `highlightedComment` (a fresh root post), `highlightedComment?.parentCommentId === rootComment.id` evaluates `undefined === undefined` → `true`, then the next line dereferences `highlightedComment.id` on `undefined` → **TypeError → app crash**.

The recent prefetch PR (#14450) added a second live observer on the same `gcTime: 0` list query, widening this window and making the latent guard-ordering bug a reliable crash.

## Fixes

1. **`CommentThread.tsx`** — compute `hasRootComment` immediately after `useComment` and gate every `rootComment.id` / `rootComment.replies` access on it (including the replies-height effect) before the early return. Hooks order is preserved. *(This is the crash fix.)*
2. **`usePostComment.ts`** — the optimistic comment set `replies: undefined`, while the server-hydrated shape (`commentFromSDK`) always returns an array. Aligned the optimistic shape to `replies: []` so the optimistic and confirmed renders are identical. *(Defensive — removes the one real shape divergence on the render path.)*

### Ruled out (not crashing)
- **gcTime:0 eviction mid-post:** GC only runs when observers hit 0; `enabled: false` keeps the observer, so list data isn't evicted while visible.
- **Hydration map/find on null:** `combineQueryResults` filters falsy data and `keyBy(comments, 'id')` tolerates a `{}` entry; the rendered list uses `commentIds`, not the hydrated array.

## Verification (static only)
- `tsc --noEmit` — `@audius/common` **pass (0)**, `@audius/mobile` **pass (0)**
- `eslint` on both changed files — **pass (0)**

### Manual (recommended)
- [ ] Post the **first** comment on a track with no prior comments — no crash, comment appears.
- [ ] Post additional root comments and a reply.
- [ ] Open comments via a deep link with a highlighted comment, then post.

## Follow-up (not in this PR)
`useComments`' queryFn writing `{}` onto the shared `[comment, id]` cache key is the underlying footgun that lets a malformed `rootComment` exist at all — worth addressing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)