### PR TITLE
fix(web): show Stems & Downloads section for stem-only tracks

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -3,7 +3,8 @@ import { useCallback, useState, useEffect, useRef } from 'react'
 import {
   useTrackRank,
   useToggleFavoriteTrack,
-  useTrack
+  useTrack,
+  useStems
 } from '@audius/common/api'
 import {
   isContentUSDCPurchaseGated,
@@ -194,7 +195,8 @@ export const GiantTrackTile = ({
   const { data: collaborators } = useTrack(trackId, {
     select: (track) => track.collaborators
   })
-  const shouldShowDownloadSection = !!track?.is_downloadable
+  const { data: stems = [] } = useStems(trackId)
+  const shouldShowDownloadSection = !!track?.is_downloadable || stems.length > 0
   // Preview button is shown for USDC-gated tracks if user does not have access
   // or is the owner
   const showPreview =

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback } from 'react'
 
-import { useTrack, useTrackRank } from '@audius/common/api'
+import { useTrack, useTrackRank, useStems } from '@audius/common/api'
 import {
   SquareSizes,
   isContentUSDCPurchaseGated,
@@ -185,22 +185,16 @@ const TrackHeader = ({
         album_backlink: track?.album_backlink,
         release_date: track?.release_date,
         ddex_app: track?.ddex_app,
-        permalink: track?.permalink,
-        _stems: track?._stems
+        permalink: track?.permalink
       }
     }
   })
-  const {
-    is_downloadable,
-    album_backlink,
-    release_date,
-    ddex_app,
-    permalink,
-    _stems
-  } = partialTrack ?? {}
+  const { is_downloadable, album_backlink, release_date, ddex_app, permalink } =
+    partialTrack ?? {}
 
   const dispatch = useDispatch()
-  const hasDownloadableAssets = is_downloadable || (_stems?.length ?? 0) > 0
+  const { data: stems = [] } = useStems(trackId)
+  const hasDownloadableAssets = is_downloadable || stems.length > 0
 
   const showSocials = !isUnlisted && hasStreamAccess
   const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)


### PR DESCRIPTION
## Problem

Reported in Slack: after purchasing a premium sample pack on web, the extras (downloadable files) never appear. Michael could see them on the native mobile app but not on web.

Repro track: [Sounds For The People Vol. 2 | ATMO & TEXTURES](https://audius.co/FullCrate/sample-pack-%7C-sounds-for-the-people-vol-2-%7C-atmo-textures)

## Root cause

This is **not** a post-purchase access-gate problem — the section never renders for this track regardless of purchase state.

The web track page gated the Stems & Downloads section on `is_downloadable` alone:

```ts
// GiantTrackTile.tsx
const shouldShowDownloadSection = !!track?.is_downloadable
```

Sample packs have `is_downloadable === false` — the purchased content is entirely stems. Confirmed against the reported track via the API:

```
is_downloadable   = false
is_download_gated = true
stem count        = 12
```

So the gate evaluated to `false` and the section was never mounted. Native mobile gates on `is_downloadable || stems.length > 0`, which is why it worked there.

The mobile-web `TrackHeader` *looked* correct (`is_downloadable || (_stems?.length ?? 0) > 0`), but `_stems` is a vestigial field on the `Track` model that nothing ever assigns — it's only ever read. That check silently degraded to the same broken condition.

## Fix

Match native mobile's gate on both web surfaces by sourcing stems from the `useStems` query:

- **`GiantTrackTile.tsx`** (desktop) — add the stems check.
- **`TrackHeader.tsx`** (mobile web) — use `useStems` and drop the dead `_stems` read.

## Verification

Ran the web client against production and loaded the reported track logged out, toggling the fix via `git stash` to isolate cause and effect:

- **Before:** no Stems & Downloads section at all.
- **After:** section renders and lists all 12 stems.

The purchase gate itself was already correct — once the section mounts, `useDownloadableContentAccess` drives the locked/unlocked state as expected.

`tsc --noEmit` and `eslint` pass clean on both changed files.

## Notes for reviewers

- Adds a `useStems` query to the desktop track tile. It's the same query the `DownloadSection` already issues, so it's a cache hit rather than an extra request.
- `_stems` is now unread on the track page but still referenced by the purchase modals (`PurchaseContentPage`, `GuestCheckoutPage`, `PremiumContentPurchaseDrawer`, `PurchaseSuccess`), where it looks equally dead — those show a stem count in the purchase UI and are likely rendering `0`. Left alone here to keep this fix scoped; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)