### PR TITLE
fix(contest): style contest share as a proper harmony button

### DIFF
--- a/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
+++ b/packages/web/src/pages/contest-page/components/desktop/ContestPage.tsx
@@ -29,7 +29,6 @@ import {
   Divider,
   FilterButton,
   Flex,
-  IconButton,
   IconShare,
   IconUserFollow,
   IconUserFollowing,
@@ -442,9 +441,10 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
     }
     return (
       <Flex gap='s' alignItems='center' wrap='wrap'>
-        <IconButton
-          icon={IconShare}
-          color='default'
+        <Button
+          size='small'
+          variant='secondary'
+          iconLeft={IconShare}
           aria-label={messages.share}
           onClick={handleShareContest}
         />
@@ -530,7 +530,7 @@ const ContestPage = ({ containerRef: _containerRef }: ContestPageProps) => {
                 >
                   <Skeleton h={20} w={140} />
                   <Flex gap='s'>
-                    <Skeleton h={32} w={32} css={{ borderRadius: '50%' }} />
+                    <Skeleton h={32} w={48} />
                     <Skeleton h={32} w={120} />
                     <Skeleton h={32} w={120} />
                   </Flex>


### PR DESCRIPTION
## Description

The share action on the contest page rendered as a bare `IconButton` — an unstyled arrow icon sitting awkwardly next to the properly styled Follow and Enter Contest buttons.

This replaces it with an icon-only harmony `Button` (`variant='secondary'`, `size='small'`, `iconLeft={IconShare}`), matching the Figma design and the height/border/hover treatment of the neighboring buttons. It's the same icon-only button pattern already used by the profile page `StatBanner` action row. The header loading skeleton is updated to match the new rectangular shape.

**Before:** bare arrow icon, no button chrome
**After:** bordered secondary button, 32px tall like Follow / Enter Contest, purple fill on hover

## How Has This Been Tested?

- Verified in the local web client on a live contest page (`/soundsbymystic/contest/mstic-dfwm-1`):
  - Button renders with the same height (32px), corner radius, and inset border as the adjacent Follow button
  - Hover fills purple per the secondary variant
  - Clicking still opens the Share Contest modal
  - `aria-label="Share contest"` preserved
- `eslint` passes on the modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)