### PR TITLE
fix(ci): stop main web runs from queueing behind unapproved runs

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -24,10 +24,12 @@ on:
   workflow_dispatch:
 
 # Cancel superseded PR runs (new commits supersede in-flight CI). Keyed on the
-# PR branch for PRs; on main, head_ref is empty so runs group by ref and do NOT
-# cancel — an in-flight production deploy is never interrupted by a new push.
+# PR branch for PRs; on main, head_ref is empty so we fall back to run_id, giving
+# every main run its own group. Main runs are therefore independent — a run parked
+# at the production/release approval gate never blocks (or is blocked by) the next
+# push, and an in-flight deploy is never interrupted.
 concurrency:
-  group: web-${{ github.head_ref || github.ref }}
+  group: web-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
## Problem

Web CI on `main` regularly gets stuck. The workflow-level concurrency group was:

```yaml
group: web-${{ github.head_ref || github.ref }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

On `main`, `head_ref` is empty, so every push landed in the same group (`web-refs/heads/main`), and `cancel-in-progress` is `false` for pushes.

A job waiting at the `production` or `release` environment approval gate keeps its run **in progress** for as long as it waits — holding the group. So:

1. Run A parks at the gate, sometimes for days.
2. Run B (next push) sits pending behind it.
3. Run C arrives and evicts B — GitHub keeps only one pending run per group.

Recent `main` run history shows both halves of this:

| Run | Duration | Result |
|---|---|---|
| 29782124640 | 107h1m | cancelled (parked at gate) |
| 29532082633 | 96h50m | cancelled (parked at gate) |
| 29868310076 | 46h27m | cancelled (parked at gate) |
| 30865573872 | 22s | cancelled — **zero jobs executed** |
| 29868296983 | 12s | cancelled — **zero jobs executed** |

`GET /actions/runs/30865573872/jobs` returns an empty job list, confirming those short runs never started a single job; they were evicted while pending.

## Fix

Fall back to `github.run_id` instead of `github.ref` when `head_ref` is empty, so each `main` run gets its own concurrency group and runs independently. A run parked at an approval gate can no longer block or evict the next push, and an in-flight deploy is never interrupted.

PR behavior is unchanged: still keyed on the branch, still cancels superseded runs on new commits.

## Trade-offs

- `main` now runs full CI on every push instead of evicting queued runs, so spend rises slightly versus today's broken behavior. The alternative — `cancel-in-progress: true` on `main` — would let a new push kill an in-flight production deploy, which is worse.
- Multiple gates can be pending at once, so approving an older run deploys older code. This was already true before this change; a SHA-freshness guard in `web-deploy` would close it, but that's out of scope here.

`identity.yml` and `sdk.yml` use the same `github.ref` pattern but have no environment gates, so nothing can park there — left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)