### PR TITLE
fix(web): make signup resumable after incomplete account creation

### DIFF
--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -22,6 +22,7 @@ export const VALIDATE_HANDLE_FAILED = 'SIGN_ON/VALIDATE_HANDLE_FAILED'
 export const HIDE_PREVIEW_HINT = 'SIGN_ON/HIDE_PREVIEW_HINT'
 export const FOLLOW_ARTISTS = 'SIGN_ON/FOLLOW_ARTISTS'
 export const SET_ACCOUNT_READY = 'SIGN_ON/SET_ACCOUNT_READY'
+export const SET_IDENTITY_ACCOUNT_READY = 'SIGN_ON/SET_IDENTITY_ACCOUNT_READY'
 
 export const CHECK_EMAIL = 'SIGN_ON/CHECK_EMAIL'
 
@@ -191,6 +192,7 @@ export type SignUpFailedParams = {
   error: string
   phase: string
   redirectRoute?: string
+  shouldRedirect?: boolean
   shouldReport: boolean
   shouldToast: boolean
   message?: string
@@ -201,6 +203,7 @@ export const signUpFailed = ({
   error,
   phase,
   redirectRoute,
+  shouldRedirect,
   shouldReport,
   shouldToast,
   message,
@@ -210,6 +213,7 @@ export const signUpFailed = ({
   error,
   phase,
   redirectRoute,
+  shouldRedirect,
   shouldReport,
   shouldToast,
   message,
@@ -286,6 +290,14 @@ export function setAccountReady() {
 }
 
 /**
+ * Marks the Identity portion of signup complete so core account creation can
+ * be retried without registering the email again.
+ */
+export function setIdentityAccountReady() {
+  return { type: SET_IDENTITY_ACCOUNT_READY }
+}
+
+/**
  * Adds the user ids to be followed on account completion
  * @param userIds The user ids to add as selected and follow
  */
@@ -326,7 +338,10 @@ export const nextPage = (isMobile: boolean) => ({ type: NEXT_PAGE, isMobile })
 export const previousPage = () => ({ type: PREVIOUS_PAGE })
 export const goToPage = (page: Pages) => ({ type: GO_TO_PAGE, page })
 
-export const signUpTimeout = () => ({ type: SIGN_UP_TIMEOUT })
+export const signUpTimeout = () => ({
+  type: SIGN_UP_TIMEOUT,
+  shouldRedirect: false
+})
 export const updateRouteOnCompletion = (route: string) => ({
   type: UPDATE_ROUTE_ON_COMPLETION,
   route

--- a/packages/web/src/common/store/pages/signon/errorSagas.ts
+++ b/packages/web/src/common/store/pages/signon/errorSagas.ts
@@ -18,7 +18,10 @@ function* handleSignOnError(
   const SIGN_IN_ERROR_PREFIX = 'SIGN_ON/SIGN_IN_ERROR_'
 
   // Determine whether the error should redirect to /error and whether it should report it.
-  const shouldRedirect = !noRedirectSet.has(action.type)
+  const shouldRedirect =
+    'shouldRedirect' in action
+      ? (action.shouldRedirect ?? !noRedirectSet.has(action.type))
+      : !noRedirectSet.has(action.type)
 
   const shouldReport = 'shouldReport' in action ? action.shouldReport : true
 

--- a/packages/web/src/common/store/pages/signon/getSignOnRoute.test.ts
+++ b/packages/web/src/common/store/pages/signon/getSignOnRoute.test.ts
@@ -1,0 +1,52 @@
+import {
+  SIGN_IN_PAGE,
+  SIGN_UP_FINISH_PROFILE_PAGE,
+  SIGN_UP_HANDLE_PAGE,
+  SIGN_UP_PASSWORD_PAGE
+} from '@audius/common/src/utils/route'
+import { describe, expect, it } from 'vitest'
+
+import { getSignOnRoute } from './getSignOnRoute'
+import { Pages } from './types'
+
+describe('getSignOnRoute', () => {
+  it('routes Identity-only accounts to handle selection', () => {
+    expect(
+      getSignOnRoute({
+        signIn: false,
+        page: Pages.PROFILE,
+        hasHandle: false
+      })
+    ).toBe(SIGN_UP_HANDLE_PAGE)
+  })
+
+  it('routes indexed incomplete accounts to profile completion', () => {
+    expect(
+      getSignOnRoute({
+        signIn: false,
+        page: Pages.PROFILE,
+        hasHandle: true
+      })
+    ).toBe(SIGN_UP_FINISH_PROFILE_PAGE)
+  })
+
+  it('preserves the guest password resume route', () => {
+    expect(
+      getSignOnRoute({
+        signIn: false,
+        page: Pages.PASSWORD,
+        hasHandle: true
+      })
+    ).toBe(SIGN_UP_PASSWORD_PAGE)
+  })
+
+  it('routes sign-in requests to sign in regardless of page state', () => {
+    expect(
+      getSignOnRoute({
+        signIn: true,
+        page: Pages.PROFILE,
+        hasHandle: true
+      })
+    ).toBe(SIGN_IN_PAGE)
+  })
+})

--- a/packages/web/src/common/store/pages/signon/getSignOnRoute.ts
+++ b/packages/web/src/common/store/pages/signon/getSignOnRoute.ts
@@ -1,0 +1,37 @@
+import {
+  SIGN_IN_PAGE,
+  SIGN_UP_FINISH_PROFILE_PAGE,
+  SIGN_UP_HANDLE_PAGE,
+  SIGN_UP_PAGE,
+  SIGN_UP_PASSWORD_PAGE
+} from '@audius/common/src/utils/route'
+
+import { Pages } from './types'
+
+type GetSignOnRouteParams = {
+  signIn: boolean
+  page: string | null
+  hasHandle: boolean
+}
+
+/**
+ * Maps the legacy sign-on page state to the URL-based signup flow.
+ * Incomplete Identity-only accounts have no handle yet, so PROFILE resumes at
+ * handle selection; accounts with an indexed handle resume at profile details.
+ */
+export const getSignOnRoute = ({
+  signIn,
+  page,
+  hasHandle
+}: GetSignOnRouteParams) => {
+  if (signIn) return SIGN_IN_PAGE
+
+  switch (page) {
+    case Pages.PASSWORD:
+      return SIGN_UP_PASSWORD_PAGE
+    case Pages.PROFILE:
+      return hasHandle ? SIGN_UP_FINISH_PROFILE_PAGE : SIGN_UP_HANDLE_PAGE
+    default:
+      return SIGN_UP_PAGE
+  }
+}

--- a/packages/web/src/common/store/pages/signon/reducer.js
+++ b/packages/web/src/common/store/pages/signon/reducer.js
@@ -2,6 +2,7 @@ import { route } from '@audius/common/utils'
 
 import {
   SET_ACCOUNT_READY,
+  SET_IDENTITY_ACCOUNT_READY,
   SET_FIELD,
   SET_VALUE_FIELD,
   VALIDATE_EMAIL,
@@ -21,6 +22,7 @@ import {
   FINISH_SIGN_UP,
   SIGN_UP_SUCCEEDED,
   SIGN_UP_FAILED,
+  SIGN_UP_TIMEOUT,
   SIGN_IN,
   SIGN_IN_FAILED,
   SIGN_IN_SUCCEEDED,
@@ -83,6 +85,12 @@ const actionsMap = {
     return {
       ...state,
       accountReady: true
+    }
+  },
+  [SET_IDENTITY_ACCOUNT_READY](state) {
+    return {
+      ...state,
+      accountAlreadyExisted: true
     }
   },
   [RESET_SIGN_ON](state) {
@@ -294,6 +302,12 @@ const actionsMap = {
     }
   },
   [SIGN_UP_FAILED](state, action) {
+    return {
+      ...state,
+      status: 'failure'
+    }
+  },
+  [SIGN_UP_TIMEOUT](state, action) {
     return {
       ...state,
       status: 'failure'

--- a/packages/web/src/common/store/pages/signon/reducer.test.ts
+++ b/packages/web/src/common/store/pages/signon/reducer.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { setIdentityAccountReady, signUpTimeout } from './actions'
+import reducer from './reducer'
+
+describe('sign-on resumable signup state', () => {
+  it('preserves the Identity completion checkpoint for retries', () => {
+    const state = reducer(undefined, setIdentityAccountReady())
+
+    expect(state.accountAlreadyExisted).toBe(true)
+  })
+
+  it('turns a confirmation timeout into a retryable failure', () => {
+    const loadingState = {
+      ...reducer(undefined, { type: 'TEST/INIT' }),
+      status: 'loading'
+    }
+    const timeoutAction = signUpTimeout()
+
+    expect(reducer(loadingState, timeoutAction).status).toBe('failure')
+    expect(timeoutAction.shouldRedirect).toBe(false)
+  })
+})

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -77,6 +77,7 @@ import { waitForRead, waitForWrite } from 'utils/sagaHelpers'
 
 import * as signOnActions from './actions'
 import { watchSignOnError } from './errorSagas'
+import { getSignOnRoute } from './getSignOnRoute'
 import {
   getFollowIds,
   getIsGuest,
@@ -85,7 +86,7 @@ import {
 } from './selectors'
 import { Pages } from './types'
 
-const { FEED_PAGE, SIGN_IN_PAGE, SIGN_UP_PAGE, SIGN_UP_PASSWORD_PAGE } = route
+const { FEED_PAGE } = route
 const { requestPushNotificationPermissions } = settingsPageActions
 const { saveCollection } = collectionsSocialActions
 const { toast } = toastActions
@@ -119,6 +120,8 @@ const PASSWORD_RESET_REQUIRED_KEY = 'password-reset-required'
 const messages = {
   incompleteAccount:
     'Oops, it looks like your account was never fully completed!',
+  accountCreationFailed:
+    "We couldn't finish creating your account. Your login is saved; please try again.",
   emailCheckFailed: 'Something has gone wrong, please try again later.',
   deactivatedAccount:
     'Your account has been deactivated. Please contact support.'
@@ -574,6 +577,11 @@ function* signUp() {
                     username: email
                   })
                 }
+
+                // Identity is committed before the core user write. Preserve
+                // that checkpoint so a failed core write can be retried without
+                // attempting to register the same email again.
+                yield* put(signOnActions.setIdentityAccountReady())
               }
 
               const [wallet] = yield* call([
@@ -581,35 +589,67 @@ function* signUp() {
                 sdk.services.audiusWalletClient.getAddresses
               ])
 
-              const events: CreateUserRequestWithFiles['metadata']['events'] =
-                {}
-              if (referrer) {
-                events.referrer = OptionalId.parse(referrer)
-              }
-              if (isNativeMobile) {
-                events.isMobileUser = true
-              }
+              // A previous relay may have succeeded even if its confirmation
+              // timed out. Check the wallet before issuing another CREATE so
+              // resuming remains idempotent once that user is indexed.
+              const existingAccount = alreadyExisted
+                ? yield* call(getWalletAccountSaga, wallet, sdk, queryClient)
+                : null
 
-              const createUserMetadata: CreateUserRequestWithFiles = {
-                profilePictureFile: signOn.profileImage?.file as File,
-                coverArtFile: signOn.coverPhoto?.file as File,
-                metadata: {
-                  location: location ?? undefined,
-                  name,
-                  events,
-                  handle,
-                  wallet
+              if (existingAccount) {
+                userId = existingAccount.user.user_id
+
+                // Older incomplete accounts can have an indexed core user but
+                // no profile name. Complete that user rather than creating a
+                // second user ID for the same wallet.
+                if (!existingAccount.user.name) {
+                  const completeProfileRequest: UpdateUserRequestWithFiles = {
+                    id: Id.parse(userId),
+                    userId: Id.parse(userId),
+                    profilePictureFile: signOn.profileImage?.file as File,
+                    coverArtFile: signOn.coverPhoto?.file as File,
+                    metadata: {
+                      location: location ?? undefined,
+                      name,
+                      handle
+                    }
+                  }
+                  yield* call(
+                    [sdk.users, sdk.users.updateUser],
+                    completeProfileRequest
+                  )
                 }
-              }
+              } else {
+                const events: CreateUserRequestWithFiles['metadata']['events'] =
+                  {}
+                if (referrer) {
+                  events.referrer = OptionalId.parse(referrer)
+                }
+                if (isNativeMobile) {
+                  events.isMobileUser = true
+                }
 
-              const { userId: returnedUserId } = yield* call(
-                [sdk.users, sdk.users.createUser],
-                createUserMetadata
-              )
-              if (!returnedUserId) {
-                throw new Error('User ID not returned from createUser')
+                const createUserMetadata: CreateUserRequestWithFiles = {
+                  profilePictureFile: signOn.profileImage?.file as File,
+                  coverArtFile: signOn.coverPhoto?.file as File,
+                  metadata: {
+                    location: location ?? undefined,
+                    name,
+                    events,
+                    handle,
+                    wallet
+                  }
+                }
+
+                const { userId: returnedUserId } = yield* call(
+                  [sdk.users, sdk.users.createUser],
+                  createUserMetadata
+                )
+                if (!returnedUserId) {
+                  throw new Error('User ID not returned from createUser')
+                }
+                userId = decodeHashId(returnedUserId)!
               }
-              userId = decodeHashId(returnedUserId)!
             }
 
             yield* put(
@@ -644,11 +684,11 @@ function* signUp() {
             const params: signOnActions.SignUpFailedParams = {
               error: error.message,
               // TODO: Remove phase, stop using error Sagas for signup
-              // We are mostly handling reporting here already and we're
-              // only using it for error redirects.
               phase: 'CREATE_USER',
-              shouldReport: false, // We are reporting in this saga
-              shouldToast: rateLimited
+              shouldRedirect: false,
+              shouldReport: true,
+              shouldToast: true,
+              message: messages.accountCreationFailed
             }
             if (rateLimited) {
               params.message = 'Please try again later'
@@ -675,6 +715,9 @@ function* signUp() {
               console.error(error)
             }
             yield* put(signOnActions.signUpFailed(params))
+            // Let the confirmer run its failure callback. Swallowing this error
+            // causes the success callback to run and overwrite the failure.
+            throw error
           }
         },
         function* () {
@@ -770,7 +813,10 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
       )
       yield* put(
         signOnActions.openSignOn(false, Pages.PROFILE, {
-          accountAlreadyExisted: true
+          accountAlreadyExisted: true,
+          finishedPhase1: false,
+          startedSignUpProcess: true,
+          status: 'editing'
         })
       )
 
@@ -813,19 +859,22 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
         yield* put(
           signOnActions.openSignOn(false, Pages.PASSWORD, {
             accountAlreadyExisted: true,
+            finishedPhase1: false,
+            startedSignUpProcess: true,
+            status: 'editing',
             handle: {
               value: user.handle,
               status: 'disabled'
             }
           })
         )
-        if (!isNativeMobile) {
-          yield* put(pushRoute(SIGN_UP_PASSWORD_PAGE))
-        }
       } else {
         yield* put(
           signOnActions.openSignOn(false, Pages.PROFILE, {
             accountAlreadyExisted: true,
+            finishedPhase1: false,
+            startedSignUpProcess: true,
+            status: 'editing',
             handle: {
               value: user.handle,
               status: 'disabled'
@@ -1058,8 +1107,13 @@ function* watchOpenSignOn() {
   yield* takeLatest(
     signOnActions.OPEN_SIGN_ON,
     function* (action: ReturnType<typeof signOnActions.openSignOn>) {
-      const route = action.signIn ? SIGN_IN_PAGE : SIGN_UP_PAGE
-      yield* put(pushRoute(route))
+      const signOn = yield* select(getSignOn)
+      const signOnRoute = getSignOnRoute({
+        signIn: action.signIn,
+        page: action.page,
+        hasHandle: Boolean(signOn.handle.value)
+      })
+      yield* put(pushRoute(signOnRoute))
     }
   )
 }

--- a/packages/web/src/pages/sign-up-page/pages/LoadingAccountPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/LoadingAccountPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { route } from '@audius/common/utils'
-import { Flex } from '@audius/harmony'
-import { useSelector } from 'react-redux'
+import { Button, Flex } from '@audius/harmony'
+import { useDispatch, useSelector } from 'react-redux'
 
+import { signUp } from 'common/store/pages/signon/actions'
 import { getStatus, getAccountReady } from 'common/store/pages/signon/selectors'
 import { EditingStatus } from 'common/store/pages/signon/types'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
@@ -16,12 +17,17 @@ const { SIGN_UP_COMPLETED_REDIRECT } = route
 
 const messages = {
   heading: 'Your Account is Almost Ready to Rock 🤘',
-  description: "We're just finishing up a few things..."
+  description: "We're just finishing up a few things...",
+  failureHeading: "We Couldn't Finish Creating Your Account",
+  failureDescription:
+    'Your login is saved. Try again to finish creating your account.',
+  retry: 'Try Again'
 }
 
 // This loading page shows up when the users account is still being created either due to slow creation or a fast user
 // The user just waits here until the account is created and before being shown the welcome modal on the trending page
 export const LoadingAccountPage = () => {
+  const dispatch = useDispatch()
   const navigate = useNavigateToPage()
   const isFastReferral = useFastReferral()
   const accountReady = useSelector(getAccountReady)
@@ -30,23 +36,40 @@ export const LoadingAccountPage = () => {
   const isAccountReady = isFastReferral
     ? accountReady
     : accountReady || accountCreationStatus === EditingStatus.SUCCESS
+  const didAccountCreationFail = accountCreationStatus === EditingStatus.FAILURE
+
+  const handleRetry = useCallback(() => {
+    dispatch(signUp())
+  }, [dispatch])
 
   useEffect(() => {
     if (isAccountReady) {
       navigate(SIGN_UP_COMPLETED_REDIRECT)
     }
-    // TODO: what to do in an error scenario? Any way to recover to a valid step?
   }, [navigate, isAccountReady])
 
   return (
     <Page gap='3xl' justifyContent='center' alignItems='center' pb='3xl'>
-      <LoadingSpinner css={{ height: '72px' }} />
+      {didAccountCreationFail ? null : (
+        <LoadingSpinner css={{ height: '72px' }} />
+      )}
       <Flex justifyContent='center' css={{ textAlign: 'center' }}>
         <Heading
-          heading={messages.heading}
-          description={messages.description}
+          heading={
+            didAccountCreationFail ? messages.failureHeading : messages.heading
+          }
+          description={
+            didAccountCreationFail
+              ? messages.failureDescription
+              : messages.description
+          }
         />
       </Flex>
+      {didAccountCreationFail ? (
+        <Button variant='primary' onClick={handleRetry}>
+          {messages.retry}
+        </Button>
+      ) : null}
     </Page>
   )
 }


### PR DESCRIPTION
## Summary

- checkpoint successful Identity registration so a failed core write can retry without registering the email again
- resume Identity-only accounts at handle/profile setup in the current URL-based signup router
- reuse an indexed user after an uncertain relay result and update partially completed users instead of creating a second user ID
- keep create-user failures retryable, report them, and prevent the confirmer from overwriting failure with success
- replace the indefinite loading state with a Try Again action

## Root cause

Signup commits Identity credentials before submitting the core CreateUser write. When the chain or relay is unavailable, Identity reserves the email but the core user is never created. The existing incomplete-account recovery path still targeted legacy page state, which the current router ignored and redirected back to email entry. The create-user catch also swallowed its error, allowing the confirmation success callback to run afterward.

## Test plan

- npm test -- --run src/common/store/pages/signon/getSignOnRoute.test.ts src/common/store/pages/signon/reducer.test.ts
- npm run typecheck
- ESLint on all touched files
- Prettier check and git diff --check