### PR TITLE
fix(coins): remove all-time volume stat from coin UI

### DIFF
--- a/packages/common/src/messages/coinDetailsMessages.ts
+++ b/packages/common/src/messages/coinDetailsMessages.ts
@@ -39,7 +39,6 @@ export const coinDetailsMessages = {
     pricePerCoin: 'Price',
     holdersOnAudius: 'Holders on Audius',
     uniqueHolders: 'Unique Holders',
-    totalVolume: 'Volume (All-Time)',
     marketCap: 'Market Cap',
     unableToLoad: 'Unable to load insights',
     graduated: 'Graduated',

--- a/packages/common/src/utils/coinMetrics.ts
+++ b/packages/common/src/utils/coinMetrics.ts
@@ -21,7 +21,6 @@ const messages = {
   pricePerCoin: 'Price',
   holdersOnAudius: 'Holders on Audius',
   uniqueHolders: 'Unique Holders',
-  totalVolume: 'Volume (All-Time)',
   volume24h: 'Volume (24h)',
   marketCap: 'Market Cap',
   graduationProgress: 'Graduation Progress'
@@ -77,10 +76,6 @@ export const createCoinMetrics = (coin: Coin): MetricData[] => {
     createMetric({
       value: `$${formatCount(coin.displayMarketCap ?? 0, 2)}`,
       label: messages.marketCap
-    }),
-    createMetric({
-      value: `$${formatCount(coin.totalVolumeUSD ?? 0, 2)}`,
-      label: messages.totalVolume
     }),
     createMetric({
       value: formatCount(coin.holder ?? 0),

--- a/packages/web/src/components/table/responsivePolicies.ts
+++ b/packages/web/src/components/table/responsivePolicies.ts
@@ -61,22 +61,11 @@ export const RESPONSIVE_TABLE_POLICIES = {
       },
       {
         maxWidth: 671,
-        hide: [
-          'holders',
-          'createdDate',
-          'marketCap',
-          'artist'
-        ]
+        hide: ['holders', 'createdDate', 'marketCap', 'artist']
       },
       {
         maxWidth: 420,
-        hide: [
-          'holders',
-          'createdDate',
-          'marketCap',
-          'artist',
-          'price'
-        ]
+        hide: ['holders', 'createdDate', 'marketCap', 'artist', 'price']
       }
     ],
     ['tokenName', 'buy']

--- a/packages/web/src/components/table/responsivePolicies.ts
+++ b/packages/web/src/components/table/responsivePolicies.ts
@@ -57,7 +57,7 @@ export const RESPONSIVE_TABLE_POLICIES = {
       },
       {
         maxWidth: 815,
-        hide: ['holders', 'createdDate', 'marketCap', 'totalVolumeUSD']
+        hide: ['holders', 'createdDate', 'marketCap']
       },
       {
         maxWidth: 671,
@@ -65,7 +65,6 @@ export const RESPONSIVE_TABLE_POLICIES = {
           'holders',
           'createdDate',
           'marketCap',
-          'totalVolumeUSD',
           'artist'
         ]
       },
@@ -75,7 +74,6 @@ export const RESPONSIVE_TABLE_POLICIES = {
           'holders',
           'createdDate',
           'marketCap',
-          'totalVolumeUSD',
           'artist',
           'price'
         ]

--- a/packages/web/src/pages/fan-club-detail-page/FanClubDetailPage.test.tsx
+++ b/packages/web/src/pages/fan-club-detail-page/FanClubDetailPage.test.tsx
@@ -95,14 +95,6 @@ const assertFanClubInsightsSection = async () => {
   expect(within(marketCapRow).getByText(/\$9\.0K/i)).toBeInTheDocument()
   expect(within(marketCapRow).getByText(/^market cap$/i)).toBeInTheDocument()
 
-  // Volume (All-Time): $127.32
-  const volumeRow = screen.getByTestId('metric-row-Volume (All-Time)')
-  expect(volumeRow).toBeInTheDocument()
-  expect(within(volumeRow).getByText(/\$127\.32/)).toBeInTheDocument()
-  expect(
-    within(volumeRow).getByText(/^volume \(all-time\)$/i)
-  ).toBeInTheDocument()
-
   // Unique Holders: 11
   const holdersRow = screen.getByTestId('metric-row-Unique Holders')
   expect(holdersRow).toBeInTheDocument()

--- a/packages/web/src/pages/fan-clubs-launchpad-page/components/FanClubsTable.tsx
+++ b/packages/web/src/pages/fan-clubs-launchpad-page/components/FanClubsTable.tsx
@@ -184,16 +184,6 @@ const renderMarketCapCell = (cellInfo: CoinCell) => {
   )
 }
 
-const renderTotalVolumeUSDCell = (cellInfo: CoinCell) => {
-  const coin = cellInfo.row.original
-  return (
-    <Text variant='body' size='m'>
-      {walletMessages.dollarSign}
-      {formatCount(coin.totalVolumeUSD ?? 0, 2)}
-    </Text>
-  )
-}
-
 const renderHoldersCell = (cellInfo: CoinCell) => {
   const coin = cellInfo.row.original
   return (
@@ -272,19 +262,6 @@ const tableColumnMap = {
     disableResizing: true,
     sorter: numericSorter('price')
   },
-  totalVolumeUSD: {
-    id: 'totalVolumeUSD',
-    Header: 'Vol',
-    accessor: 'totalVolumeUSD',
-    Cell: renderTotalVolumeUSDCell,
-    disableSortBy: false,
-    align: 'right',
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    disableResizing: true,
-    sorter: numericSorter('totalVolumeUSD')
-  },
   marketCap: {
     id: 'marketCap',
     Header: 'Market Cap',
@@ -340,7 +317,6 @@ const tableColumnMap = {
 const sortMethodMap: Record<string, GetCoinsSortMethodEnum> = {
   price: GetCoinsSortMethodEnum.Price,
   marketCap: GetCoinsSortMethodEnum.MarketCap,
-  totalVolumeUSD: GetCoinsSortMethodEnum.Volume,
   createdAt: GetCoinsSortMethodEnum.CreatedAt,
   holder: GetCoinsSortMethodEnum.Holder
 }
@@ -508,7 +484,6 @@ export const FanClubsTable = ({ viewMode }: FanClubsTableProps) => {
       baseColumns.tokenName,
       baseColumns.artist,
       baseColumns.price,
-      baseColumns.totalVolumeUSD,
       baseColumns.marketCap,
       baseColumns.createdDate,
       baseColumns.holders,


### PR DESCRIPTION
## What
Removes the **"Volume (All-Time)"** metric from:
- the coin details insights (`createCoinMetrics`)
- the fan-clubs launchpad table (column + sort + responsive hide rules)

## Why
The all-time volume figure is an unreliable, unverifiable stat:
- **No other aggregator reports it.** DexScreener has no pairs for these Meteora DBC coins, GeckoTerminal exposes only rolling-window volume (h24/h6/…) and doesn't index most of them, and Jupiter marks them not-tradable. There's no consensus number to validate against.
- The source value (Birdeye's all-time `total_volume_usd`) is a black-box figure we can't reproduce on-chain — repricing the exact same trades at trade-time brackets but doesn't match it, and for multi-market coins it aggregates pools we don't track.

Rather than display a number we can't stand behind, we remove it. (Price, market cap, holders, and graduation progress are unchanged; the AUDIO 24h volume shown via CoinGecko is unaffected.)

## Test
`FanClubDetailPage.test.tsx` updated (dropped the volume-row assertion); suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)