### PR TITLE
Fix DM unread dot layering

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatListItem.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatListItem.module.css
@@ -64,6 +64,8 @@
 .minimizedUnreadIndicatorTag {
   display: none;
   position: absolute;
+  /* Harmony Image renders the avatar img at z-index 2. */
+  z-index: 3;
   top: var(--harmony-unit-4);
   right: var(--harmony-unit-4);
   height: var(--harmony-unit-4);


### PR DESCRIPTION
## Summary
- raise the compact DM unread indicator above the profile image layer
- keep the existing compact DM layout unchanged

## Verification
- git diff --check
- stylelint not run locally: node_modules are not installed in this worktree, and npx tried to fetch a newer Stylelint dependency that npm rejected under the date-pinned install window