### PR TITLE
chore(sdk): sync Event model — add permalink

### DIFF
--- a/.changeset/sdk-event-permalink.md
+++ b/.changeset/sdk-event-permalink.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Add `permalink` to the `Event` model, syncing the generated SDK with the current API (the `/v1/events` response now returns a canonical contest permalink).

--- a/packages/sdk/src/sdk/api/generated/default/models/Event.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/Event.ts
@@ -79,6 +79,12 @@ export interface Event {
      * @memberof Event
      */
     eventData: object;
+    /**
+     * Canonical contest permalink derived from event_routes.
+     * @type {string}
+     * @memberof Event
+     */
+    permalink?: string;
 }
 
 
@@ -138,6 +144,7 @@ export function EventFromJSONTyped(json: any, ignoreDiscriminator: boolean): Eve
         'createdAt': json['created_at'],
         'updatedAt': json['updated_at'],
         'eventData': json['event_data'],
+        'permalink': !exists(json, 'permalink') ? undefined : json['permalink'],
     };
 }
 
@@ -160,6 +167,7 @@ export function EventToJSON(value?: Event | null): any {
         'created_at': value.createdAt,
         'updated_at': value.updatedAt,
         'event_data': value.eventData,
+        'permalink': value.permalink,
     };
 }
 


### PR DESCRIPTION
## What
Regenerates the SDK `Event` model to add the `permalink` field (canonical contest permalink) the API now returns on `/v1/events`.

## Context
Surfaced while regenerating the SDK for the `Coin` change (AudiusProject/apps#14543) — the committed SDK was behind prod on this field. Split into its own PR. The generator also touched `EventsResponse`/`TrackCollaboratorNotification*`, but those diffs were EOF/whitespace-only noise (no API change), so they're excluded.

## Safety
Additive optional field — backward-compatible for existing consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)