### PR TITLE
fix(mobile): prevent comment drawer crash on open from unguarded track access

### DIFF
--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -190,7 +190,11 @@ export const ComposerInput = forwardRef(function ComposerInput(
   const prevLinkEntities = usePrevious(linkEntities)
 
   const timestamps = useMemo(() => {
-    if (!partialTrack || !partialTrack.access.stream) return []
+    // `access` is typed as required on Track but is frequently absent at
+    // runtime (tracks hydrated from search/lineup/notification caches before
+    // gated-access enrichment). Optional-chain it so the comment drawer's
+    // composer doesn't crash on open when there's no access info yet.
+    if (!partialTrack || !partialTrack.access?.stream) return []
 
     const { duration } = partialTrack
     return Array.from(value.matchAll(timestampRegex))


### PR DESCRIPTION
## Problem

Opening the comment drawer on a track screen crashes the app with a `TypeError` — **just by opening it, before any comment is sent**. This is separate from the post-comment crash fixed in #14490.

## Root cause

The footer composer (`ComposerInput`) mounts on **every** comment-drawer open and computes `timestamps` in a render-phase `useMemo`:

```ts
const { data: partialTrack } = useTrack(entityId, {
  select: (track) => pick(track, ['duration', 'genre', 'release_date', 'access'])
})
...
const timestamps = useMemo(() => {
  if (!partialTrack || !partialTrack.access.stream) return []   // 💥
  ...
}, [partialTrack, value])
```

`partialTrack` is a `pick(...)`, so it is **truthy even when the track has no `access` field**. `access` is typed as required on `Track`, but at runtime it is frequently absent — tracks hydrated from search, lineup, or notification caches before gated-access enrichment have no `access` yet. In that window `partialTrack.access.stream` dereferences `undefined` and throws, crashing the app the instant the drawer opens.

Introduced in #14388 (`feat(for-you)`), which added this composer and the unguarded `partialTrack.access.stream` read.

## Fix

Optional-chain the access read so it falls back to "no timestamps" when access info isn't loaded yet — the same outcome as the gated / no-stream-access path:

```ts
if (!partialTrack || !partialTrack.access?.stream) return []
```

This matches existing precedent in the codebase (e.g. `track?.access?.download` in `DownloadSection.tsx`).

## Testing
- `eslint src/components/composer-input/ComposerInput.tsx` — passes
- `tsc --noEmit` (`@audius/mobile`) — passes, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)