### PR TITLE
fix(migrate-tool): use apiKey+apiSecret for server-side SDK auth instead of bearer token

### DIFF
--- a/packages/migrate-tool/.env.example
+++ b/packages/migrate-tool/.env.example
@@ -19,10 +19,11 @@ VITE_GOOGLE_CLIENT_ID=your-google-oauth-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_ID=your-google-oauth-client-id.apps.googleusercontent.com
 AUTH_SESSION_SECRET=at-least-32-character-secret-for-jwt-signing
 
-# Audius bearer token. Backend only. Used with the API key above so the
-# server can act on behalf of users who have authorized the developer app.
+# Audius API secret. Backend only. Used with the API key above so the
+# server can authenticate the developer app and sign its requests. Never
+# expose this in the browser.
 AUDIUS_API_KEY=
-AUDIUS_BEARER_TOKEN=
+AUDIUS_API_SECRET=
 
 # Optional escape hatch for programmatic/CLI access to the admin endpoints
 # (list/approve/reject) via "Authorization: Bearer <token>". The admin UI

--- a/packages/migrate-tool/README.md
+++ b/packages/migrate-tool/README.md
@@ -64,12 +64,12 @@ You'll need:
 ### 2. Audius developer app
 
 Create a developer app at <https://audius.co/settings> → Developer Apps. You'll
-get an **API Key** and a **Bearer Token**.
+get an **API Key** and an **API Secret**.
 
 - `VITE_AUDIUS_API_KEY` — the API key (safe in the browser; baked into the build)
 - `AUDIUS_API_KEY` — same API key, for the backend
-- `AUDIUS_BEARER_TOKEN` — backend-only; grants the app permission to act on
-  behalf of users who have authorized it via OAuth
+- `AUDIUS_API_SECRET` — backend-only; authenticates the app and signs its
+  requests server-side. Never expose this in the browser.
 
 You'll also need to whitelist the deployment's OAuth redirect URI in the dev
 app's settings (e.g. `https://migrate.audius.co/`).
@@ -101,7 +101,7 @@ npx vercel link
 npx vercel env add VITE_AUDIUS_API_KEY
 npx vercel env add VITE_GOOGLE_CLIENT_ID
 npx vercel env add AUDIUS_API_KEY
-npx vercel env add AUDIUS_BEARER_TOKEN
+npx vercel env add AUDIUS_API_SECRET
 npx vercel env add GOOGLE_CLIENT_ID
 npx vercel env add AUTH_SESSION_SECRET
 npx vercel env add ADMIN_BEARER_TOKEN   # optional escape hatch

--- a/packages/migrate-tool/api/_lib/audius.ts
+++ b/packages/migrate-tool/api/_lib/audius.ts
@@ -6,13 +6,12 @@ import {
 let serverSdk: AudiusSdkWithServices | null = null
 
 /**
- * Server-side SDK initialized with the developer app's API key + bearer
- * token. The bearer token grants the app permission to act on behalf of
- * any user who has authorized it via OAuth.
+ * Server-side SDK initialized with the developer app's API key + API
+ * secret. The API secret authenticates the app and lets it sign requests
+ * server-side, so it must never be exposed in browser or mobile code.
  *
- * Per the SDK README: "Bearer Token — backend only. Grants your app the
- * ability to act on behalf of users who have authorized it. Never expose
- * this in browser or mobile code."
+ * Per the SDK README: "apiSecret should only be provided server side so
+ * that it isn't exposed."
  *
  * We use createSdkWithServices (rather than the public sdk() factory) so
  * sdk.tracks is the wrapped TracksApi with friendly helpers like
@@ -22,15 +21,15 @@ let serverSdk: AudiusSdkWithServices | null = null
 export function getServerSDK(): AudiusSdkWithServices {
   if (serverSdk) return serverSdk
   const apiKey = process.env.AUDIUS_API_KEY
-  const bearerToken = process.env.AUDIUS_BEARER_TOKEN
-  if (!apiKey || !bearerToken) {
+  const apiSecret = process.env.AUDIUS_API_SECRET
+  if (!apiKey || !apiSecret) {
     throw new Error(
-      'AUDIUS_API_KEY and AUDIUS_BEARER_TOKEN must be set on the server.'
+      'AUDIUS_API_KEY and AUDIUS_API_SECRET must be set on the server.'
     )
   }
   serverSdk = createSdkWithServices({
     apiKey,
-    bearerToken,
+    apiSecret,
     appName: 'AudiusTrackMigration'
   })
   return serverSdk


### PR DESCRIPTION
## Summary

Follow-up to #14392. Switches the migrate-tool's server-side SDK initialization from a bearer token to `apiKey` + `apiSecret` (Basic auth), which is cleaner for app-level server-side operations.

The SDK's EntityManager relay call in `manageEntity` accepts either `Authorization: Bearer <bearerToken>` or `Basic base64(apiKey:apiSecret)`. Using `apiKey`+`apiSecret` lets the developer app authenticate and sign its own requests server-side without an OAuth-derived bearer token.

## Changes

- `api/_lib/audius.ts` — `getServerSDK()` now reads `AUDIUS_API_SECRET` and passes `apiSecret` to `createSdkWithServices` instead of `bearerToken`. Updated error message and doc comment.
- `.env.example` — `AUDIUS_BEARER_TOKEN` → `AUDIUS_API_SECRET`.
- `README.md` — env var documentation updated to reference the API Secret.

The unrelated `ADMIN_BEARER_TOKEN` escape hatch for admin endpoints is untouched.

## Verification

- `tsc -b` passes.
- `vite build` passes (polyfill issue resolved by the vite-plugin-node-polyfills 0.17.0 pin from #14392).

🤖 Generated with [Claude Code](https://claude.com/claude-code)