### PR TITLE
Fix empty comments loading state

### DIFF
--- a/packages/common/src/api/tan-query/comments/types.ts
+++ b/packages/common/src/api/tan-query/comments/types.ts
@@ -4,6 +4,7 @@ export type CommentOrReply = Comment | ReplyComment
 
 export const COMMENT_ROOT_PAGE_SIZE = 15
 export const COMMENT_REPLIES_PAGE_SIZE = 15
+export const COMMENT_LIST_MUTATION_KEY = ['commentListMutation'] as const
 
 export const messages = {
   loadError: (type: 'comments' | 'replies') =>

--- a/packages/common/src/api/tan-query/comments/useDeleteComment.ts
+++ b/packages/common/src/api/tan-query/comments/useDeleteComment.ts
@@ -7,7 +7,7 @@ import { useQueryContext } from '~/api/tan-query/utils'
 import { Comment, ID, ReplyComment } from '~/models'
 import { toast } from '~/store/ui/toast/slice'
 
-import { messages } from './types'
+import { COMMENT_LIST_MUTATION_KEY, messages } from './types'
 import {
   getCommentQueryKey,
   getTrackCommentListQueryKey,
@@ -27,6 +27,7 @@ export const useDeleteComment = () => {
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
   return useMutation({
+    mutationKey: COMMENT_LIST_MUTATION_KEY,
     mutationFn: async ({ commentId, userId }: DeleteCommentArgs) => {
       const commentData = {
         userId: Id.parse(userId),

--- a/packages/common/src/api/tan-query/comments/useMuteUser.ts
+++ b/packages/common/src/api/tan-query/comments/useMuteUser.ts
@@ -6,7 +6,7 @@ import { useQueryContext } from '~/api/tan-query/utils'
 import { Comment, ID } from '~/models'
 import { toast } from '~/store/ui/toast/slice'
 
-import { messages } from './types'
+import { COMMENT_LIST_MUTATION_KEY, messages } from './types'
 import {
   getCommentQueryKey,
   getTrackCommentCountQueryKey,
@@ -27,6 +27,7 @@ export const useMuteUser = () => {
   const dispatch = useDispatch()
 
   return useMutation({
+    mutationKey: COMMENT_LIST_MUTATION_KEY,
     mutationFn: async ({ userId, mutedUserId, isMuted }: MuteUserArgs) => {
       const sdk = await audiusSdk()
       await sdk.comments.muteUser(userId, mutedUserId, isMuted)

--- a/packages/common/src/api/tan-query/comments/usePinComment.ts
+++ b/packages/common/src/api/tan-query/comments/usePinComment.ts
@@ -10,7 +10,7 @@ import { Nullable } from '~/utils'
 
 import { getTrackQueryKey } from '../tracks/useTrack'
 
-import { messages } from './types'
+import { COMMENT_LIST_MUTATION_KEY, messages } from './types'
 import { getTrackCommentListQueryKey } from './utils'
 
 export type PinCommentArgs = {
@@ -27,6 +27,7 @@ export const usePinComment = () => {
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
   return useMutation({
+    mutationKey: COMMENT_LIST_MUTATION_KEY,
     mutationFn: async (args: PinCommentArgs) => {
       const { userId, commentId, isPinned, trackId } = args
       const sdk = await audiusSdk()

--- a/packages/common/src/api/tan-query/comments/usePostComment.ts
+++ b/packages/common/src/api/tan-query/comments/usePostComment.ts
@@ -6,6 +6,7 @@ import { useQueryContext } from '~/api/tan-query/utils'
 import { Comment, ID } from '~/models'
 import { toast } from '~/store/ui/toast/slice'
 
+import { COMMENT_LIST_MUTATION_KEY } from './types'
 import {
   addCommentCount,
   getCommentQueryKey,
@@ -30,6 +31,7 @@ export const usePostComment = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
+    mutationKey: COMMENT_LIST_MUTATION_KEY,
     mutationFn: async (args: PostCommentArgs) => {
       const sdk = await audiusSdk()
       return await sdk.comments.createComment({

--- a/packages/common/src/api/tan-query/comments/useReportComment.ts
+++ b/packages/common/src/api/tan-query/comments/useReportComment.ts
@@ -7,7 +7,7 @@ import { useQueryContext } from '~/api/tan-query/utils'
 import { Comment, ID, ReplyComment } from '~/models'
 import { toast } from '~/store/ui/toast/slice'
 
-import { messages } from './types'
+import { COMMENT_LIST_MUTATION_KEY, messages } from './types'
 import {
   getCommentQueryKey,
   getTrackCommentListQueryKey,
@@ -27,6 +27,7 @@ export const useReportComment = () => {
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
   return useMutation({
+    mutationKey: COMMENT_LIST_MUTATION_KEY,
     mutationFn: async ({ userId, commentId }: ReportCommentArgs) => {
       const sdk = await audiusSdk()
       await sdk.comments.reportComment({

--- a/packages/common/src/api/tan-query/comments/useTrackComments.ts
+++ b/packages/common/src/api/tan-query/comments/useTrackComments.ts
@@ -21,7 +21,11 @@ import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { primeCommentData } from '../utils/primeCommentData'
 import { primeRelatedData } from '../utils/primeRelatedData'
 
-import { COMMENT_ROOT_PAGE_SIZE, messages } from './types'
+import {
+  COMMENT_LIST_MUTATION_KEY,
+  COMMENT_ROOT_PAGE_SIZE,
+  messages
+} from './types'
 import { useComments } from './useComments'
 import { getTrackCommentListQueryKey } from './utils'
 
@@ -46,7 +50,9 @@ const useTrackCommentsQuery = (
   options?: QueryOptions
 ) => {
   const { audiusSdk } = useQueryContext()
-  const isMutating = useIsMutating()
+  const isMutatingCommentList = useIsMutating({
+    mutationKey: COMMENT_LIST_MUTATION_KEY
+  })
   const queryClient = useQueryClient()
   const { data: currentUserId } = useCurrentUserId()
 
@@ -84,7 +90,8 @@ const useTrackCommentsQuery = (
     staleTime: Infinity, // Stale time is set to infinity so that we never reload data thats currently shown on screen (because sorting could have changed)
     gcTime: 0, // Cache time is set to 1 so that the data is cleared any time we leave the page viewing it or change sorts
     ...options,
-    enabled: isMutating === 0 && options?.enabled !== false && !!trackId
+    enabled:
+      isMutatingCommentList === 0 && options?.enabled !== false && !!trackId
   })
 }
 

--- a/packages/common/src/api/tan-query/comments/useUserComments.ts
+++ b/packages/common/src/api/tan-query/comments/useUserComments.ts
@@ -18,7 +18,11 @@ import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { primeCommentData } from '../utils/primeCommentData'
 import { primeRelatedData } from '../utils/primeRelatedData'
 
-import { COMMENT_ROOT_PAGE_SIZE, messages } from './types'
+import {
+  COMMENT_LIST_MUTATION_KEY,
+  COMMENT_ROOT_PAGE_SIZE,
+  messages
+} from './types'
 import { useComments } from './useComments'
 
 export const useUserComments = (
@@ -33,7 +37,9 @@ export const useUserComments = (
 ) => {
   const { audiusSdk } = useQueryContext()
   const { data: currentUserId } = useCurrentUserId()
-  const isMutating = useIsMutating()
+  const isMutatingCommentList = useIsMutating({
+    mutationKey: COMMENT_LIST_MUTATION_KEY
+  })
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
 
@@ -68,7 +74,8 @@ export const useUserComments = (
     },
     select: (data) => data.pages.flat(),
     ...options,
-    enabled: isMutating === 0 && options?.enabled !== false && !!userId
+    enabled:
+      isMutatingCommentList === 0 && options?.enabled !== false && !!userId
   })
 
   const { error, data: commentIds } = queryRes

--- a/packages/common/src/api/tan-query/comments/utils.test.ts
+++ b/packages/common/src/api/tan-query/comments/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCommentSectionLoading } from './utils'
+
+describe('getCommentSectionLoading', () => {
+  it('does not show the loading state when the comment count is known to be zero', () => {
+    expect(
+      getCommentSectionLoading({
+        commentCount: 0,
+        isLoadingMorePages: false,
+        status: 'pending'
+      })
+    ).toBe(false)
+  })
+
+  it('shows the loading state while the initial comment list is pending for non-empty counts', () => {
+    expect(
+      getCommentSectionLoading({
+        commentCount: 1,
+        isLoadingMorePages: false,
+        status: 'pending'
+      })
+    ).toBe(true)
+  })
+
+  it('does not show the loading state while loading additional pages', () => {
+    expect(
+      getCommentSectionLoading({
+        commentCount: 1,
+        isLoadingMorePages: true,
+        status: 'pending'
+      })
+    ).toBe(false)
+  })
+})

--- a/packages/common/src/api/tan-query/comments/utils.ts
+++ b/packages/common/src/api/tan-query/comments/utils.ts
@@ -8,6 +8,20 @@ import { QueryKey } from '../types'
 
 import { CommentOrReply, TrackCommentCount } from './types'
 
+type CommentQueryStatus = 'error' | 'pending' | 'success'
+
+export const getCommentSectionLoading = ({
+  commentCount,
+  isLoadingMorePages,
+  status
+}: {
+  commentCount: number | undefined
+  isLoadingMorePages: boolean
+  status: CommentQueryStatus
+}) => {
+  return status === 'pending' && !isLoadingMorePages && commentCount !== 0
+}
+
 export const getCommentQueryKey = (commentId: ID | null | undefined) => {
   return [QUERY_KEYS.comment, commentId] as unknown as QueryKey<CommentOrReply>
 }

--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -19,7 +19,8 @@ import {
   useTrackCommentCount,
   resetPreviousCommentCount,
   useTrack,
-  useCurrentUserId
+  useCurrentUserId,
+  getCommentSectionLoading
 } from '~/api'
 import { useGatedContentAccess } from '~/hooks'
 import { ModalSource, ID, Comment, ReplyComment, Name, Track } from '~/models'
@@ -122,7 +123,6 @@ export function CommentSectionProvider<NavigationProp>(
     data: comments = [],
     commentIds = [],
     status,
-    isFetching,
     hasNextPage,
     fetchNextPage: loadMorePages,
     isFetchingNextPage: isLoadingMorePages
@@ -148,6 +148,7 @@ export function CommentSectionProvider<NavigationProp>(
     commentCountData?.previousValue !== undefined &&
     commentCountData?.currentValue !== undefined &&
     commentCountData?.previousValue < commentCountData?.currentValue
+  const commentCount = commentCountData?.currentValue ?? track?.comment_count
 
   const dispatch = useDispatch()
 
@@ -226,8 +227,11 @@ export function CommentSectionProvider<NavigationProp>(
     ]
   )
 
-  const commentSectionLoading =
-    (status === 'pending' || isFetching) && !isLoadingMorePages
+  const commentSectionLoading = getCommentSectionLoading({
+    commentCount,
+    isLoadingMorePages,
+    status
+  })
 
   if (!track) {
     return null
@@ -242,7 +246,7 @@ export function CommentSectionProvider<NavigationProp>(
         artistId: owner_id,
         entityId,
         entityType,
-        commentCount: commentCountData?.currentValue ?? track.comment_count,
+        commentCount,
         isCommentCountLoading,
         commentIds,
         commentSectionLoading,


### PR DESCRIPTION
## Summary
- render the empty comments state immediately when a track comment count is known to be 0
- scope comment-list query pausing to mutations that actually rewrite comment lists
- add coverage for the comment-section loading predicate

## Verification
- `git diff --check`
- live check: `https://audius.co/migueldbj/m-mix-2` resolved to `Comments (0)` / empty state in browser
- attempted `npm run test -w @audius/common -- --run src/api/tan-query/comments/utils.test.ts`, but this worktree initially had no dependencies installed and the common workspace did not expose `vitest`; attempted lint was also blocked by missing shared ESLint config in the partial dependency tree