### PR TITLE
fix(stems): surface archive job timeouts on mobile

### DIFF
--- a/packages/mobile/src/components/download-track-archive-drawer/DownloadTrackArchiveDrawer.tsx
+++ b/packages/mobile/src/components/download-track-archive-drawer/DownloadTrackArchiveDrawer.tsx
@@ -124,13 +124,27 @@ const DownloadTrackArchiveDrawerContent = ({
 
   const { mutate: cancelStemsArchiveJob } = useCancelStemsArchiveJob()
 
-  const { data: jobState } = useGetStemsArchiveJobStatus({
+  const {
+    data: jobState,
+    isError: isJobStatusError,
+    isTimedOut: isJobTimedOut
+  } = useGetStemsArchiveJobStatus({
     jobId
   })
 
+  // `isTimedOut` and `isError` have to be part of this, not just `failed`.
+  // A job that never leaves `waiting` — the archiver worker losing its Redis
+  // lock and holding every concurrency slot, for instance — is reported as a
+  // perfectly valid non-terminal state forever, so keying only off `failed`
+  // leaves the drawer spinning with no error and no retry until the user
+  // gives up. The shared hook already enforces STEMS_ARCHIVE_POLL_TIMEOUT_MS
+  // and hands back `isTimedOut`; web consumes it and mobile did not.
   const hasError =
     !isStartingDownload &&
-    (downloadError || initiateDownloadFailed || jobState?.state === 'failed')
+    (downloadError ||
+      initiateDownloadFailed ||
+      jobState?.state === 'failed' ||
+      (!!jobId && (isJobStatusError || isJobTimedOut)))
 
   useEffect(() => {
     if (hasError) {


### PR DESCRIPTION
Closes #14536.

## Problem

`DownloadTrackArchiveDrawer` keyed `hasError` off `jobState.state === 'failed'` alone:

```ts
const hasError =
  !isStartingDownload &&
  (downloadError || initiateDownloadFailed || jobState?.state === 'failed')
```

A stems archive job that never leaves `waiting` is reported as a valid non-terminal state forever, so the drawer spun indefinitely — no error, no retry affordance, no way for the user to tell it would never finish.

#14535 added `STEMS_ARCHIVE_POLL_TIMEOUT_MS` to `useGetStemsArchiveJobStatus` and wired the resulting `isTimedOut` into the **web** modal, but the mobile drawer was never updated. It destructured only `data`, dropping both `isTimedOut` and `isError`.

## Why this isn't hypothetical

During the 2026-07-28 archiver outage the worker lost its Redis locks when `archiver-redis` was recreated, kept all five concurrency slots, and 24 jobs sat in `waiting` across 15 tracks for ~7 hours (AudiusProject/pedalboard#77). Web users got an error and a retry link after 15 minutes. Mobile users got a spinner that could never resolve.

## Change

Destructure `isError` and `isTimedOut` from the shared hook and fold them into `hasError`, matching the web modal exactly:

```ts
const hasError =
  !isStartingDownload &&
  (downloadError ||
    initiateDownloadFailed ||
    jobState?.state === 'failed' ||
    (!!jobId && (isJobStatusError || isJobTimedOut)))
```

The `!!jobId` guard mirrors web — job-status errors only count once a job actually exists, so a pending create isn't reported as a failed download.

No hook changes; the timeout and flag already existed and were simply unused here.

## Scope

Deliberately narrow. The error copy shown on both platforms is still the hardcoded "check your connection" string even when the archiver returns a real `failedReason` — that's #14537 and unchanged here.

## Testing

- `tsc --noEmit` clean; confirmed via `--listFiles` that the drawer is actually in the checked program.
- `eslint --ext=ts,tsx src/components/download-track-archive-drawer/` clean.
- Not exercised on a device — reproducing it requires an archiver whose worker is wedged, which is the condition pedalboard#84 exists to make recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
