### PR TITLE
fix(mobile): uniform contest tile height in horizontal scroll row

### DIFF
--- a/packages/mobile/src/components/contest-card/ContestCard.tsx
+++ b/packages/mobile/src/components/contest-card/ContestCard.tsx
@@ -326,13 +326,17 @@ export const ContestCard = (props: ContestCardProps) => {
         <Divider orientation='horizontal' />
 
         <Flex direction='column' gap='s'>
-          <Text
-            variant='heading'
-            size={variant === 'hero' ? 'l' : 'm'}
-            numberOfLines={2}
-          >
-            {contestTitle}
-          </Text>
+          {/* minHeight reserves space for 2 lines of heading/m (lineHeight xl = 32px × 2)
+              so grid cards stay the same height whether the title wraps or not. */}
+          <View style={{ minHeight: variant === 'hero' ? undefined : 64 }}>
+            <Text
+              variant='heading'
+              size={variant === 'hero' ? 'l' : 'm'}
+              numberOfLines={2}
+            >
+              {contestTitle}
+            </Text>
+          </View>
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}

--- a/packages/mobile/src/screens/explore-screen/components/FeaturedRemixContests.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/FeaturedRemixContests.tsx
@@ -36,9 +36,7 @@ export const FeaturedRemixContests = () => {
           carouselSpacing={spacing.l}
           horizontalCardWidth={contestCardWidth}
           isLoading={isAllContestsPending}
-          LoadingCardComponent={() => (
-            <ContestCardSkeleton style={{ width: contestCardWidth }} />
-          )}
+          LoadingCardComponent={() => <ContestCardSkeleton />}
         />
       </ExploreSection>
     </InViewWrapper>


### PR DESCRIPTION
Contest cards in the Explore carousel were different heights when a title wrapped to two lines vs one line, making the row look uneven. Fix: wrap the grid-variant title Text in a View with minHeight 64 (2 x lineHeight-xl = 2 x 32px for heading/m). Single-line titles now reserve space for a second line. Hero variant left unconstrained. Pure layout change, no data or API logic touched.