### PR TITLE
fix(contest): preserve untouched event_data fields when editing a contest

### DIFF
--- a/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
+++ b/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
@@ -147,7 +147,11 @@ export const HostRemixContestDrawer = () => {
       updateEvent({
         eventId: remixContest.eventId,
         endDate: endDate.toISOString(),
+        // event_data is replaced wholesale by the indexer on update, so
+        // carry over the fields this form doesn't edit (title,
+        // coverPhotoUrl, sourceTrackIds, etc.) instead of dropping them.
         eventData: {
+          ...remixContest.eventData,
           description,
           prizeInfo,
           videoUrl: videoUrl.trim() || undefined,

--- a/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
+++ b/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
@@ -138,7 +138,11 @@ export const HostRemixContestModal = NiceModal.create(() => {
     if (hasError || !trackId || !userId) return
 
     const endDate = parsedDate.toISOString()
+    // event_data is replaced wholesale by the indexer on update, so carry
+    // over the fields this form doesn't edit (title, coverPhotoUrl,
+    // sourceTrackIds, etc.) instead of dropping them.
     const eventData = {
+      ...remixContest?.eventData,
       description: contestDescription,
       prizeInfo: contestPrizeInfo,
       winners: remixContest?.eventData.winners ?? []


### PR DESCRIPTION
## What

Editing a remix contest (web `HostRemixContestModal`, mobile `HostRemixContestDrawer`) rebuilt `eventData` from only the fields the form edits. The indexer's event-update handler replaces `event_data` wholesale (`COALESCE($2, event_data)` with the full marshaled JSON), so saving an edit — e.g. **extending a contest end date** — silently wiped `title`, `coverPhotoUrl`, `sourceTrackIds`, and any other field the form doesn't own.

Spread the existing `eventData` first so untouched fields survive the round-trip. `PickWinnersPage` already follows this pattern.

## Why now

BURKO's Labyrinth contest needs its end date extended (Jul 20 → Aug 3). Without this fix, doing that through the UI destroys the contest's `title` and `source_track_ids`.

## Changes

- `packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx` — spread `remixContest?.eventData` into the submitted `eventData`
- `packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx` — same for the edit branch

## Test plan

- [ ] Edit an existing contest's end date on web; confirm `event_data.title` / `source_track_ids` are unchanged via `GET /v1/events/entity`
- [ ] Same on mobile, including clearing the video URL (an explicit `undefined` still removes it since `JSON.stringify` drops it)
- [ ] Create-contest flow unaffected (spread of `undefined` is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)