### PR TITLE
Fix SDK album creation with provided id

### DIFF
--- a/.changeset/fix-blank-album-create.md
+++ b/.changeset/fix-blank-album-create.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fix `AlbumsApi.createAlbum` when callers provide an `albumId`, ensuring the id is passed through as playlist create metadata and blank album creation sends explicit empty playlist contents.

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -5,7 +5,11 @@ import { describe, it, expect, vitest, beforeAll } from 'vitest'
 
 import { developmentConfig } from '../../config/development'
 import { createAppWalletClient } from '../../services/AudiusWalletClient'
-import { EntityManagerClient } from '../../services/EntityManager'
+import {
+  EntityManagerAction,
+  EntityManagerClient,
+  EntityType
+} from '../../services/EntityManager'
 import { Logger } from '../../services/Logger'
 import { SolanaRelay } from '../../services/Solana/SolanaRelay'
 import { SolanaRelayWalletAdapter } from '../../services/Solana/SolanaRelayWalletAdapter'
@@ -69,7 +73,7 @@ vitest
     return 1
   })
 
-vitest
+const manageEntitySpy = vitest
   .spyOn(EntityManagerClient.prototype, 'manageEntity')
   .mockImplementation(async () => {
     return {
@@ -145,6 +149,40 @@ describe('AlbumsApi', () => {
     vitest.spyOn(console, 'info').mockImplementation(() => {})
     vitest.spyOn(console, 'debug').mockImplementation(() => {})
     vitest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  describe('createAlbum', () => {
+    it('creates a blank album with a provided album id', async () => {
+      manageEntitySpy.mockClear()
+
+      const result = await albums.createAlbum({
+        userId: '7eP5n',
+        albumId: 'x5pJ3Aj',
+        metadata: {
+          albumName: 'My Album'
+        }
+      })
+
+      expect(result).toStrictEqual({
+        blockHash: 'a',
+        blockNumber: 1,
+        playlistId: 'x5pJ3Aj'
+      })
+      expect(manageEntitySpy).toHaveBeenCalledTimes(1)
+
+      const manageEntityOptions = manageEntitySpy.mock.calls[0]![0]
+      expect(manageEntityOptions.entityType).toBe(EntityType.PLAYLIST)
+      expect(manageEntityOptions.action).toBe(EntityManagerAction.CREATE)
+
+      const metadata = JSON.parse(manageEntityOptions.metadata!)
+      expect(metadata.data).toMatchObject({
+        is_album: true,
+        playlist_contents: [],
+        playlist_id: manageEntityOptions.entityId,
+        playlist_name: 'My Album'
+      })
+      expect(metadata.data).not.toHaveProperty('album_id')
+    })
   })
 
   describe('uploadAlbum', () => {

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -152,6 +152,36 @@ describe('AlbumsApi', () => {
   })
 
   describe('createAlbum', () => {
+    it('does not pass album id as a top-level playlist create param', async () => {
+      const createPlaylistSpy = vitest
+        .spyOn((albums as any).playlistsApi, 'createPlaylist')
+        .mockResolvedValueOnce({ playlistId: 'x5pJ3Aj' } as any)
+
+      try {
+        await albums.createAlbum({
+          userId: '7eP5n',
+          albumId: 'x5pJ3Aj',
+          metadata: {
+            albumName: 'My Album'
+          }
+        })
+
+        const playlistParams = createPlaylistSpy.mock.calls[0]![0]
+        expect(playlistParams).not.toHaveProperty('albumId')
+        expect(playlistParams).toMatchObject({
+          userId: '7eP5n',
+          metadata: {
+            isAlbum: true,
+            playlistContents: [],
+            playlistId: 'x5pJ3Aj',
+            playlistName: 'My Album'
+          }
+        })
+      } finally {
+        createPlaylistSpy.mockRestore()
+      }
+    })
+
     it('creates a blank album with a provided album id', async () => {
       manageEntitySpy.mockClear()
 

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
@@ -86,16 +86,26 @@ export class AlbumsApi {
     params: CreateAlbumRequestWithFiles,
     requestInit?: RequestInit
   ) {
-    const { metadata, albumId, ...rest } = params
+    const { albumId, imageFile, metadata, onProgress, trackIds, userId } = params
     const { albumName, ...playlistMetadata } = metadata
+    const timestamp = Math.floor(Date.now() / 1000)
+    const playlistContents =
+      playlistMetadata.playlistContents ??
+      (trackIds ?? []).map((trackId) => ({
+        trackId,
+        timestamp,
+        metadataTimestamp: timestamp
+      }))
 
     // Transform album request to playlist request
     const playlistParams = {
-      ...rest,
+      imageFile,
+      onProgress,
+      userId,
       metadata: {
         ...playlistMetadata,
         ...(albumId ? { playlistId: albumId } : {}),
-        playlistContents: playlistMetadata.playlistContents ?? [],
+        playlistContents,
         playlistName: albumName,
         isAlbum: true
       }

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
@@ -86,7 +86,7 @@ export class AlbumsApi {
     params: CreateAlbumRequestWithFiles,
     requestInit?: RequestInit
   ) {
-    const { metadata, ...rest } = params
+    const { metadata, albumId, ...rest } = params
     const { albumName, ...playlistMetadata } = metadata
 
     // Transform album request to playlist request
@@ -94,6 +94,8 @@ export class AlbumsApi {
       ...rest,
       metadata: {
         ...playlistMetadata,
+        ...(albumId ? { playlistId: albumId } : {}),
+        playlistContents: playlistMetadata.playlistContents ?? [],
         playlistName: albumName,
         isAlbum: true
       }

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
@@ -86,7 +86,8 @@ export class AlbumsApi {
     params: CreateAlbumRequestWithFiles,
     requestInit?: RequestInit
   ) {
-    const { albumId, imageFile, metadata, onProgress, trackIds, userId } = params
+    const { albumId, imageFile, metadata, onProgress, trackIds, userId } =
+      params
     const { albumName, ...playlistMetadata } = metadata
     const timestamp = Math.floor(Date.now() / 1000)
     const playlistContents =

--- a/packages/sdk/src/sdk/api/albums/types.ts
+++ b/packages/sdk/src/sdk/api/albums/types.ts
@@ -54,6 +54,7 @@ export type UpdateAlbumRequestBody = Omit<
 export type CreateAlbumRequest = {
   userId: string
   albumId?: string
+  trackIds?: string[]
   metadata: CreateAlbumRequestBody
 }
 

--- a/packages/web/turbo.json
+++ b/packages/web/turbo.json
@@ -12,6 +12,7 @@
         "@audius/fixed-decimal#build",
         "@audius/harmony#build",
         "@audius/eth#build",
+        "@audius/sdk#build",
         "@audius/spl#build"
       ],
       "outputLogs": "new-only",
@@ -24,6 +25,7 @@
         "@audius/fixed-decimal#build",
         "@audius/harmony#build",
         "@audius/eth#build",
+        "@audius/sdk#build",
         "@audius/spl#build"
       ],
       "outputLogs": "new-only"
@@ -36,6 +38,7 @@
         "@audius/fixed-decimal#build",
         "@audius/harmony#build",
         "@audius/eth#build",
+        "@audius/sdk#build",
         "@audius/spl#build"
       ],
       "outputLogs": "new-only"


### PR DESCRIPTION
## Summary
- map `albumId` onto playlist create metadata as `playlistId` when `AlbumsApi.createAlbum` delegates to playlists
- send explicit empty `playlistContents` for blank album creation
- add regression coverage for creating a blank album with a provided album id

## Testing
- `git diff --check`
- `npm run test -w @audius/sdk -- AlbumsApi.test.ts` *(fails before collecting tests in this local workspace because `@audius/spl` is symlinked but unbuilt: Vite cannot resolve its `dist` entry after the SDK-scoped install)*