### PR TITLE
fix(identity): reduce noisy client-error logs

### DIFF
--- a/packages/identity-service/src/apiHelpers.js
+++ b/packages/identity-service/src/apiHelpers.js
@@ -32,7 +32,11 @@ const sendResponse = (module.exports.sendResponse = (req, res, resp) => {
     logger = logger.child({
       errorMessage: resp.object.error
     })
-    logger.error('Error processing request:', resp.object.error)
+    if (resp.statusCode >= 500) {
+      logger.error('Error processing request:', resp.object.error)
+    } else {
+      logger.debug('Client error response:', resp.object.error)
+    }
   }
   res.status(resp.statusCode).send(resp.object)
 })

--- a/packages/identity-service/src/authMiddleware.js
+++ b/packages/identity-service/src/authMiddleware.js
@@ -5,6 +5,7 @@ const {
   errorResponseBadRequest,
   errorResponseForbidden
 } = require('./apiHelpers')
+const { getErrorLogFields } = require('./logging')
 
 const models = require('./models')
 
@@ -128,7 +129,10 @@ async function authMiddleware(req, res, next) {
             isGuest: !handle
           })
         } catch (e) {
-          req.logger.error(e, 'Failed to update blockchainUserId/handle')
+          req.logger.warn(
+            { error: getErrorLogFields(e) },
+            'Failed to update blockchainUserId/handle'
+          )
         }
       }
       req.user = user
@@ -195,7 +199,10 @@ const parameterizedAuthMiddleware = ({ shouldRespondBadRequest }) => {
             isGuest: !handle
           })
         } catch (e) {
-          req.logger.error(e, 'Failed to update blockchainUserId/handle')
+          req.logger.warn(
+            { error: getErrorLogFields(e) },
+            'Failed to update blockchainUserId/handle'
+          )
         }
       }
       req.user = user

--- a/packages/identity-service/src/logging.js
+++ b/packages/identity-service/src/logging.js
@@ -38,6 +38,64 @@ function requestNotExcludedFromLogging(url) {
   return excludedRoutes.indexOf(url) === -1
 }
 
+const sensitiveQueryParamKeys = new Set([
+  'email',
+  'username',
+  'lookupkey',
+  'otp',
+  'token',
+  'signature',
+  'encoded-data-message',
+  'encoded-data-signature'
+])
+
+function sanitizeQueryParams(queryParams) {
+  if (!queryParams) return undefined
+
+  const params = new URLSearchParams(queryParams)
+  const sanitizedParams = []
+  params.forEach((value, key) => {
+    const sanitizedValue = sensitiveQueryParamKeys.has(key.toLowerCase())
+      ? '[redacted]'
+      : value
+    sanitizedParams.push(
+      `${encodeURIComponent(key)}=${encodeURIComponent(sanitizedValue)}`
+    )
+  })
+
+  return sanitizedParams.length ? sanitizedParams.join('&') : undefined
+}
+
+function withoutEmptyFields(obj) {
+  return Object.fromEntries(
+    Object.entries(obj).filter(
+      ([, value]) => value !== undefined && value !== null && value !== ''
+    )
+  )
+}
+
+function stripQueryParams(url) {
+  return typeof url === 'string' ? url.split('?')[0] : undefined
+}
+
+function getErrorLogFields(error) {
+  if (typeof error === 'string') {
+    return { message: error }
+  }
+  if (!error || typeof error !== 'object') {
+    return { message: String(error) }
+  }
+
+  return withoutEmptyFields({
+    name: error?.name,
+    message: error?.message,
+    code: error?.code,
+    status: error?.response?.status,
+    method: error?.config?.method,
+    url: stripQueryParams(error?.config?.url)
+  })
+}
+
 function loggingMiddleware(req, res, next) {
   const providedRequestID = req.header('X-Request-ID')
   const requestID = providedRequestID || shortid.generate()
@@ -49,7 +107,8 @@ function loggingMiddleware(req, res, next) {
     requestMethod: req.method,
     requestHostname: req.hostname,
     requestUrl: urlParts[0],
-    requestQueryParams: urlParts.length > 1 ? urlParts[1] : undefined,
+    requestQueryParams:
+      urlParts.length > 1 ? sanitizeQueryParams(urlParts[1]) : undefined,
     requestIP: req.ip,
     requestXForwardedFor: req.headers['x-forwarded-for']
   })
@@ -59,4 +118,10 @@ function loggingMiddleware(req, res, next) {
   next()
 }
 
-module.exports = { logger, loggingMiddleware, requestNotExcludedFromLogging }
+module.exports = {
+  getErrorLogFields,
+  logger,
+  loggingMiddleware,
+  requestNotExcludedFromLogging,
+  sanitizeQueryParams
+}

