### PR TITLE
feat(email-verification): expose isEmailVerified to client + settings UI

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -145,6 +145,7 @@ export * from './tan-query/users/useOtherChatUsers'
 // Account
 export * from './tan-query/users/account/useResetPassword'
 export * from './tan-query/users/account/useResendRecoveryEmail'
+export * from './tan-query/users/account/useCurrentUserEmail'
 
 // Playlist updates
 export * from './tan-query/playlist-updates/usePlaylistUpdates'

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -46,6 +46,7 @@ export const QUERY_KEYS = {
   salesCount: 'salesCount',
   mutualFollowers: 'mutualFollowers',
   emailInUse: 'emailInUse',
+  currentUserEmail: 'currentUserEmail',
   handleInUse: 'handleInUse',
   handleReservedStatus: 'handleReservedStatus',
   search: 'search',

--- a/packages/common/src/api/tan-query/users/account/useCurrentUserEmail.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentUserEmail.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { UserEmailResponse } from '~/services/auth/identity'
+
+import { QUERY_KEYS } from '../../queryKeys'
+import { QueryKey, QueryOptions } from '../../types'
+import { useQueryContext } from '../../utils'
+
+import { useCurrentUserId } from './useCurrentUserId'
+
+export const getCurrentUserEmailQueryKey = () =>
+  [QUERY_KEYS.currentUserEmail] as unknown as QueryKey<UserEmailResponse>
+
+/**
+ * Hook to get the currently logged in user's email address and email
+ * verification status from identity service.
+ */
+export const useCurrentUserEmail = (options?: QueryOptions) => {
+  const { identityService } = useQueryContext()
+  const { data: currentUserId } = useCurrentUserId()
+
+  return useQuery({
+    queryKey: getCurrentUserEmailQueryKey(),
+    queryFn: () => identityService.getUserEmailAndStatus(),
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
+  })
+}

--- a/packages/common/src/messages/settings.ts
+++ b/packages/common/src/messages/settings.ts
@@ -69,6 +69,8 @@ export const settingsMessages = {
   emailVerificationAlreadyVerified: 'Your email is already verified.',
   emailVerificationNotSent:
     'Unable to send verification email. Please try again!',
+  emailVerifiedStatus: 'Email verified',
+  emailNotVerifiedStatus: 'Email not verified',
   changeEmailButtonText: 'Change Email',
   changePasswordButtonText: 'Change Password',
   desktopAppButtonText: 'Get The App',

--- a/packages/common/src/services/auth/identity.ts
+++ b/packages/common/src/services/auth/identity.ts
@@ -30,6 +30,11 @@ type ResendEmailVerificationResponse = {
   alreadyVerified?: boolean
 }
 
+export type UserEmailResponse = {
+  email: string | undefined | null
+  isEmailVerified: boolean
+}
+
 enum TransactionMetadataType {
   PURCHASE_SOL_AUDIO_SWAP = 'PURCHASE_SOL_AUDIO_SWAP'
 }
@@ -220,16 +225,24 @@ export class IdentityService {
   }
 
   /**
-   * Get the user's email used for notifications and display.
+   * Get the user's email and verification status used for notifications and
+   * display.
    */
-  async getUserEmail() {
+  async getUserEmailAndStatus() {
     const headers = await this.getAuthHeaders()
 
-    const res = await this._makeRequest<{ email: string | undefined | null }>({
+    return await this._makeRequest<UserEmailResponse>({
       url: '/user/email',
       method: 'get',
       headers
     })
+  }
+
+  /**
+   * Get the user's email used for notifications and display.
+   */
+  async getUserEmail() {
+    const res = await this.getUserEmailAndStatus()
 
     if (!res.email) {
       throw new Error('No email found')

--- a/packages/identity-service/src/routes/user.js
+++ b/packages/identity-service/src/routes/user.js
@@ -198,7 +198,8 @@ module.exports = function (app) {
       })
 
       return successResponse({
-        email: userData.email
+        email: userData.email,
+        isEmailVerified: userData.isEmailVerified
       })
     })
   )

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsItem.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsItem.tsx
@@ -2,7 +2,13 @@ import type { ComponentType } from 'react'
 
 import type { SvgProps } from 'react-native-svg'
 
-import { Button } from '@audius/harmony-native'
+import {
+  Button,
+  Flex,
+  IconError,
+  IconValidationCheck,
+  Text
+} from '@audius/harmony-native'
 import { makeStyles } from 'app/styles'
 
 import { SettingsRowLabel } from './SettingRowLabel'
@@ -16,33 +22,66 @@ type AccountSettingsItemProps = {
   buttonTitle: string
   onPress?: () => void
   disabled?: boolean
+  /** Optional verification status shown above the action button. */
+  isVerified?: boolean
+  verifiedText?: string
+  notVerifiedText?: string
+  /** Hide the action button (e.g. once the email is verified). */
+  hideButton?: boolean
 }
 
 const useStyles = makeStyles(({ spacing }) => ({
   button: {
     marginTop: spacing(2)
+  },
+  status: {
+    marginTop: spacing(2)
   }
 }))
 
 export const AccountSettingsItem = (props: AccountSettingsItemProps) => {
-  const { title, titleIcon, description, buttonTitle, onPress, disabled } =
-    props
+  const {
+    title,
+    titleIcon,
+    description,
+    buttonTitle,
+    onPress,
+    disabled,
+    isVerified,
+    verifiedText,
+    notVerifiedText,
+    hideButton
+  } = props
   const styles = useStyles()
 
   return (
     <SettingsRow>
       <SettingsRowLabel label={title} icon={titleIcon} />
       <SettingsRowDescription>{description}</SettingsRowDescription>
-      <Button
-        style={styles.button}
-        variant='secondary'
-        size='small'
-        fullWidth
-        onPress={onPress}
-        disabled={disabled}
-      >
-        {buttonTitle}
-      </Button>
+      {verifiedText && notVerifiedText ? (
+        <Flex row alignItems='center' gap='xs' style={styles.status}>
+          {isVerified ? (
+            <IconValidationCheck size='s' />
+          ) : (
+            <IconError size='s' color='subdued' />
+          )}
+          <Text variant='body' size='s' color='subdued'>
+            {isVerified ? verifiedText : notVerifiedText}
+          </Text>
+        </Flex>
+      ) : null}
+      {hideButton ? null : (
+        <Button
+          style={styles.button}
+          variant='secondary'
+          size='small'
+          fullWidth
+          onPress={onPress}
+          disabled={disabled}
+        >
+          {buttonTitle}
+        </Button>
+      )}
     </SettingsRow>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import {
   useCurrentAccountUser,
+  useCurrentUserEmail,
   useQueryContext,
   useResendRecoveryEmail
 } from '@audius/common/api'
@@ -52,6 +53,8 @@ const messages = {
   emailVerificationAlreadyVerified: 'Your email is already verified.',
   emailVerificationNotSent:
     'Unable to send verification email. Please try again!',
+  emailVerifiedStatus: 'Email verified',
+  emailNotVerifiedStatus: 'Email not verified',
   verifyTitle: 'Verification',
   verifyDescription:
     'Verify your Audius profile by completing identity verification.',
@@ -90,6 +93,8 @@ export const AccountSettingsScreen = () => {
   const { identityService } = useQueryContext()
   const [isSendingVerificationEmail, setIsSendingVerificationEmail] =
     useState(false)
+  const { data: emailData } = useCurrentUserEmail()
+  const isEmailVerified = emailData?.isEmailVerified
   const { data: accountData } = useCurrentAccountUser({
     select: (user) => pick(user, ['user_id', 'handle', 'name'])
   })
@@ -191,6 +196,10 @@ export const AccountSettingsScreen = () => {
             buttonTitle={messages.emailVerificationButtonTitle}
             onPress={handlePressEmailVerification}
             disabled={isSendingVerificationEmail}
+            isVerified={isEmailVerified}
+            verifiedText={messages.emailVerifiedStatus}
+            notVerifiedText={messages.emailNotVerifiedStatus}
+            hideButton={isEmailVerified}
           />
           <AccountSettingsItem
             title={messages.verifyTitle}

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { useCurrentAccountUser, useQueryContext } from '@audius/common/api'
+import {
+  useCurrentAccountUser,
+  useCurrentUserEmail,
+  useQueryContext
+} from '@audius/common/api'
 import { useIsManagedAccount } from '@audius/common/hooks'
 import { settingsMessages } from '@audius/common/messages'
 import {
@@ -39,6 +43,7 @@ import {
   IconReceive,
   IconSettings,
   IconSignOut,
+  IconValidationCheck,
   IconVerified,
   Modal,
   ModalContent,
@@ -158,6 +163,8 @@ export const SettingsPage = () => {
   const emailFrequency = useSelector(getEmailFrequency)
   const notificationSettings = useSelector(getBrowserNotificationSettings)
   const { tier } = useTierAndVerifiedForUser(userId)
+  const { data: emailData } = useCurrentUserEmail()
+  const isEmailVerified = emailData?.isEmailVerified
   const showMatrix =
     tier === 'gold' ||
     tier === 'platinum' ||
@@ -649,22 +656,39 @@ export const SettingsPage = () => {
             title={settingsMessages.emailVerificationCardTitle}
             description={settingsMessages.emailVerificationCardDescription}
           >
-            <Toast
-              text={emailVerificationToastText}
-              open={isEmailVerificationToastVisible}
-              className={styles.cardToast}
-              anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
-              transformOrigin={{ horizontal: 'center', vertical: 'top' }}
-            >
-              <Button
-                onClick={showEmailVerificationToast}
-                variant='secondary'
-                fullWidth
-                isLoading={isEmailVerificationLoading}
-              >
-                {settingsMessages.emailVerificationButtonText}
-              </Button>
-            </Toast>
+            <Flex direction='column' gap='s'>
+              <Flex alignItems='center' gap='xs'>
+                {isEmailVerified ? (
+                  <IconValidationCheck size='s' />
+                ) : (
+                  <IconError size='s' color='subdued' />
+                )}
+                <Text variant='body' size='s' color='subdued'>
+                  {isEmailVerified
+                    ? settingsMessages.emailVerifiedStatus
+                    : settingsMessages.emailNotVerifiedStatus}
+                </Text>
+              </Flex>
+              {!isEmailVerified ? (
+                <Toast
+                  text={emailVerificationToastText}
+                  open={isEmailVerificationToastVisible}
+                  className={styles.cardToast}
+                  anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
+                  transformOrigin={{ horizontal: 'center', vertical: 'top' }}
+                >
+                  <Button
+                    onClick={showEmailVerificationToast}
+                    variant='secondary'
+                    fullWidth
+                    isLoading={isEmailVerificationLoading}
+                    disabled={isEmailVerificationLoading}
+                  >
+                    {settingsMessages.emailVerificationButtonText}
+                  </Button>
+                </Toast>
+              ) : null}
+            </Flex>
           </SettingsCard>
         ) : null}
         {!isManagedAccount ? (

--- a/packages/web/src/pages/settings-page/components/mobile/AccountSettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/mobile/AccountSettingsPage.tsx
@@ -1,6 +1,10 @@
 import { useState, useContext, useCallback } from 'react'
 
-import { useQueryContext, useCurrentAccountUser } from '@audius/common/api'
+import {
+  useQueryContext,
+  useCurrentAccountUser,
+  useCurrentUserEmail
+} from '@audius/common/api'
 import { Name, SquareSizes } from '@audius/common/models'
 import { useTierAndVerifiedForUser } from '@audius/common/store'
 import { route } from '@audius/common/utils'
@@ -8,8 +12,10 @@ import {
   Button,
   IconRecoveryEmail,
   IconEmailAddress,
+  IconError,
   IconKey,
   IconSignOut,
+  IconValidationCheck,
   IconVerified,
   Flex,
   Text,
@@ -53,6 +59,8 @@ const messages = {
   emailVerificationAlreadyVerified: 'Your email is already verified.',
   emailVerificationNotSent:
     'Unable to send verification email. Please try again!',
+  emailVerifiedStatus: 'Email verified',
+  emailNotVerifiedStatus: 'Email not verified',
   verifyTitle: 'Verify Your Account',
   verifyDescription:
     'Verify your Audius profile by completing identity verification',
@@ -83,6 +91,12 @@ type AccountSettingsItemProps = {
   buttonTitle: string
   disabled?: boolean
   onClick: () => void
+  /** Optional verification status shown above the action button. */
+  isVerified?: boolean
+  verifiedText?: string
+  notVerifiedText?: string
+  /** Hide the action button (e.g. once the email is verified). */
+  hideButton?: boolean
 }
 
 const AccountSettingsItem = ({
@@ -91,7 +105,11 @@ const AccountSettingsItem = ({
   icon: Icon,
   buttonTitle,
   disabled,
-  onClick
+  onClick,
+  isVerified,
+  verifiedText,
+  notVerifiedText,
+  hideButton
 }: AccountSettingsItemProps) => {
   const { color } = useTheme()
   return (
@@ -123,15 +141,29 @@ const AccountSettingsItem = ({
       >
         {description}
       </Text>
-      <Button
-        variant='secondary'
-        size='small'
-        fullWidth
-        onClick={onClick}
-        disabled={disabled}
-      >
-        {buttonTitle}
-      </Button>
+      {verifiedText && notVerifiedText ? (
+        <Flex alignItems='center' gap='xs'>
+          {isVerified ? (
+            <IconValidationCheck size='s' />
+          ) : (
+            <IconError size='s' color='subdued' />
+          )}
+          <Text variant='body' size='xs' color='subdued'>
+            {isVerified ? verifiedText : notVerifiedText}
+          </Text>
+        </Flex>
+      ) : null}
+      {hideButton ? null : (
+        <Button
+          variant='secondary'
+          size='small'
+          fullWidth
+          onClick={onClick}
+          disabled={disabled}
+        >
+          {buttonTitle}
+        </Button>
+      )}
     </Flex>
   )
 }
@@ -147,6 +179,8 @@ const AccountSettingsPage = () => {
     })
   })
   const { userId, handle, name } = accountData ?? {}
+  const { data: emailData } = useCurrentUserEmail()
+  const isEmailVerified = emailData?.isEmailVerified
   const [showModalSignOut, setShowModalSignOut] = useState(false)
   const [isSendingVerificationEmail, setIsSendingVerificationEmail] =
     useState(false)
@@ -239,6 +273,10 @@ const AccountSettingsPage = () => {
           buttonTitle={messages.emailVerificationButtonTitle}
           onClick={onClickResendVerificationEmail}
           disabled={isSendingVerificationEmail}
+          isVerified={isEmailVerified}
+          verifiedText={messages.emailVerifiedStatus}
+          notVerifiedText={messages.emailNotVerifiedStatus}
+          hideButton={isEmailVerified}
         />
         <AccountSettingsItem
           icon={IconVerified}


### PR DESCRIPTION
## Summary

Completes the remaining email-verification work: exposes the identity-service `isEmailVerified` flag to clients and surfaces verification status in account settings on all three clients (web desktop, mobile-web, React Native).

The backend already stored `isEmailVerified`, had `/email/verify` + `/email/resend-verification` endpoints, the `/verify-email` landing page, and resend UI in settings. This PR wires the verification *status* through to the UI.

## Changes

**Expose `isEmailVerified`**
- `identity-service`: include `isEmailVerified` in the `GET /user/email` response.
- `common`: add `IdentityService.getUserEmailAndStatus()` returning `{ email, isEmailVerified }` (existing `getUserEmail()` now delegates to it — no caller changes), and a new `useCurrentUserEmail` tan-query hook.

**Settings status indicator (all 3 clients)**
- Show a "Email verified" (check) / "Email not verified" (error) indicator in the Email Verification card.
- Hide the "Resend Verification Email" button once the email is verified.

**Desktop resend button**
- Add `disabled` while the request is in-flight, matching mobile-web and RN (it already had `isLoading`).

## Note on data flow
The audit suggested adding `isEmailVerified` to `UserMetadata` and mapping it through the SDK account adapter. Email and verification status live in **identity-service** (`/user/email`), not in the SDK/discovery user model, so a field on `UserMetadata` would never be populated. Instead the status flows through the dedicated `useCurrentUserEmail` hook, which the settings pages read directly.

## Testing
- `tsc` passes for `@audius/common`, `@audius/web`, `@audius/mobile`.
- `eslint` clean for all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)