### PR TITLE
fix(explore): wrap trending genre pills and honor the genre from the URL

### DIFF
--- a/packages/mobile/src/screens/explore-screen/components/TrendingGenres.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/TrendingGenres.tsx
@@ -4,7 +4,6 @@ import { usePopularGenres } from '@audius/common/api'
 import { exploreMessages as messages } from '@audius/common/messages'
 import { trendingPageActions } from '@audius/common/store'
 import { toTrendingGenreValue } from '@audius/common/utils'
-import { ScrollView } from 'react-native'
 import { useDispatch } from 'react-redux'
 
 import { Flex, SelectablePill, Skeleton } from '@audius/harmony-native'
@@ -53,33 +52,21 @@ export const TrendingGenres = () => {
   return (
     <InViewWrapper>
       <ExploreSection title={messages.trendingGenres}>
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          keyboardShouldPersistTaps='handled'
-        >
-          <Flex row gap='s' alignItems='center'>
-            {showSkeleton
-              ? Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-                  <Skeleton
-                    key={i}
-                    h={36}
-                    w={96}
-                    borderRadius='2xl'
-                    noShimmer
-                  />
-                ))
-              : topGenres.map((genre) => (
-                  <SelectablePill
-                    key={genre.value}
-                    type='button'
-                    size='large'
-                    label={genre.label}
-                    onPress={() => handleGenrePress(genre.value)}
-                  />
-                ))}
-          </Flex>
-        </ScrollView>
+        <Flex row wrap='wrap' gap='s' alignItems='center'>
+          {showSkeleton
+            ? Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                <Skeleton key={i} h={36} w={96} borderRadius='2xl' noShimmer />
+              ))
+            : topGenres.map((genre) => (
+                <SelectablePill
+                  key={genre.value}
+                  type='button'
+                  size='large'
+                  label={genre.label}
+                  onPress={() => handleGenrePress(genre.value)}
+                />
+              ))}
+        </Flex>
       </ExploreSection>
     </InViewWrapper>
   )

--- a/packages/web/src/pages/trending-page/components/desktop/TrendingPageContent.tsx
+++ b/packages/web/src/pages/trending-page/components/desktop/TrendingPageContent.tsx
@@ -159,12 +159,20 @@ const TrendingPageContent = ({ containerRef }: TrendingPageContentProps) => {
     [dispatch]
   )
 
