### PR TITLE
fix(comments): show loading state instead of blank comment drawer when opened from a tile

### DIFF
--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -5,7 +5,8 @@ import type { SearchCategory } from '@audius/common/api'
 import {
   useCurrentUserId,
   useFollowers,
-  useSearchUserResults
+  useSearchUserResults,
+  useTrack
 } from '@audius/common/api'
 import type { ReplyingAndEditingState } from '@audius/common/context'
 import {
@@ -238,6 +239,12 @@ export const CommentDrawer = (props: CommentDrawerProps) => {
   const insets = useSafeAreaInsets()
   const commentListRef = useRef<BottomSheetFlatListMethods>(null)
 
+  // When the drawer is opened from a lineup tile (e.g. the feed), the full
+  // track may not yet be in the query cache. CommentSectionProvider returns
+  // null until the track loads, which would render an empty bottom sheet, so
+  // fetch the track here and show a loading state instead of a blank drawer.
+  const { data: track } = useTrack(entityId)
+
   const [onAutocomplete, setOnAutocomplete] = useState<
     (user: UserMetadata) => void
   >(() => {})
@@ -339,28 +346,36 @@ export const CommentDrawer = (props: CommentDrawerProps) => {
         keyboardBlurBehavior='restore'
         android_keyboardInputMode='adjustResize'
       >
-        <CommentSectionProvider
-          entityId={entityId}
-          replyingAndEditingState={replyingAndEditingState}
-          setReplyingAndEditingState={setReplyingAndEditingState}
-          navigation={navigation}
-          closeDrawer={handleCloseDrawer}
-          playbackSource={playbackSource}
-        >
-          <CommentDrawerHeader minimal={autoCompleteActive} />
-          <Divider orientation='horizontal' />
-          {autoCompleteActive ? (
-            <CommentDrawerAutocompleteContent
-              query={acText}
-              onSelect={onAutocomplete}
-            />
-          ) : (
-            <CommentDrawerContent
-              commentListRef={commentListRef}
-              highlightedComment={highlightedComment}
-            />
-          )}
-        </CommentSectionProvider>
+        {track ? (
+          <CommentSectionProvider
+            entityId={entityId}
+            replyingAndEditingState={replyingAndEditingState}
+            setReplyingAndEditingState={setReplyingAndEditingState}
+            navigation={navigation}
+            closeDrawer={handleCloseDrawer}
+            playbackSource={playbackSource}
+          >
+            <CommentDrawerHeader minimal={autoCompleteActive} />
+            <Divider orientation='horizontal' />
+            {autoCompleteActive ? (
+              <CommentDrawerAutocompleteContent
+                query={acText}
+                onSelect={onAutocomplete}
+              />
+            ) : (
+              <CommentDrawerContent
+                commentListRef={commentListRef}
+                highlightedComment={highlightedComment}
+              />
+            )}
+          </CommentSectionProvider>
+        ) : (
+          <>
+            <CommentSkeleton />
+            <CommentSkeleton />
+            <CommentSkeleton />
+          </>
+        )}
       </BottomSheetModal>
       {isDrawerVisible ? (
         <Box


### PR DESCRIPTION
## Problem

Pressing the comment button on a track tile in the **feed** opened a **blank** comment drawer. Opening the drawer from the **track screen** worked fine.

## Root cause

`CommentSectionProvider` (`packages/common/src/context/comments/commentsContext.tsx`) fetches the full track via `useTrack(entityId)` and short-circuits with `if (!track) return null` until it loads.

- On the **track screen**, the track is already in the tan-query `[track, trackId]` cache (the screen pre-fetches it), so the provider renders immediately.
- From the **feed**, the track is not guaranteed to be in that cache when the global `CommentDrawer` mounts with the new `entityId`. While `useTrack` is fetching, the provider returns `null`, rendering **nothing** inside the bottom sheet → a blank drawer.

## Fix

In the mobile `CommentDrawer`, fetch the track with `useTrack(entityId)` and render comment skeletons while it's loading, instead of relying on the provider (which renders nothing). Once the track resolves, the full `CommentSectionProvider` tree renders as before. This keeps the change mobile-scoped (where the blank was observed) and reuses the existing `CommentSkeleton` loading aesthetic.

## Testing

- `eslint` clean on the changed file
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)