--- a/packages/identity-service/test/apiHelpersTest.js
+++ b/packages/identity-service/test/apiHelpersTest.js
@@ -1,0 +1,112 @@
+const assert = require('assert')
+
+const {
+  errorResponseBadRequest,
+  errorResponseServerError,
+  sendResponse
+} = require('../src/apiHelpers')
+const { getErrorLogFields, sanitizeQueryParams } = require('../src/logging')
+
+function createLogger(events, fields = {}) {
+  return {
+    child(childFields) {
+      return createLogger(events, { ...fields, ...childFields })
+    },
+    debug(...args) {
+      events.push({ level: 'debug', fields, args })
+    },
+    error(...args) {
+      events.push({ level: 'error', fields, args })
+    }
+  }
+}
+
+function createReq(events) {
+  return {
+    logger: createLogger(events),
+    originalUrl: '/test',
+    startTime: process.hrtime()
+  }
+}
+
+function createRes() {
+  return {
+    body: undefined,
+    statusCode: undefined,
+    status(statusCode) {
+      this.statusCode = statusCode
+      return this
+    },
+    send(body) {
+      this.body = body
+      return this
+    }
+  }
+}
+
+describe('apiHelpers logging', function () {
+  it('logs expected 4xx responses at debug instead of error', function () {
+    const events = []
+    const res = createRes()
+
+    sendResponse(
+      createReq(events),
+      res,
+      errorResponseBadRequest('Invalid credentials')
+    )
+
+    assert.strictEqual(res.statusCode, 400)
+    assert.deepStrictEqual(res.body, { error: 'Invalid credentials' })
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0].level, 'debug')
+    assert.strictEqual(events[0].fields.statusCode, 400)
+    assert.strictEqual(events[0].fields.errorMessage, 'Invalid credentials')
+  })
+
+  it('keeps 5xx responses at error', function () {
+    const events = []
+    const res = createRes()
+
+    sendResponse(
+      createReq(events),
+      res,
+      errorResponseServerError('Internal server error')
+    )
+
+    assert.strictEqual(res.statusCode, 500)
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0].level, 'error')
+    assert.strictEqual(events[0].fields.statusCode, 500)
+  })
+})
+
+describe('identity-service log shaping', function () {
+  it('redacts sensitive request query parameters', function () {
+    assert.strictEqual(
+      sanitizeQueryParams(
+        'email=fb%40audius.co&otp=123456&lookupKey=abc&limit=10'
+      ),
+      'email=%5Bredacted%5D&otp=%5Bredacted%5D&lookupKey=%5Bredacted%5D&limit=10'
+    )
+  })
+
+  it('keeps axios-style error logs compact', function () {
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:80')
+    error.code = 'ECONNREFUSED'
+    error.config = {
+      method: 'get',
+      url: 'undefined/users?wallet=0xabc',
+      request: { large: true }
+    }
+    error.response = { status: 503 }
+
+    assert.deepStrictEqual(getErrorLogFields(error), {
+      name: 'Error',
+      message: 'connect ECONNREFUSED 127.0.0.1:80',
+      code: 'ECONNREFUSED',
+      status: 503,
+      method: 'get',
+      url: 'undefined/users'
+    })
+  })
+})

--- a/packages/identity-service/test/index.ts
+++ b/packages/identity-service/test/index.ts
@@ -1,4 +1,5 @@
 require('./expressAppTest')
+require('./apiHelpersTest')
 require('./authenticationTest')
 require('./relayTest')
 require('./configTest')


### PR DESCRIPTION
## Summary

- Move expected identity-service 4xx responses from error logs to debug logs while preserving 5xx responses at error level.
- Redact sensitive query parameters in request log context and add compact error shaping for axios-style failures.
- Use the compact error shape for auth backfill failures so dependency errors do not serialize giant request objects.
- Add helper tests covering 4xx/5xx log levels, query redaction, and compact axios-style error fields.

## Context

A live `stern -n identity-service .` sample showed most app-container log volume coming from expected client-side 400s (`/users/check?email=` and invalid `/authentication` credentials). The pasted `updateBlockchainIds` giant log and repeated download-app email delivery logs come from the older deployed notification runtime; current code has already removed that runtime, and this PR handles the remaining central response/logging path.

## Verification

- `node -c packages/identity-service/src/apiHelpers.js && node -c packages/identity-service/src/authMiddleware.js && node -c packages/identity-service/src/logging.js && node -c packages/identity-service/test/apiHelpersTest.js && node -c packages/identity-service/test/index.ts`
- `git diff --check`

Not run: full `npm test -w identity-service`; this worktree is missing local workspace test dependencies (`../../node_modules/ts-mocha`, plus `bunyan`/`mocha`). The attempted run created the standard test Postgres/Redis containers before failing, and those containers were removed.
