### PR TITLE
fix(events): prevent follow button flash on contest page

### DIFF
--- a/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
+++ b/packages/mobile/src/screens/contest-screen/ContestScreen.tsx
@@ -169,7 +169,8 @@ export const ContestScreen = () => {
   const eventId = contest?.eventId
 
   const { data: currentUserId } = useCurrentUserId()
-  const { data: followState } = useEventFollowState(eventId)
+  const { data: followState, isPending: isFollowStatePending } =
+    useEventFollowState(eventId)
   const { mutate: followEvent } = useFollowEvent()
   const { mutate: unfollowEvent } = useUnfollowEvent()
   const isOwner = !!currentUserId && currentUserId === track?.owner_id
@@ -444,10 +445,18 @@ export const ContestScreen = () => {
                 variant={followState?.isFollowed ? 'secondary' : 'primary'}
                 size='small'
                 onPress={handleToggleFollow}
+                // Show a spinner while the follow state loads instead of
+                // defaulting to "Follow", which would flash before snapping
+                // to "Following" for users who already follow the contest.
+                isLoading={isFollowStatePending}
                 disabled={!currentUserId || !eventId}
                 fullWidth
               >
-                {followState?.isFollowed ? messages.following : messages.follow}
+                {isFollowStatePending
+                  ? ''
+                  : followState?.isFollowed
+                    ? messages.following
+                    : messages.follow}
               </Button>
             </Flex>
             {!isEnded ? (

--- a/packages/web/src/pages/contest-page/ContestPage.test.tsx
+++ b/packages/web/src/pages/contest-page/ContestPage.test.tsx
@@ -263,6 +263,24 @@ describe('ContestPage', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('does not flash "Follow" while the follow state is still loading', () => {
+    // Mid-flight: no data yet. The button must not render the unfollowed
+    // "Follow" label, otherwise it flashes before snapping to "Following"
+    // for users who already follow the contest.
+    mocks.useEventFollowState.mockReturnValue({
+      data: undefined,
+      isPending: true
+    })
+    renderContestPage()
+
+    expect(
+      screen.queryByRole('button', { name: /^follow$/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /^following$/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('includes the track title in the page header when the contest is attached to a track', () => {
     renderContestPage()
     // The redesigned hero composes the display title as

--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -220,7 +220,8 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
   const eventId = contest?.eventId
 
   const { data: currentUserId } = useCurrentUserId()
-  const { data: followState } = useEventFollowState(eventId)
+  const { data: followState, isPending: isFollowStatePending } =
+    useEventFollowState(eventId)
   const { mutate: followEvent } = useFollowEvent()
   const { mutate: unfollowEvent } = useUnfollowEvent()
   // Drives the Following → Unfollow label swap on hover for the contest
@@ -452,12 +453,17 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
           size='small'
           variant={isFollowed ? 'primary' : 'secondary'}
           iconLeft={followIcon}
+          // While the follow state is still loading, render a spinner-only
+          // button (fixed width keeps layout stable) so it doesn't flash
+          // "Follow" before snapping to "Following" for users who already
+          // follow the contest.
+          isLoading={isFollowStatePending}
           onClick={handleToggleFollow}
           onMouseEnter={() => setIsFollowHovering(true)}
           onMouseLeave={() => setIsFollowHovering(false)}
           css={{ width: 112, justifyContent: 'center' }}
         >
-          {followLabel}
+          {isFollowStatePending ? '' : followLabel}
         </Button>
         {!isEnded ? (
           <Button size='small' onClick={handleEnterContest}>
@@ -471,6 +477,7 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     isOwner,
     isEnded,
     followState?.isFollowed,
+    isFollowStatePending,
     isFollowHovering,
     handleToggleFollow,
     handleEditContest,


### PR DESCRIPTION
## Summary

Small UX nit reported by Ray in Slack: when loading a contest page, the Follow button briefly flashes **"Follow"** (unfollowed state) before snapping to **"Following"** for users who already follow the contest.

## Cause

The button derived its state from `useEventFollowState` with `const isFollowed = !!followState?.isFollowed`. While the query is in-flight `followState` is `undefined`, so `isFollowed` evaluates to `false` and the button renders the unfollowed "Follow" state — then re-renders to "Following" once the query resolves.

Note: a `placeholderData`/`staleTime` tweak on the query does **not** fix this — React Query already returns cached data immediately, so the flash only happens on a genuine first load with no cache. The real fix is to not commit to a label until the data resolves.

## Fix

Gate the visible follow button on the query's `isPending` state. While loading, render a spinner-only button (the fixed width keeps layout stable) instead of the misleading "Follow" label:

- **`packages/web/.../desktop/ContestPage.tsx`** — `isLoading={isFollowStatePending}`, empty label while pending.
- **`packages/mobile/.../contest-screen/ContestScreen.tsx`** — same treatment on the RN button.
- **Mobile web** (`components/mobile/ContestPage.tsx`) hides follow inside an overflow kebab menu, so there's no visible flash on load — left unchanged.

## Test

Added a regression test to `ContestPage.test.tsx` asserting that neither "Follow" nor "Following" renders while the follow state is still loading. Full contest-page suite passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)