### PR TITLE
fix: Dedupe track collaborators

### DIFF
--- a/packages/common/src/adapters/track.test.ts
+++ b/packages/common/src/adapters/track.test.ts
@@ -68,6 +68,21 @@ describe('getTrackCollaboratorsForEdit', () => {
       })
     ).toEqual([accepted, pending])
   })
+
+  it('deduplicates collaborators and excludes the owner', () => {
+    const accepted = makeUserMetadata(2)
+    const duplicateAccepted = makeUserMetadata(2)
+    const pending = makeUserMetadata(3)
+    const owner = makeUserMetadata(1)
+
+    expect(
+      getTrackCollaboratorsForEdit({
+        owner_id: 1,
+        collaborators: [accepted, duplicateAccepted, owner],
+        pending_collaborators: [pending, accepted]
+      })
+    ).toEqual([accepted, pending])
+  })
 })
 
 describe('userTrackMetadataFromSDK', () => {
@@ -129,6 +144,22 @@ describe('trackMetadataForUploadToSdk', () => {
     const result = trackMetadataForUploadToSdk(
       makeMetadata({
         collaborators: [makeUserMetadata(2), makeUserMetadata(3)]
+      })
+    )
+
+    expect(result).toMatchObject({ collaborators: [2, 3] })
+  })
+
+  it('deduplicates collaborator user ids before upload', () => {
+    const result = trackMetadataForUploadToSdk(
+      makeMetadata({
+        owner_id: 1,
+        collaborators: [
+          makeUserMetadata(2),
+          makeUserMetadata(2),
+          makeUserMetadata(1),
+          makeUserMetadata(3)
+        ]
       })
     )
 

--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -77,15 +77,34 @@ export const trackSegmentFromSDK = ({
 
 type TrackCollaboratorMetadata = Pick<
   TrackMetadata,
-  'collaborators' | 'pending_collaborators'
+  'owner_id' | 'collaborators' | 'pending_collaborators'
 >
+
+const getUniqueCollaborators = <T extends { user_id: number }>(
+  collaborators: T[],
+  ownerId?: number | null
+): T[] => {
+  const seenUserIds = new Set<number>()
+  if (ownerId) {
+    seenUserIds.add(ownerId)
+  }
+
+  return collaborators.filter((collaborator) => {
+    if (seenUserIds.has(collaborator.user_id)) {
+      return false
+    }
+    seenUserIds.add(collaborator.user_id)
+    return true
+  })
+}
 
 export const getTrackCollaboratorsForEdit = (
   track?: Partial<TrackCollaboratorMetadata> | null
-): NonNullable<TrackMetadata['collaborators']> => [
-  ...(track?.collaborators ?? []),
-  ...(track?.pending_collaborators ?? [])
-]
+): NonNullable<TrackMetadata['collaborators']> =>
+  getUniqueCollaborators(
+    [...(track?.collaborators ?? []), ...(track?.pending_collaborators ?? [])],
+    track?.owner_id
+  )
 
 export const userTrackMetadataFromSDK = (
   input: Track | SearchTrack
@@ -360,7 +379,9 @@ export const trackMetadataForUploadToSdk = (
     // Collaborators are tagged as full user objects in the form; the on-chain
     // metadata carries numeric user ids, which the ETL reconciles into invites.
     collaborators: input.collaborators
-      ? input.collaborators.map((collaborator) => collaborator.user_id)
+      ? getUniqueCollaborators(input.collaborators, input.owner_id).map(
+          (collaborator) => collaborator.user_id
+        )
       : undefined,
     stemOf: input.stem_of
       ? {

--- a/packages/web/src/components/link/TrackArtists.test.tsx
+++ b/packages/web/src/components/link/TrackArtists.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, vi } from 'vitest'
+
+import { render, screen, it } from 'test/test-utils'
+
+import { TrackArtists } from './TrackArtists'
+
+vi.mock('./UserLink', () => ({
+  UserLink: ({ userId }: { userId: number }) => (
+    <span data-testid='user-link'>{userId}</span>
+  )
+}))
+
+describe('TrackArtists', () => {
+  it('renders the owner once when collaborators are empty', () => {
+    render(<TrackArtists userId={1} collaborators={[]} />)
+
+    expect(screen.getAllByTestId('user-link')).toHaveLength(1)
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('deduplicates collaborators and excludes the owner', () => {
+    render(
+      <TrackArtists
+        userId={1}
+        collaborators={[
+          { user_id: 2 },
+          { user_id: 2 },
+          { user_id: 1 },
+          { user_id: 3 },
+          { user_id: 3 }
+        ]}
+      />
+    )
+
+    expect(
+      screen.getAllByTestId('user-link').map((link) => link.textContent)
+    ).toEqual(['1', '2', '3'])
+    expect(screen.getAllByText(',')).toHaveLength(2)
+  })
+})

--- a/packages/web/src/components/link/TrackArtists.tsx
+++ b/packages/web/src/components/link/TrackArtists.tsx
@@ -24,7 +24,14 @@ export const TrackArtists = ({
   collaborators,
   ...userLinkProps
 }: TrackArtistsProps) => {
-  const extraArtists = collaborators ?? []
+  const seenUserIds = new Set<ID>([userId])
+  const extraArtists = (collaborators ?? []).filter((collaborator) => {
+    if (seenUserIds.has(collaborator.user_id)) {
+      return false
+    }
+    seenUserIds.add(collaborator.user_id)
+    return true
+  })
 
   if (extraArtists.length === 0) {
     return <UserLink userId={userId} {...userLinkProps} />


### PR DESCRIPTION
## Summary
- Deduplicate collaborator artists before rendering track artist bylines, excluding the track owner from the extra artist list.
- Deduplicate accepted and pending collaborators when preparing edit metadata and when serializing collaborator IDs for upload.
- Add regression coverage for duplicate collaborator display and upload mapping.

## API-side note
The API/indexer should ideally also enforce collaborator uniqueness at the write or read boundary so clients do not receive duplicated users. This client-side guard is still useful because it protects current web surfaces from any already-indexed, cached, or malformed collaborator payloads.

## Testing
- npm run test -w @audius/common -- src/adapters/track.test.ts --run
- npm run test -w @audius/web -- src/components/link/TrackArtists.test.tsx --run
- npm run lint -w @audius/web -- src/components/link/TrackArtists.tsx src/components/link/TrackArtists.test.tsx
- cd packages/common && npx eslint src/adapters/track.ts src/adapters/track.test.ts
- git diff --check
