### PR TITLE
Handle mobile archive job errors

### DIFF
--- a/packages/mobile/src/components/download-track-archive-drawer/DownloadTrackArchiveDrawer.tsx
+++ b/packages/mobile/src/components/download-track-archive-drawer/DownloadTrackArchiveDrawer.tsx
@@ -124,13 +124,20 @@ const DownloadTrackArchiveDrawerContent = ({
 
   const { mutate: cancelStemsArchiveJob } = useCancelStemsArchiveJob()
 
-  const { data: jobState } = useGetStemsArchiveJobStatus({
+  const {
+    data: jobState,
+    isError: isJobStatusError,
+    isTimedOut: isJobTimedOut
+  } = useGetStemsArchiveJobStatus({
     jobId
   })
 
   const hasError =
     !isStartingDownload &&
-    (downloadError || initiateDownloadFailed || jobState?.state === 'failed')
+    (downloadError ||
+      initiateDownloadFailed ||
+      jobState?.state === 'failed' ||
+      (!!jobId && (isJobStatusError || isJobTimedOut)))
 
   useEffect(() => {
     if (hasError) {


### PR DESCRIPTION
## Summary
- show the mobile archive drawer error state when the archive job status query errors or times out
- keep existing failed-job and download-file error handling intact

Fixes #14536

## Testing
- npx eslint --no-cache --ext=js,jsx,ts,tsx src/components/download-track-archive-drawer/DownloadTrackArchiveDrawer.tsx (from packages/mobile)
- npm run typecheck -w @audius/mobile -- --noEmit --pretty false