### PR TITLE
Fix AUDIO migration for missing userbanks

### DIFF
--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -1,5 +1,6 @@
 import { AUDIO, wAUDIO, AudioWei } from '@audius/fixed-decimal'
 import { type AudiusSdkWithServices, Id } from '@audius/sdk'
+import { getAccount } from '@solana/spl-token'
 import { PublicKey } from '@solana/web3.js'
 
 import { userWalletsFromSDK } from '~/adapters'
@@ -9,7 +10,6 @@ import { isNullOrUndefined } from '~/utils/typeUtils'
 
 import {
   AudiusBackend,
-  getUserbankAccountInfo,
   pollForTokenBalanceChange
 } from '../audius-backend'
 import { Env } from '../env'
@@ -68,10 +68,15 @@ export class WalletClient {
     ethAddress: string
   }): Promise<string> {
     const sdk = await this.audiusSdk()
-    const account = await getUserbankAccountInfo(sdk, {
-      ethAddress,
-      mint: 'wAUDIO'
-    })
+    const { userBank } =
+      await sdk.services.claimableTokensClient.getOrCreateUserBank({
+        ethWallet: ethAddress,
+        mint: 'wAUDIO'
+      })
+    const account = await getAccount(
+      sdk.services.solanaClient.connection,
+      userBank
+    )
     if (!account) {
       throw new Error('No userbank account.')
     }


### PR DESCRIPTION
## Summary
- create the wAUDIO userbank before attempting legacy ERC-20 AUDIO migration
- read the newly-created/existing token account and use it as the Wormhole recipient
- prevents older accounts with an ETH AUDIO balance but no Solana userbank from failing before the bridge transaction is sent

## Root cause
The migration path called `getUserbankAccountInfo` first. For legacy accounts whose derived wAUDIO userbank had never been created, that read failed before the flow could send the permit or Wormhole transfer, surfacing only the generic “Migration failed, please try again” toast.

## Testing
- `git diff --check`
- Not run: `npm run typecheck -w @audius/common -- --pretty false` (`tsc: command not found`; this worktree has no installed `node_modules`).