### PR TITLE
Fix Launch VIP Discord mixed content

### DIFF
--- a/packages/web/src/services/env/env.prod.test.ts
+++ b/packages/web/src/services/env/env.prod.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { env } from './env.prod'
+
+describe('production env', () => {
+  it('uses HTTPS for the Discord bot server', () => {
+    expect(env.DISCORD_BOT_SERVER).toBe('https://discord.audius.co')
+  })
+})

--- a/packages/web/src/services/env/env.prod.ts
+++ b/packages/web/src/services/env/env.prod.ts
@@ -82,5 +82,5 @@ export const env: Env = {
   EMAIL_ENCRYPTION_UUID: 61969424,
   EMAIL_ENCRYPTION_PUBLIC_KEY:
     'BMpaZ9tHeeNXvmEL1bqxbcJfi0HOcp+Zf1HARJ+N5ZPUwqYuUU67td1GgE1NjX+hb2j39OwI9wjfBmnfagHKMqk=',
-  DISCORD_BOT_SERVER: 'http://discord.audius.co'
+  DISCORD_BOT_SERVER: 'https://discord.audius.co'
 }


### PR DESCRIPTION
## Summary
- switch the production Discord bot server from HTTP to HTTPS
- add a regression test covering the production Discord endpoint

## Diagnosis
The Launch VIP Discord flow was blocked by the browser because `https://audius.co/rewards` tried to fetch `http://discord.audius.co/request_discord_code`. The HTTP endpoint redirects to HTTPS, but browsers block mixed-content requests before following that redirect.

## Follow-ups
- App POST client change: https://github.com/AudiusProject/apps/pull/14521
- Bot POST support: https://github.com/AudiusProject/discord-audio-bot/pull/24
- k8s JWT secret wiring: https://github.com/AudiusProject/audius-k8s/pull/514

## Test plan
- `git diff --check -- packages/web/src/services/env/env.prod.ts packages/web/src/services/env/env.prod.test.ts`
- `curl -sSIL --max-time 10 https://discord.audius.co/request_discord_code` returns an app-level response over HTTPS, confirming the HTTPS endpoint is reachable

Could not run the focused Vitest test locally because this worktree had no installed `node_modules`, so `vitest` was unavailable (`sh: vitest: command not found`).