### PR TITLE
fix(mobile): reduce swipe sensitivity on profile page scroll

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -251,7 +251,13 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
       <Stack.Screen
         name='Profile'
         component={ProfileScreen}
-        options={{ headerShown: false }}
+        // Profile uses a collapsible tab view (horizontal pager + vertical
+        // scroll). The global `fullScreenGestureEnabled: true` makes the
+        // swipe-to-pop recognizer span the whole screen, so a slightly diagonal
+        // vertical scroll gets hijacked as a back gesture. Restrict swipe-back
+        // to the left edge here (same treatment as the Chat screen) so
+        // mid-screen scrolling reaches the list untouched.
+        options={{ headerShown: false, fullScreenGestureEnabled: false }}
       />
       <Stack.Group>
         <Stack.Screen name='Followers' component={FollowersScreen} />


### PR DESCRIPTION
## Problem

On mobile profile pages, any slightly diagonal scroll motion triggers the left/right swipe navigation (back gesture) instead of scrolling vertically. The profile page is noticeably harder to scroll than the feed, which scrolls fine.

## Root cause

The app's global stack `screenOptions` (`useAppScreenOptions.tsx`) intentionally enables **full-screen** swipe-to-pop:

```ts
animation: 'simple_push',
customAnimationOnGesture: true,
fullScreenGestureEnabled: true,
```

This makes RNScreens' `RNSPanGestureRecognizer` span the entire screen so users can swipe back from anywhere. On the **Profile** screen — which layers a horizontal tab pager + vertical scroll via `react-native-collapsible-tab-view` — that full-screen recognizer grabs any slightly-diagonal drag before the list can scroll vertically.

The **feed is unaffected** because it's a root tab screen: there's nothing to pop, so no back-swipe competes with its vertical scroll. Only pushed screens like Profile hit this.

## Fix

Set `fullScreenGestureEnabled: false` on the `Profile` `Stack.Screen`, restricting swipe-back to the left edge. Mid-screen vertical/diagonal drags now reach the scroll list; the tab pager and edge swipe-back both keep working.

This mirrors the existing precedent on the `Chat` screen, which disabled the full-screen gesture for the same class of gesture conflict.

## Testing

Requires a device/simulator (native gesture behavior, not automatable):
- [ ] Open an artist profile, scroll vertically with a slightly diagonal finger motion → scrolls instead of popping back
- [ ] Swipe from the far-left edge → still navigates back
- [ ] Horizontal swipes between tabs (Tracks/Albums/etc.) → still switch tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)