### PR TITLE
fix(profile): preserve label account type across page refreshes

### DIFF
--- a/packages/common/src/api/tan-query/users/useUpdateProfile.ts
+++ b/packages/common/src/api/tan-query/users/useUpdateProfile.ts
@@ -81,12 +81,28 @@ export const useUpdateProfile = () => {
 
       return { previousMetadata }
     },
-    onError: (error, metadata, context?: MutationContext) => {
-      // If the mutation fails, roll back user data
+    onSuccess: (_data, variables) => {
+      // Re-confirm the mutation in the cache after server success.
+      // We re-apply mutation variables rather than the raw server response
+      // to guard against discovery-node propagation lag: the node answering
+      // getUser may not yet have indexed the confirmed block.
+      const currentCache = queryClient.getQueryData<UserMetadata>(
+        getUserQueryKey(currentUserId)
+      )
+      if (currentCache) {
+        primeUserData({
+          queryClient,
+          users: [{ ...currentCache, ...variables }],
+          forceReplace: true
+        })
+      }
+    },
+    onError: (error, _metadata, context?: MutationContext) => {
+      // If the mutation fails, roll back user data to previous state
       if (context?.previousMetadata) {
         primeUserData({
           queryClient,
-          users: [{ ...context.previousMetadata, ...metadata }],
+          users: [context.previousMetadata],
           forceReplace: true
         })
       }

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -364,7 +364,18 @@ function* setLocalStorageAccountAndUser(
   }
 
   yield* call([localStorage, localStorage.setAudiusAccount], formattedAccount)
-  yield* call([localStorage, localStorage.setAudiusAccountUser], accountUser)
+  // Prefer cached user data (which may include recent optimistic mutations
+  // like profile_type changes) over the server-fetched response. This prevents
+  // setLocalStorageAccountAndUser from overwriting changes that haven't yet
+  // propagated to all discovery nodes.
+  const queryClient = yield* getContext('queryClient')
+  const cachedUser = queryClient.getQueryData<UserMetadata>(
+    getUserQueryKey(accountUser.user_id)
+  )
+  yield* call(
+    [localStorage, localStorage.setAudiusAccountUser],
+    cachedUser ?? accountUser
+  )
 }
 
 function* recordIPIfNotRecent(handle: string): SagaIterator {


### PR DESCRIPTION
## Problem

Switching from artist to label account appeared to work, but reverted to artist within ~10 seconds of a page refresh. Reproduced on @futurevibes and @theboathouse.

## Root Cause

Three bugs conspired to cause the revert:

**Bug 1 — `useUpdateProfile`: no `onSuccess` handler**

`mutationFn` calls `sdk.users.updateUser()` (entity manager, waits for block confirmation), then fetches fresh user data via `sdk.users.getUser()` and returns it. But there was no `onSuccess` handler, so the server-confirmed data was silently discarded. The optimistic update from `onMutate` stayed in the React Query cache, but nothing re-confirmed it after the write landed on-chain.

**Bug 2 — `useUpdateProfile`: broken `onError` rollback**

`onError` rolled back with `{ ...context.previousMetadata, ...metadata }` instead of `context.previousMetadata` alone — applying the *failed* mutation on top of the pre-mutation state, the opposite of a rollback.

**Bug 3 — `setLocalStorageAccountAndUser`: overwrites recent mutations**

`fetchAccountAsync` runs on every page load and calls `setLocalStorageAccountAndUser`, which writes the server-fetched `accountUser` directly to `localStorage`. This overwrites any recent optimistic updates (e.g. `profile_type: label`) that haven't yet propagated to all discovery nodes. On the *next* reload, `fetchLocalAccountAsync` reads this stale `localStorage` value and primes the cache with `profile_type: null`, reverting the user back to artist.

## Fix

**`packages/common/src/api/tan-query/users/useUpdateProfile.ts`**

- Added `onSuccess` that re-applies the mutation variables to the query cache (`forceReplace: true`). Uses the mutation variables rather than the raw server response to guard against discovery-node propagation lag — the `getUser` call may hit a node that has not yet indexed the confirmed block.
- Fixed `onError` to roll back with `context.previousMetadata` only (not spread with current `metadata`).

**`packages/common/src/store/account/sagas.ts`**

- `setLocalStorageAccountAndUser` now prefers the React Query cached user over the server-fetched response when writing to `localStorage`. The cache already holds the correct post-mutation state; the server may lag due to node propagation. Falls back to the server value if the cache is empty (first load, no prior mutations).

## Testing

Manually verify with a label-eligible account:
1. Go to Settings → Account Type → toggle to Label
2. Refresh the page — should still show Label immediately and after ~10 s
3. Refresh again — should remain Label
