### PR TITLE
chore(sdk): regenerate Coin model — drop totalVolumeUSD

### DIFF
--- a/.changeset/sdk-coin-drop-total-volume.md
+++ b/.changeset/sdk-coin-drop-total-volume.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Remove `totalVolumeUSD` from the `Coin` model. The `/v1/coins` endpoint no longer returns this field.

--- a/packages/sdk/src/sdk/api/generated/default/models/Coin.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/Coin.ts
@@ -201,12 +201,6 @@ export interface Coin {
      */
     marketCap?: number;
     /**
-     * Total volume traded in USD (all time)
-     * @type {number}
-     * @memberof Coin
-     */
-    totalVolumeUSD?: number;
-    /**
      * Number of holders
      * @type {number}
      * @memberof Coin
@@ -300,7 +294,6 @@ export function CoinFromJSONTyped(json: any, ignoreDiscriminator: boolean): Coin
         'rewardPool': !exists(json, 'reward_pool') ? undefined : RewardPoolFromJSON(json['reward_pool']),
         'price': !exists(json, 'price') ? undefined : json['price'],
         'marketCap': !exists(json, 'marketCap') ? undefined : json['marketCap'],
-        'totalVolumeUSD': !exists(json, 'totalVolumeUSD') ? undefined : json['totalVolumeUSD'],
         'holder': !exists(json, 'holder') ? undefined : json['holder'],
         'totalSupply': !exists(json, 'totalSupply') ? undefined : json['totalSupply'],
         'liquidity': !exists(json, 'liquidity') ? undefined : json['liquidity'],
@@ -346,7 +339,6 @@ export function CoinToJSON(value?: Coin | null): any {
         'reward_pool': RewardPoolToJSON(value.rewardPool),
         'price': value.price,
         'marketCap': value.marketCap,
-        'totalVolumeUSD': value.totalVolumeUSD,
         'holder': value.holder,
         'totalSupply': value.totalSupply,
         'liquidity': value.liquidity,


### PR DESCRIPTION
## What
Regenerates the SDK `Coin` model after AudiusProject/api#1004 removed `totalVolumeUSD` from the `/v1/coins` response — dropping the field from the interface, `CoinFromJSONTyped`, and `CoinToJSON`.

## How
Ran `gen:prod` (openapi-generator against the deployed prod swagger). Verified the change is live on prod first (`/v1/coins` no longer returns the field). Scoped to `Coin.ts` only — the generator also surfaced unrelated drift in `Event`/`TrackCollaboratorNotification*` models (the committed SDK was behind prod there), which I reverted to keep this PR focused.

## Safety
Backward-compatible. The field was optional and its generated deserializer already handled absence (`!exists(json, 'totalVolumeUSD') ? undefined`), so old SDK builds tolerate the missing field. The client display usage was already removed in #14542 (merged), so no source references the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)