### PR TITLE
fix(privacy): hide profile photo and banner for deactivated accounts

### DIFF
--- a/packages/mobile/src/components/image/CoverPhoto.tsx
+++ b/packages/mobile/src/components/image/CoverPhoto.tsx
@@ -39,10 +39,13 @@ export const useCoverPhoto = ({
     defaultImage: ''
   })
   const { data: partialUser } = useUser(userId, {
-    select: (user) => pick(user, 'cover_photo', 'updatedCoverPhoto')
+    select: (user) =>
+      pick(user, 'cover_photo', 'updatedCoverPhoto', 'is_deactivated')
   })
-  const { cover_photo, updatedCoverPhoto } = partialUser ?? {}
-  const coverPhoto = cover_photo
+  const { cover_photo, updatedCoverPhoto, is_deactivated } = partialUser ?? {}
+  // Deactivated/deleted accounts must not expose their cover photo
+  // (privacy/GDPR) — force the default placeholder instead.
+  const coverPhoto = is_deactivated ? undefined : cover_photo
   const { imageUrl, onError: onImageError } = useImageSize({
     artwork: coverPhoto,
     targetSize: size,

--- a/packages/mobile/src/components/image/UserImage.tsx
+++ b/packages/mobile/src/components/image/UserImage.tsx
@@ -28,16 +28,20 @@ export const useProfilePicture = ({
   defaultImage?: string
 }) => {
   const { data: partialUser } = useUser(userId, {
-    select: (user) => pick(user, 'profile_picture', 'updatedProfilePicture')
+    select: (user) =>
+      pick(user, 'profile_picture', 'updatedProfilePicture', 'is_deactivated')
   })
 
-  const { profile_picture, updatedProfilePicture } = partialUser ?? {}
+  const { profile_picture, updatedProfilePicture, is_deactivated } =
+    partialUser ?? {}
   const {
     imageUrl,
     priorityLowResUrl,
     onError: onImageError
   } = useImageSize({
-    artwork: profile_picture,
+    // Deactivated/deleted accounts must not expose their profile picture
+    // (privacy/GDPR) — force the default placeholder instead.
+    artwork: is_deactivated ? undefined : profile_picture,
     targetSize: size,
     defaultImage: '',
     preloadImageFn: async (url: string) => {
@@ -45,7 +49,7 @@ export const useProfilePicture = ({
     }
   })
 
-  if (imageUrl === '') {
+  if (is_deactivated || imageUrl === '') {
     return {
       source: profilePicEmpty,
       isFallbackImage: true,

--- a/packages/web/src/hooks/useCoverPhoto.ts
+++ b/packages/web/src/hooks/useCoverPhoto.ts
@@ -30,11 +30,14 @@ export const useCoverPhoto = ({
     defaultImage: imageProfilePicEmpty
   })
   const { data: partialUser } = useUser(userId, {
-    select: (user) => pick(user, 'cover_photo', 'updatedCoverPhoto')
+    select: (user) =>
+      pick(user, 'cover_photo', 'updatedCoverPhoto', 'is_deactivated')
   })
-  const { cover_photo, updatedCoverPhoto } = partialUser ?? {}
+  const { cover_photo, updatedCoverPhoto, is_deactivated } = partialUser ?? {}
   const { imageUrl } = useImageSize({
-    artwork: cover_photo,
+    // Deactivated/deleted accounts must not expose their cover photo
+    // (privacy/GDPR) — force the default placeholder instead.
+    artwork: is_deactivated ? undefined : cover_photo,
     targetSize: size,
     defaultImage: defaultImage ?? imageCoverPhotoBlank,
     preloadImageFn: preload
@@ -49,6 +52,9 @@ export const useCoverPhoto = ({
     defaultProfilePicture: imageProfilePicEmpty
   })
 
+  if (is_deactivated) {
+    return { image: defaultImage ?? imageCoverPhotoBlank, shouldBlur: false }
+  }
   if (updatedCoverPhoto) {
     return { image: updatedCoverPhoto.url, shouldBlur: false }
   }

--- a/packages/web/src/hooks/useProfilePicture.ts
+++ b/packages/web/src/hooks/useProfilePicture.ts
@@ -16,17 +16,24 @@ export const useProfilePicture = ({
   defaultImage?: string
 }) => {
   const { data: partialUser } = useUser(userId, {
-    select: (user) => pick(user, 'profile_picture', 'updatedProfilePicture')
+    select: (user) =>
+      pick(user, 'profile_picture', 'updatedProfilePicture', 'is_deactivated')
   })
-  const { profile_picture, updatedProfilePicture } = partialUser ?? {}
+  const { profile_picture, updatedProfilePicture, is_deactivated } =
+    partialUser ?? {}
 
   const { imageUrl } = useImageSize({
-    artwork: profile_picture,
+    // Deactivated/deleted accounts must not expose their profile picture
+    // (privacy/GDPR) — force the default placeholder instead.
+    artwork: is_deactivated ? undefined : profile_picture,
     targetSize: size,
     defaultImage: defaultImage ?? profilePicEmpty,
     preloadImageFn: preload
   })
 
+  if (is_deactivated) {
+    return defaultImage ?? profilePicEmpty
+  }
   if (updatedProfilePicture) {
     return updatedProfilePicture.url
   }

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -451,7 +451,7 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
     >
       <Box ref={profileFocusRootRef} w='100%' pb='2xl'>
         <CoverPhoto
-          userId={userId}
+          userId={isDeactivated ? null : userId}
           updatedCoverPhoto={updatedCoverPhoto ? updatedCoverPhoto.url : ''}
           error={updatedCoverPhoto ? updatedCoverPhoto.error : false}
           loading={status === Status.LOADING}
@@ -484,7 +484,7 @@ const ProfilePage = ({ containerRef }: ProfilePageProps) => {
               >
                 {/* @ts-ignore */}
                 <ProfilePicture
-                  userId={userId}
+                  userId={isDeactivated ? undefined : userId}
                   updatedProfilePicture={
                     updatedProfilePicture ? updatedProfilePicture.url : ''
                   }

--- a/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
@@ -1,10 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 
 import { useArtistCreatedFanClub } from '@audius/common/api'
-import {
-  imageCoverPhotoBlank,
-  imageProfilePicEmpty
-} from '@audius/common/assets'
+import { imageCoverPhotoBlank } from '@audius/common/assets'
 import {
   Name,
   SquareSizes,
@@ -202,7 +199,7 @@ const ProfileHeader = ({
     userId,
     size: WidthSizes.SIZE_2000
   })
-  coverPhoto = isDeactivated ? imageProfilePicEmpty : coverPhoto
+  coverPhoto = isDeactivated ? imageCoverPhotoBlank : coverPhoto
   let coverPhotoStyle = {}
   if (coverPhoto === imageCoverPhotoBlank) {
     coverPhotoStyle = {
@@ -299,7 +296,9 @@ const ProfileHeader = ({
         {isEditing && <UploadStub onChange={onUpdateCoverPhoto} />}
       </GrowingCoverPhoto>
       <Image
-        src={updatedProfilePicture || profilePicture}
+        src={
+          isDeactivated ? undefined : updatedProfilePicture || profilePicture
+        }
         alt={messages.profilePicAltText}
         className={cn(styles.profilePictureWrapper, styles.profilePicture, {
           [styles.isEditing]: isEditing


### PR DESCRIPTION
## Problem

A deactivated/deleted artist account (reported in Slack: `audius.co/cyranomusic`) still displayed their **profile photo and banner** on the profile page. This is a privacy/GDPR concern — a user who deletes their account should no longer have their uploaded images shown.

## Fix

When `is_deactivated` is `true`, force the default placeholder for both the profile picture and the cover photo instead of resolving the user's uploaded images.

The fix is applied **centrally in the shared image hooks** so the placeholder renders everywhere a deactivated user's avatar/banner would otherwise appear (profile page, comments, follower lists, cards, etc.), not just the profile page:

- **Web** — `packages/web/src/hooks/useProfilePicture.ts`, `packages/web/src/hooks/useCoverPhoto.ts`
- **Mobile** — `packages/mobile/src/components/image/UserImage.tsx` (`useProfilePicture`), `packages/mobile/src/components/image/CoverPhoto.tsx` (`useCoverPhoto`)

Plus explicit/defensive handling in the web profile page components:

- `packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx`
- `packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx`

## Platforms

- ✅ Web (desktop + mobile web)
- ✅ Mobile (iOS + Android — shared hooks)

## Testing

- Lint passes on all changed files.
- Manual: view a deactivated account's profile → profile picture and banner render as the default placeholders instead of the user's images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)