+  // A `?genre=` in the URL is the user's intent for this visit and must win
+  // over whatever genre an earlier trending visit left behind in redux —
+  // otherwise arriving from Explore with `?genre=Jazz` silently keeps showing
+  // the previous genre. With no genre in the URL, redux still wins so the last
+  // filter is remembered (and gets written back to the URL by the sync effect
+  // below).
+  const genreFromUrlOnMount = useRef(parseUrlParams().genre)
+
   useEffect(() => {
     const { genre, timeRange } = parseUrlParams()
-    if (trendingGenre) {
-      updateGenreUrlParam(trendingGenre, replaceRouteCallback)
-    } else if (isValidGenre(genre)) {
-      dispatch(trendingPageActions.setTrendingGenre(genre as any))
+    if (isValidGenre(genre)) {
+      dispatch(
+        trendingPageActions.setTrendingGenre(toTrendingGenreValue(genre))
+      )
     }
     if (isValidTimeRange(timeRange)) {
       dispatch(trendingPageActions.setTrendingTimeRange(timeRange as TimeRange))
@@ -177,6 +185,13 @@ const TrendingPageContent = ({ containerRef }: TrendingPageContentProps) => {
   }, [trendingTimeRange, replaceRouteCallback])
 
   useEffect(() => {
+    // Skip the first run when the URL already carries the genre: redux has not
+    // caught up with the effect above yet, and writing the stale value back
+    // would clobber the incoming param.
+    if (isValidGenre(genreFromUrlOnMount.current)) {
+      genreFromUrlOnMount.current = null
+      return
+    }
     updateGenreUrlParam(trendingGenre, replaceRouteCallback)
   }, [trendingGenre, replaceRouteCallback])
 

--- a/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.tsx
+++ b/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import {
   getTrendingQueryKey,
@@ -13,7 +20,11 @@ import {
   trendingPageActions,
   trendingPageSelectors
 } from '@audius/common/store'
-import { route, toTrendingGenre } from '@audius/common/utils'
+import {
+  route,
+  toTrendingGenre,
+  toTrendingGenreValue
+} from '@audius/common/utils'
 import {
   FilterButton,
   Flex,
@@ -136,12 +147,20 @@ const TrendingPageMobileContent = ({
     dispatch(pushRoute(TRENDING_GENRES_ROUTE))
   }, [dispatch])
 
+  // A `?genre=` in the URL is the user's intent for this visit and must win
+  // over whatever genre an earlier trending visit left behind in redux —
+  // otherwise arriving from Explore with `?genre=Jazz` silently keeps showing
+  // the previous genre. With no genre in the URL, redux still wins so the last
+  // filter is remembered (and gets written back to the URL by the sync effect
+  // below).
+  const genreFromUrlOnMount = useRef(parseUrlParams().genre)
+
   useEffect(() => {
     const { genre, timeRange } = parseUrlParams()
-    if (trendingGenre) {
-      updateGenreUrlParam(trendingGenre, replaceRouteCallback)
-    } else if (isValidGenre(genre)) {
-      dispatch(trendingPageActions.setTrendingGenre(genre as any))
+    if (isValidGenre(genre)) {
+      dispatch(
+        trendingPageActions.setTrendingGenre(toTrendingGenreValue(genre))
+      )
     }
     if (isValidTimeRange(timeRange)) {
       dispatch(trendingPageActions.setTrendingTimeRange(timeRange as TimeRange))
@@ -152,6 +171,13 @@ const TrendingPageMobileContent = ({
     updateTimeRangeUrlParam(trendingTimeRange, replaceRouteCallback)
   }, [trendingTimeRange, replaceRouteCallback])
   useEffect(() => {
+    // Skip the first run when the URL already carries the genre: redux has not
+    // caught up with the effect above yet, and writing the stale value back
+    // would clobber the incoming param.
+    if (isValidGenre(genreFromUrlOnMount.current)) {
+      genreFromUrlOnMount.current = null
+      return
+    }
     updateGenreUrlParam(trendingGenre, replaceRouteCallback)
   }, [trendingGenre, replaceRouteCallback])
 


### PR DESCRIPTION
## Description

Two fixes for the Trending Genres section on Explore.

**1. Pills only rendered on a single line (mobile)**

The mobile section wrapped its pills in a horizontal `ScrollView`, so only the first few genres were visible and the rest required a sideways swipe that isn't discoverable. It now uses `<Flex row wrap='wrap'>` and flows onto multiple lines, matching the web section (which already wrapped).

**2. Picking a second genre kept showing the first**

Clicking a pill navigates to `/trending?genre=<genre>`, but `TrendingPageContent` preferred the genre in redux over the one in the URL:

```ts
if (trendingGenre) {
  updateGenreUrlParam(trendingGenre, replaceRouteCallback)   // redux wins
} else if (isValidGenre(genre)) {
  dispatch(setTrendingGenre(genre as any))
}
```

Redux keeps `trendingGenre` across visits, so on the second pill click the branch above discarded the incoming `?genre=` and the follow-up sync effect rewrote the URL back to the stale genre. The lineup keys off redux, so it kept showing the old genre.

The mount effect now treats the URL as the source of truth and falls back to redux only when there's no genre param — so landing on a bare `/trending` still remembers the last filter. A ref guards the redux→URL sync effect from clobbering the incoming param on its first run, before redux catches up.

Also switched the dispatch from `genre as any` to `toTrendingGenreValue(genre)`, matching how the page's own genre filter normalizes values (it strips the `Electronic - ` prefix and supports freeform genres).

## How Has This Been Tested?

Verified against the running web app (`npm run web`, prod API), driving Explore → Trending in the browser.

Reproduced the bug and confirmed the fix with the same sequence — load `/trending?genre=Electronic`, go to Explore, then navigate to `/trending?genre=Rock`:

| | resulting URL | redux `trendingGenre` |
|---|---|---|
| before | `?genre=Electronic` | `Electronic` ❌ |
| after | `?genre=Rock` | `Rock` ✅ |

After the fix, the genre filter and lineup both show Rock.

Regressions checked in the browser:
- Bare `/trending` with `Rock` in redux → still remembers Rock and writes `?genre=Rock` back to the URL.
- Clearing to All Genres → `?genre=` is removed and does not come back.
- Deep link to `/trending?genre=Electronic` → loads Electronic.
- Web pills confirmed wrapping across 2 rows at a 976px container (10 pills).

Typecheck and lint pass for `@audius/web` and `@audius/mobile`.

Note: the mobile layout change was not run in a simulator — it's a `ScrollView` → `Flex row wrap='wrap'` swap, and `wrap` is an existing `harmony-native` `Flex` prop used elsewhere in the app, but it's worth a look on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)