### PR TITLE
OTP account binding

### DIFF
--- a/packages/identity-service/src/routes/authentication.js
+++ b/packages/identity-service/src/routes/authentication.js
@@ -253,6 +253,13 @@ module.exports = function (app) {
 
       const otpRequired = await requiresOtp({ email })
       if (!otpRequired) {
+        const associatedEmail = await getWalletAssociatedEmail({
+          req,
+          authUser: existingUser
+        })
+        if (!associatedEmail || email !== associatedEmail.toLowerCase()) {
+          return errorResponseBadRequest('Invalid credentials')
+        }
         return successResponse(existingUser)
       } else if (!otp) {
         // use email from registered address if available

--- a/packages/identity-service/test/authenticationTest.js
+++ b/packages/identity-service/test/authenticationTest.js
@@ -235,6 +235,25 @@ describe('test authentication routes', function () {
     assert.ok(otp)
   })
 
+  it('only bypasses otp for the associated review email', async function () {
+    const [authRecord, userRecord] = await signUpUser({
+      associateWallet: true
+    })
+    const email = 'testflight@audius.co'
+
+    await request(app)
+      .get('/authentication')
+      .query({ lookupKey: authRecord.lookupKey, email })
+      .expect(400, { error: 'Invalid credentials' })
+
+    await userRecord.update({ email })
+
+    await request(app)
+      .get('/authentication')
+      .query({ lookupKey: authRecord.lookupKey, email })
+      .expect(200)
+  })
+
   it('is case-insensitive for OTP code checks', async function () {
     await signUpUser()
 


### PR DESCRIPTION
## Summary
- require an OTP bypass email to match the requested record's associated email
- fail closed when no associated email exists
- add focused regression coverage

## Testing
- identity-service authentication tests: 12 passing
- `npm run lint --workspace=identity-service`