### PR TITLE
chore(ci): reduce GitHub Actions spend

### DIFF
--- a/.github/workflows/identity.yml
+++ b/.github/workflows/identity.yml
@@ -25,6 +25,12 @@ on:
       - '.github/workflows/identity.yml'
   workflow_dispatch:
 
+# Cancel superseded PR runs; on main, head_ref is empty so the docker-push run
+# is never cancelled by a subsequent push.
+concurrency:
+  group: identity-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NODE_VERSION: '24.10.0'
 

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -12,7 +12,6 @@ on:
       - 'packages/sdk/**'
       - 'package-lock.json'
       - '.github/workflows/mobile.yml'
-      - '.circleci/**'
   workflow_dispatch:
     inputs:
       ota_channel:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,6 +22,11 @@ on:
       - '.github/workflows/sdk.yml'
   workflow_dispatch:
 
+# Cancel superseded PR runs when new commits are pushed.
+concurrency:
+  group: sdk-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NODE_VERSION: '24.10.0'
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -12,7 +12,6 @@ on:
       - 'packages/sdk/**'
       - 'package-lock.json'
       - '.github/workflows/web.yml'
-      - '.circleci/**'
   pull_request:
     paths:
       - 'packages/web/**'
@@ -22,8 +21,14 @@ on:
       - 'packages/sdk/**'
       - 'package-lock.json'
       - '.github/workflows/web.yml'
-      - '.circleci/**'
   workflow_dispatch:
+
+# Cancel superseded PR runs (new commits supersede in-flight CI). Keyed on the
+# PR branch for PRs; on main, head_ref is empty so runs group by ref and do NOT
+# cancel — an in-flight production deploy is never interrupted by a new push.
+concurrency:
+  group: web-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NODE_VERSION: '24.10.0'
@@ -379,7 +384,10 @@ jobs:
     name: Web Deploy Preview
     runs-on: ubuntu-latest
     needs: web-build
-    if: github.event_name == 'pull_request'
+    # Opt-in: only deploy a live Cloudflare preview when the PR carries the
+    # `preview` label. Most PRs don't need one, and each preview is a build
+    # download + two wrangler deploys. Add the label to get a preview URL.
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview')
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Goal
Cut GitHub Actions spend across web/identity/sdk CI.

## Changes
- **Concurrency cancellation (web, identity, sdk):** add `cancel-in-progress` keyed on the PR branch, so pushing new commits to a PR cancels the superseded in-flight run. Keyed as `${{ github.head_ref || github.ref }}` with `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` so **main deploys are never cancelled** by a subsequent push.
- **Opt-in web preview (web):** `web-deploy-preview` now requires a `preview` label on the PR. Most PRs don't need a live Cloudflare preview, and each one is a build download + two `wrangler` deploys. Add the `preview` label to get a preview URL.
- **Dead path filters (web, mobile):** removed `.circleci/**` from `paths:` — CircleCI is fully removed, so those entries never match.

## Not changed (already lean)
- **Mobile `macos-26` jobs** (10× cost) already run **only on push to main + when the app version changed**, and mobile has no `pull_request` trigger at all — so macOS spend is already minimized. Left as-is.

## Estimated savings
Concurrency cancellation saves on every multi-push PR (web runs ~6 ubuntu jobs per run); preview gating removes a deploy job from the majority of PRs. Rough estimate **~$5–8/mo** of the ~$36/mo.

## ⚠️ Reviewer check
The preview-label gate changes dev workflow (previews become opt-in). If the team prefers previews-by-default, say so and I'll drop that hunk — the concurrency + dead-path cleanups stand on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)