### PR TITLE
Use POST for Discord JWT request

### DIFF
--- a/packages/common/src/hooks/useGetDiscordOAuthLink.ts
+++ b/packages/common/src/hooks/useGetDiscordOAuthLink.ts
@@ -22,12 +22,16 @@ const requestDiscordJWT = async (sdk: AudiusSdkWithServices, env: Env) => {
     message: data
   })
   const response = await fetch(
-    `${env.DISCORD_BOT_SERVER}/request_discord_code?signature=${encodeURIComponent(signature)}&message=${encodeURIComponent(data)}`,
+    `${env.DISCORD_BOT_SERVER}/request_discord_code`,
     {
-      method: 'GET',
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      body: JSON.stringify({
+        message: data,
+        signature
+      })
     }
   )
   if (!response.ok) {
@@ -47,6 +51,8 @@ export const useGetDiscordOAuthLink = (currentCoin?: string) => {
       jwt: discordJWT.token,
       currentCoin
     })
-    return `${AUDIUS_DISCORD_OAUTH_LINK}&state=${statePayload}`
+    return `${AUDIUS_DISCORD_OAUTH_LINK}&state=${encodeURIComponent(
+      statePayload
+    )}`
   }, [audiusSdk, env, currentCoin])
 }


### PR DESCRIPTION
## Summary
- send the Discord JWT request as `POST /request_discord_code` with a JSON body instead of query params
- encode the Discord OAuth `state` payload before appending it to the OAuth URL

## Context
PR #14520 fixed the mixed-content issue by switching the production Discord bot URL to HTTPS. This follow-up moves signature/message transport out of the URL and into a JSON request body, avoiding URL length and query logging concerns.

## Companion PRs
- Bot POST support: https://github.com/AudiusProject/discord-audio-bot/pull/24
- k8s JWT secret wiring: https://github.com/AudiusProject/audius-k8s/pull/514

## Rollout
Merge/deploy after the bot supports POST. Recommended order:
1. Create/set `discord-bot-JWT_SECRET` in GCP Secret Manager.
2. Merge/apply the k8s secret wiring PR.
3. Merge/deploy the bot POST-support PR.
4. Merge/deploy this apps PR.

## Test plan
- `git diff --check`

Could not run local Vitest because this worktree has no installed `node_modules`, so `vitest` is unavailable (`sh: vitest: command not found`).