### PR TITLE
fix(upload): publish stems sequentially after parent track

### DIFF
--- a/packages/common/src/api/tan-query/upload/usePublishTracks.ts
+++ b/packages/common/src/api/tan-query/upload/usePublishTracks.ts
@@ -146,29 +146,33 @@ export const publishTracks = async (
         }
       }
 
-      const [trackResult, stemsResults] = await Promise.all([
-        publishParentTrack(),
-        publishStems(context, {
-          clientId: param.clientId,
-          parentMetadata: param.metadata,
-          stems:
-            param.metadata.stems
-              ?.map((stem, index) => {
-                const audioUploadResponse = param.stemsUploadResponses?.[index]
+      // Publish the parent track first, then publish stems sequentially.
+      // Previously both ran concurrently via Promise.all, which caused a race
+      // condition: publishStem calls referenced the parent trackId before it
+      // was confirmed on-chain, so every stem publish failed. The UI then
+      // showed red ⚠ error icons on all stem rows even though the upload
+      // succeeded (reproducible on contest uploads: Burko, Andrew Lux, etc.)
+      const trackResult = await publishParentTrack()
+      const stemsResults = await publishStems(context, {
+        clientId: param.clientId,
+        parentMetadata: param.metadata,
+        stems:
+          param.metadata.stems
+            ?.map((stem, index) => {
+              const audioUploadResponse = param.stemsUploadResponses?.[index]
 
-                // This should never be the case, but being defensive
-                if (!audioUploadResponse) return null
-                return {
-                  metadata: stem,
-                  audioUploadResponse
-                }
-              })
-              .filter(
-                (stem): stem is NonNullable<typeof stem> => stem !== null
-              ) ?? [],
-          parentTrackId: trackId
-        })
-      ])
+              // This should never be the case, but being defensive
+              if (!audioUploadResponse) return null
+              return {
+                metadata: stem,
+                audioUploadResponse
+              }
+            })
+            .filter(
+              (stem): stem is NonNullable<typeof stem> => stem !== null
+            ) ?? [],
+        parentTrackId: trackId
+      })
 
       return {
         clientId: param.clientId,


### PR DESCRIPTION
## Problem

When uploading a contest track + stems simultaneously on audius.co, the UI gets permanently stuck on "Uploading Your Track" with red ⚠ error icons on every stem and the track itself — even though the upload succeeded (the contest page works after navigating away).

Reproducible on: Burko contest, Andrew Lux contest, Audius Summer Cypher Vol 2.

## Root cause

In `usePublishTracks.ts`, `publishParentTrack()` and `publishStems()` were running **concurrently** via `Promise.all`:

```ts
// Before (race condition)
const [trackResult, stemsResults] = await Promise.all([
  publishParentTrack(),
  publishStems(context, { ..., parentTrackId: trackId })
])
```

`publishStems` received the `trackId` (generated by `sdk.tracks.generateTrackId()`) and passed it to each stem publish call — but because both ran in parallel, the stems were being published **before the parent track was confirmed on-chain**. Every `publishStem` API call failed as a result, dispatching `ProgressStatus.ERROR` for each stem row.

## Fix

Await the parent track first, then publish stems:

```ts
// After (sequential, correct)
const trackResult = await publishParentTrack()
const stemsResults = await publishStems(context, { ..., parentTrackId: trackId })
```

This ensures the parent track is on-chain before any stem references it, eliminating the race condition.