### PR TITLE
fix(mobile): guard comment components against undefined track from lineup cache

### DIFF
--- a/packages/mobile/src/components/comments/CommentBlock.tsx
+++ b/packages/mobile/src/components/comments/CommentBlock.tsx
@@ -237,7 +237,13 @@ export const CommentBlockInternal = (
 // This is an extra component wrapper because the comment data coming back from aquery could be undefined
 // There's no way to return early in the above component due to rules of hooks ordering
 export const CommentBlock = (props: CommentBlockProps) => {
+  const { track } = useCurrentCommentSection()
   const { data: comment } = useComment(props.commentId)
+  // `track` is typed as always-present, but when the drawer is opened from a
+  // lineup/feed tile the track is hydrated from the partial lineup cache and
+  // can momentarily be undefined. Bail before `CommentBlockInternal`
+  // dereferences `track.track_id` / `track.pinned_comment_id` / `track.duration`.
+  if (!track) return null
   if (!comment || !('id' in comment)) return null
   return <CommentBlockInternal {...props} comment={comment} />
 }

--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -97,7 +97,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
   } = useCurrentCommentSection()
 
   const isCommentOwner = Number(userId) === currentUserId
-  const isPinned = track.pinned_comment_id === id
+  const isPinned = track?.pinned_comment_id === id
 
   const [pinComment] = usePinComment()
   const [deleteComment] = useDeleteComment()
@@ -117,14 +117,14 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
   }
 
   const handleShare = useCallback(() => {
-    const url = `${env.AUDIUS_URL}${track.permalink}?commentId=${Id.parse(comment.id)}`
+    const url = `${env.AUDIUS_URL}${track?.permalink ?? ''}?commentId=${Id.parse(comment.id)}`
     Clipboard.setString(url)
     toast({
       content: messages.toasts.linkCopied,
       type: 'info',
       timeout: 1500
     })
-  }, [comment.id, track.permalink, toast])
+  }, [comment.id, track?.permalink, toast])
 
   const rows: ActionDrawerRow[] = [
     {


### PR DESCRIPTION
## What

Hardens the comment-drawer components against an **undefined `track`** when the drawer is opened from a lineup/feed **track tile** (where the track is hydrated from the partial lineup cache, not the full track-screen fetch).

- `CommentBlock`: bail with `if (!track) return null` before `CommentBlockInternal` dereferences `track.track_id` / `track.pinned_comment_id` / `track.duration`.
- `CommentOverflowMenu`: optional-chain the context `track` accesses (`track?.pinned_comment_id`, `track?.permalink`).

## Why

The comment section context types `track` as always-present (`track: Track`) and the provider returns `null` until the track loads — so under normal flow these are safe. This is **belt-and-suspenders hardening** for the tile-open path, the same family as the already-merged crash fixes:
- #14490 — `CommentThread.rootComment.id`
- #14492 — `ComposerInput.partialTrack.access?.stream`

## Note on the live RC crash

While investigating I found the current release-candidate branches (`release-client-v*`, up to v1.5.164) do **not** contain #14490 or #14492 — both merged to `main` on Jun 16–17. If testers are still crashing on the comment button, the most likely cause is that the RC build predates those fixes, independent of this PR. Worth confirming the RC's build commit / CodePush channel.

## Test plan

- `npx tsc --noEmit` (packages/mobile) — clean
- `npx eslint` on both files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)